### PR TITLE
Remove useMagicRaritiesNumber

### DIFF
--- a/build/rip.js
+++ b/build/rip.js
@@ -1381,11 +1381,6 @@ var addMagicLibraritiesInfoToMCISet = function(set, cb) {
 
 				// Number
 				var numberText;
-				if (set.useMagicRaritiesNumber) {
-					numberText = getTextContent(cardNameElement.parentNode.parentNode.previousElementSibling.previousElementSibling);
-					if (numberText.contains("/"))
-						numberText = numberText.substring(0, numberText.indexOf("/"));
-				}
 
 				if (releaseDate || sourceText || numberText) {
 					var cardInfo = {};

--- a/json/CST.json
+++ b/json/CST.json
@@ -6,7 +6,6 @@
     "230-rarities-coldsnap-preconstructed-reprint-cards"
   ],
   "isMCISet": true,
-  "useMagicRaritiesNumber": true,
   "releaseDate": "2006-07-21",
   "border": "black",
   "type": "box",
@@ -81,7 +80,7 @@
       ],
       "manaCost": "{3}{W}",
       "name": "Kjeldoran Home Guard",
-      "number": "8",
+      "number": "3",
       "power": "1",
       "printings": [
         "ALL",
@@ -166,7 +165,7 @@
       ],
       "manaCost": "{1}{W}",
       "name": "Kjeldoran Pride",
-      "number": "9b",
+      "number": "4",
       "printings": [
         "ALL",
         "CST"
@@ -259,7 +258,7 @@
       ],
       "manaCost": "{W}",
       "name": "Reinforcements",
-      "number": "12b",
+      "number": "5",
       "printings": [
         "ALL",
         "CST",
@@ -349,7 +348,7 @@
       ],
       "manaCost": "{4}{W}",
       "name": "Scars of the Veteran",
-      "number": "16",
+      "number": "6",
       "printings": [
         "ALL",
         "CST",
@@ -470,7 +469,7 @@
       ],
       "manaCost": "{1}{W}",
       "name": "Disenchant",
-      "number": "20",
+      "number": "1",
       "printings": [
         "LEA",
         "LEB",
@@ -584,7 +583,7 @@
       ],
       "manaCost": "{2}{U}{U}",
       "name": "Browse",
-      "number": "25",
+      "number": "10",
       "printings": [
         "ALL",
         "6ED",
@@ -670,7 +669,7 @@
       ],
       "manaCost": "{1}{U}",
       "name": "Lat-Nam's Legacy",
-      "number": "30b",
+      "number": "13",
       "printings": [
         "ALL",
         "CST",
@@ -761,7 +760,7 @@
       ],
       "manaCost": "{3}{W}",
       "name": "Kjeldoran Elite Guard",
-      "number": "34",
+      "number": "2",
       "power": "2",
       "printings": [
         "ICE",
@@ -851,7 +850,7 @@
       ],
       "manaCost": "{5}{U}",
       "name": "Storm Elemental",
-      "number": "37",
+      "number": "17",
       "power": "3",
       "printings": [
         "ALL",
@@ -951,7 +950,7 @@
       ],
       "manaCost": "{1}{U}",
       "name": "Viscerid Drone",
-      "number": "42",
+      "number": "18",
       "power": "1",
       "printings": [
         "ALL",
@@ -1042,7 +1041,7 @@
       ],
       "manaCost": "{3}{B}",
       "name": "Balduvian Dead",
-      "number": "43",
+      "number": "21",
       "power": "2",
       "printings": [
         "ALL",
@@ -1122,7 +1121,7 @@
       ],
       "manaCost": "{2}{B}",
       "name": "Casting of Bones",
-      "number": "44b",
+      "number": "22",
       "printings": [
         "ALL",
         "CST"
@@ -1192,7 +1191,7 @@
       ],
       "manaCost": "{B}",
       "name": "Insidious Bookworms",
