### PR TITLE
Fix names field of meld cards and clarify documentation

### DIFF
--- a/json/EMN.json
+++ b/json/EMN.json
@@ -1251,6 +1251,7 @@
       "multiverseid": 414304,
       "name": "Bruna, the Fading Light",
       "names": [
+        "Gisela, the Broken Blade",
         "Bruna, the Fading Light",
         "Brisela, Voice of Nightmares"
       ],
@@ -1337,8 +1338,8 @@
       "multiverseid": 414305,
       "name": "Brisela, Voice of Nightmares",
       "names": [
-        "Bruna, the Fading Light",
         "Gisela, the Broken Blade",
+        "Bruna, the Fading Light",
         "Brisela, Voice of Nightmares"
       ],
       "number": "15b",
@@ -2544,6 +2545,7 @@
       "name": "Gisela, the Broken Blade",
       "names": [
         "Gisela, the Broken Blade",
+        "Bruna, the Fading Light",
         "Brisela, Voice of Nightmares"
       ],
       "number": "28a",
@@ -8265,6 +8267,7 @@
       "name": "Graf Rats",
       "names": [
         "Graf Rats",
+        "Midnight Scavengers",
         "Chittering Host"
       ],
       "number": "91a",
@@ -8695,6 +8698,7 @@
       "multiverseid": 414391,
       "name": "Midnight Scavengers",
       "names": [
+        "Graf Rats",
         "Midnight Scavengers",
         "Chittering Host"
       ],
@@ -8777,8 +8781,8 @@
       "multiverseid": 414392,
       "name": "Chittering Host",
       "names": [
-        "Midnight Scavengers",
         "Graf Rats",
+        "Midnight Scavengers",
         "Chittering Host"
       ],
       "number": "96b",
@@ -11884,6 +11888,7 @@
       "multiverseid": 414428,
       "name": "Hanweir Garrison",
       "names": [
+        "Hanweir Battlements",
         "Hanweir Garrison",
         "Hanweir, the Writhing Township"
       ],
@@ -19015,6 +19020,7 @@
       "name": "Hanweir Battlements",
       "names": [
         "Hanweir Battlements",
+        "Hanweir Garrison",
         "Hanweir, the Writhing Township"
       ],
       "number": "204a",

--- a/web/documentation.pug
+++ b/web/documentation.pug
@@ -111,7 +111,7 @@ block contents
             td layout
             td "normal"
             td
-              | The card layout. Possible values: normal, split, flip, double-faced, token, plane, scheme, phenomenon, leveler, vanguard
+              | The card layout. Possible values: normal, split, flip, double-faced, token, plane, scheme, phenomenon, leveler, vanguard, meld
           tr
             td name
             td "Research"
@@ -121,7 +121,7 @@ block contents
             td names
             td [ "Research", "Development" ]
             td
-              | Only used for split, flip and double-faced cards. Will contain all the names on this card, front or back.
+              | Only used for split, flip, double-faced, and meld cards. Will contain all the names on this card, front or back. For meld cards, the first name is the card with the meld ability, which has the top half on its back, the second name is the card with the reminder text, and the third name is the melded back face.
           tr
             td manaCost
             td "GU"


### PR DESCRIPTION
This allows us to deduce which of the three parts of a meld card we're looking at, and refer to a specific other part by indexing the `names` array.

Closes #187.