### PR TITLE
Fix mciNumber extraction

### DIFF
--- a/build/rip.js
+++ b/build/rip.js
@@ -884,7 +884,7 @@ var compareCardToMCI = function(set, card, mciCardURL, cb) {
 	if (cardCorrection && cardCorrection.replace && cardCorrection.replace.artist)
 		hasArtistCorrection = true;
 
-	var mciNumber = mciCardURL.match(/\/([0-9][^\.]*)\.html/)[1]
+	var mciNumber = mciCardURL.match(/\/(\d+)(\.html)?$/)[1]
 	var mciURL = "http://magiccards.info" + mciCardURL;
 
 	tiptoe(

--- a/build/rip.js
+++ b/build/rip.js
@@ -884,7 +884,7 @@ var compareCardToMCI = function(set, card, mciCardURL, cb) {
 	if (cardCorrection && cardCorrection.replace && cardCorrection.replace.artist)
 		hasArtistCorrection = true;
 
-	var mciNumber = mciCardURL.match(/\/(\d+)(\.html)?$/)[1]
+	var mciNumber = mciCardURL.match(/\/(\w+)(\.html)?$/)[1]
 	var mciURL = "http://magiccards.info" + mciCardURL;
 
 	tiptoe(


### PR DESCRIPTION
This patch fixes the `mciNumber` extraction from MCI card URLs.

Currently, many of sets have completely wrong `mciNumber`. Several samples:

```
  '4e/en/104',
  '4e/en/105',
  '4e/en/241',
  '5e/en/137',
  '5e/en/69',
  '5e/en/138',
  '/ptc/en/51a.html',
  '/ptc/en/51b.html',
  '/ptc/en/52a.html',
  '/ptc/en/52b.html',
  '6e/en/328',
  '6e/en/329',
  '6e/en/330',
  '/fnmp/en/78a.html',
  '/fnmp/en/78b.html',
  '/fnmp/en/79a.html',
  '/fnmp/en/79b.html',
  '7e/en/240',
  '7e/en/241',
  '7e/en/242',
  '7e/en/243',
  '7e/en/244',
  '8e/en/274',
  '8e/en/275',
  '8e/en/276',
  '5dn/en/163',
  '5dn/en/164',
  '5dn/en/165',
  '9e/en/250',
  '9e/en/251',
  '9e/en/252',
  '10e/en/353',
  '10e/en/354',
  '10e/en/355',
```

You can get such array with this little snippet (running on Node 4.5.0):

```javascript
let _ = require('lodash');

let sets = JSON.parse(fs.readFileSync('AllSets-x.json', 'utf8'));

let mciNumbers = _.compact(_.flatten(Object.keys(sets).map(set => sets[set].cards.map(card => card.mciNumber))));
let badMciNumbers = mciNumbers.filter(num => num.match('/'));

console.log(badMciNumbers);
```

By the way, many cards have no `mciNumber` at all (see #211).

I hope that helps, and you can fill `mciNumber` for all sets now.