-      "number": "51a",
+      "number": "27",
       "power": "1",
       "printings": [
         "ALL",
@@ -1289,7 +1288,7 @@
       ],
       "manaCost": "{W}",
       "name": "Swords to Plowshares",
-      "number": "54",
+      "number": "7",
       "printings": [
         "LEA",
         "LEB",
@@ -1400,7 +1399,7 @@
       ],
       "manaCost": "{3}{B}",
       "name": "Phantasmal Fiend",
-      "number": "57a",
+      "number": "30",
       "power": "1",
       "printings": [
         "ALL",
@@ -1509,7 +1508,7 @@
       ],
       "manaCost": "{3}{U}",
       "name": "Binding Grasp",
-      "number": "60",
+      "number": "8",
       "printings": [
         "ICE",
         "5ED",
@@ -1610,7 +1609,7 @@
       ],
       "manaCost": "{U}",
       "name": "Brainstorm",
-      "number": "61",
+      "number": "9",
       "printings": [
         "ICE",
         "5ED",
@@ -1710,7 +1709,7 @@
       ],
       "manaCost": "{U}",
       "name": "Essence Flare",
-      "number": "69",
+      "number": "11",
       "printings": [
         "ICE",
         "CST",
@@ -1803,7 +1802,7 @@
       ],
       "manaCost": "{R}",
       "name": "Death Spark",
-      "number": "70",
+      "number": "32",
       "printings": [
         "ALL",
         "DKM",
@@ -1911,7 +1910,7 @@
       ],
       "manaCost": "{R}",
       "name": "Gorilla Shaman",
-      "number": "72a",
+      "number": "33",
       "power": "1",
       "printings": [
         "ALL",
@@ -2007,7 +2006,7 @@
       ],
       "manaCost": "{X}{U}{U}",
       "name": "Iceberg",
-      "number": "73",
+      "number": "12",
       "printings": [
         "ICE",
         "CST",
@@ -2076,7 +2075,7 @@
       ],
       "manaCost": "{U}{U}",
       "name": "Mistfolk",
-      "number": "84",
+      "number": "14",
       "power": "1",
       "printings": [
         "ICE",
@@ -2164,7 +2163,7 @@
       ],
       "manaCost": "{3}{G}{G}",
       "name": "Bounty of the Hunt",
-      "number": "85",
+      "number": "38",
       "printings": [
         "ALL",
         "DKM",
@@ -2238,7 +2237,7 @@
       ],
       "manaCost": "{4}{G}",
       "name": "Deadly Insect",
-      "number": "86a",
+      "number": "39",
       "power": "6",
       "printings": [
         "ALL",
@@ -2328,7 +2327,7 @@
       ],
       "manaCost": "{U}",
       "name": "Portent",
-      "number": "90",
+      "number": "15",
       "printings": [
         "ICE",
         "5ED",
@@ -2404,7 +2403,7 @@
       ],
       "manaCost": "{1}{U}",
       "name": "Snow Devil",
-      "number": "100",
+      "number": "16",
       "printings": [
         "ICE",
         "CST"
@@ -2491,7 +2490,7 @@
       ],
       "manaCost": "{2}{U}",
       "name": "Zuran Spellcaster",
-      "number": "112",
+      "number": "19",
       "power": "1",
       "printings": [
         "ICE",
@@ -2581,7 +2580,7 @@
       ],
       "manaCost": "{3}{B}",
       "name": "Ashen Ghoul",
-      "number": "114",
+      "number": "20",
       "power": "3",
       "printings": [
         "ICE",
@@ -2725,7 +2724,7 @@
       ],
       "manaCost": "{2}{B}",
       "name": "Dark Banishing",
-      "number": "119",
+      "number": "23",
       "printings": [
         "ICE",
         "MIR",
@@ -2839,7 +2838,7 @@
       ],
       "manaCost": "{B}",
       "name": "Dark Ritual",
-      "number": "120",
+      "number": "24",
       "printings": [
         "LEA",
         "LEB",
@@ -2949,7 +2948,7 @@
       ],
       "manaCost": "{3}{B}",
       "name": "Drift of the Dead",
-      "number": "123",
+      "number": "25",
       "power": "*",
       "printings": [
         "ICE",
@@ -3038,7 +3037,7 @@
       ],
       "manaCost": "{1}{B}{B}",
       "name": "Gangrenous Zombies",
-      "number": "127",
+      "number": "26",
       "power": "2",
       "printings": [
         "ICE",
@@ -3134,7 +3133,7 @@
       ],
       "manaCost": "{B}",
       "name": "Kjeldoran Dead",
-      "number": "137",
+      "number": "28",
       "power": "3",
       "printings": [
         "ICE",
@@ -3220,7 +3219,7 @@
       ],
       "manaCost": "{1}{B}{B}",
       "name": "Legions of Lim-Dûl",
-      "number": "142",
+      "number": "29",
       "power": "2",
       "printings": [
         "ICE",
@@ -3312,7 +3311,7 @@
       ],
       "manaCost": "{X}{2}{B}",
       "name": "Soul Burn",
-      "number": "161",
+      "number": "31",
       "printings": [
         "ICE",
         "INV",
@@ -3428,7 +3427,7 @@
       ],
       "manaCost": "{1}{R}",
       "name": "Incinerate",
-      "number": "194",
+      "number": "34",
       "printings": [
         "pLGM",
         "ICE",
@@ -3514,7 +3513,7 @@
       ],
       "manaCost": "{R}{R}",
       "name": "Orcish Healer",
-      "number": "208",
+      "number": "35",
       "power": "1",
       "printings": [
         "ICE",
@@ -3609,7 +3608,7 @@
       ],
       "manaCost": "{R}",
       "name": "Orcish Lumberjack",
-      "number": "210",
+      "number": "36",
       "power": "1",
       "printings": [
         "ICE",
@@ -3701,7 +3700,7 @@
       ],
       "manaCost": "{3}{G}",
       "name": "Aurochs",
-      "number": "225",
+      "number": "37",
       "power": "2",
       "printings": [
         "ICE",
@@ -3802,7 +3801,7 @@
       ],
       "manaCost": "{G}",
       "name": "Tinder Wall",
-      "number": "270",
+      "number": "40",
       "power": "0",
       "printings": [
         "ICE",
@@ -3893,7 +3892,7 @@
       ],
       "manaCost": "{1}{G}{G}",
       "name": "Woolly Mammoths",
-      "number": "278",
+      "number": "41",
       "power": "3",
       "printings": [
         "ICE",
@@ -3985,7 +3984,7 @@
       ],
       "manaCost": "{1}{R}{G}",
       "name": "Giant Trap Door Spider",
-      "number": "293",
+      "number": "42",
       "power": "2",
       "printings": [
         "ICE",
@@ -4088,7 +4087,7 @@
       ],
       "manaCost": "{W}{U}",
       "name": "Wings of Aesthir",
-      "number": "305",
+      "number": "43",
       "printings": [
         "ICE",
         "CST",
@@ -4153,7 +4152,7 @@
       ],
       "manaCost": "{2}",
       "name": "Arcum's Weathervane",
-      "number": "310",
+      "number": "44",
       "printings": [
         "ICE",
         "CST"
@@ -4240,7 +4239,7 @@
       ],
       "manaCost": "{1}",
       "name": "Barbed Sextant",
-      "number": "312",
+      "number": "45",
       "printings": [
         "ICE",
         "5ED",
@@ -4321,7 +4320,7 @@
       ],
       "manaCost": "{4}",
       "name": "Skull Catapult",
-      "number": "336",
+      "number": "46",
       "printings": [
         "ICE",
         "5ED",
@@ -4386,7 +4385,7 @@
       ],
       "manaCost": "{2}",
       "name": "Whalebone Glider",
-      "number": "349",
+      "number": "47",
       "printings": [
         "ICE",
         "CST"
@@ -4564,7 +4563,7 @@
         }
       ],
       "name": "Plains",
-      "number": "369",
+      "number": "48",
       "printings": [
         "LEA",
         "LEB",
@@ -4837,7 +4836,7 @@
         }
       ],
       "name": "Plains",
-      "number": "370",
+      "number": "49",
       "printings": [
         "LEA",
         "LEB",
@@ -5110,7 +5109,7 @@
         }
       ],
       "name": "Plains",
-      "number": "371",
+      "number": "50",
       "printings": [
         "LEA",
         "LEB",
@@ -5383,7 +5382,7 @@
         }
       ],
       "name": "Island",
-      "number": "372",
+      "number": "51",
       "printings": [
         "LEA",
         "LEB",
@@ -5653,7 +5652,7 @@
         }
       ],
       "name": "Island",
-      "number": "373",
+      "number": "52",
       "printings": [
         "LEA",
         "LEB",
@@ -5923,7 +5922,7 @@
         }
       ],
       "name": "Island",
-      "number": "374",
+      "number": "53",
       "printings": [
         "LEA",
         "LEB",
@@ -6193,7 +6192,7 @@
         }
       ],
       "name": "Swamp",
-      "number": "375",
+      "number": "54",
       "printings": [
         "LEA",
         "LEB",
@@ -6468,7 +6467,7 @@
         }
       ],
       "name": "Swamp",
-      "number": "376",
+      "number": "55",
       "printings": [
         "LEA",
         "LEB",
@@ -6743,7 +6742,7 @@
         }
       ],
       "name": "Swamp",
-      "number": "377",
+      "number": "56",
       "printings": [
         "LEA",
         "LEB",
@@ -7018,7 +7017,7 @@
         }
       ],
       "name": "Mountain",
-      "number": "378",
+      "number": "57",
       "printings": [
         "LEA",
         "LEB",
@@ -7294,7 +7293,7 @@
         }
       ],
       "name": "Mountain",
-      "number": "379",
+      "number": "58",
       "printings": [
         "LEA",
         "LEB",
@@ -7570,7 +7569,7 @@
         }
       ],
       "name": "Mountain",
-      "number": "380",
+      "number": "59",
       "printings": [
         "LEA",
         "LEB",
@@ -7846,7 +7845,7 @@
         }
       ],
       "name": "Forest",
-      "number": "381",
+      "number": "60",
       "printings": [
         "LEA",
         "LEB",
@@ -8119,7 +8118,7 @@
         }
       ],
       "name": "Forest",
-      "number": "382",
+      "number": "61",
       "printings": [
         "LEA",
         "LEB",
@@ -8392,7 +8391,7 @@
         }
       ],
       "name": "Forest",
-      "number": "383",
+      "number": "62",
       "printings": [
         "LEA",
         "LEB",

--- a/shared/C.js
+++ b/shared/C.js
@@ -1387,7 +1387,6 @@ var base = require("xbase");
 			magicCardsInfoCode : "cstd",
 			magicRaritiesCodes : ["230-rarities-coldsnap-preconstructed-reprint-cards"],
 			isMCISet : true,
-			useMagicRaritiesNumber : true,
 			releaseDate : "2006-07-21",
 			border : "black",
 			type : "box",

--- a/web/generate.js
+++ b/web/generate.js
@@ -137,7 +137,6 @@ tiptoe(
 			delete setWithExtras.isMCISet;
 			delete setWithExtras.magicRaritiesCode;
 			delete setWithExtras.essentialMagicCode;
-			delete setWithExtras.useMagicRaritiesNumber;
 
 			allSetsWithExtras[SET.code] = setWithExtras;
 			allSetsArrayWithExtras.push(setWithExtras);


### PR DESCRIPTION
Coldsnap Theme Decks (CST) is the only set with useMagicRaritiesNumber, which is undocumented on the website.

Considering that [magiccards.info](http://magiccards.info/) provides collector numbers for the cards in the set, it might be worth removing the reliance on [Magic Rarities](http://www.magiclibrarities.net/).

Change CST "number" fields to magiccards.info collector numbers
Remove any remaining references to useMagicRaritiesNumber
