### PR TITLE
Fix symbols and card names in card rulings

### DIFF
--- a/build/rip.js
+++ b/build/rip.js
@@ -497,7 +497,7 @@ var processCardPart = function(doc, cardPart, printedDoc, printedCardPart) {
 	// Rulings
 	var rulingRows = cardPart.querySelectorAll(idPrefix + "_rulingsContainer table tr.post");
 	if (rulingRows.length) {
-		card.rulings = Array.toArray(rulingRows).map(function (rulingRow) { return { date : moment(getTextContent(rulingRow.querySelector("td:first-child")).trim(), "MM/DD/YYYY").format("YYYY-MM-DD"), text : getTextContent(rulingRow.querySelector("td:last-child")).innerTrim().trim()}; });
+		card.rulings = Array.toArray(rulingRows).map(function (rulingRow) { return { date : moment(getTextContent(rulingRow.querySelector("td:first-child")).trim(), "MM/DD/YYYY").format("YYYY-MM-DD"), text : processTextBlocks(rulingRow.querySelector("td:last-child")).innerTrim().trim()}; });
 		var seenRulings = [];
 		card.rulings = card.rulings.reverse().filter(function (ruling) { if (seenRulings.contains(ruling.text)) { return false; } seenRulings.push(ruling.text); return true; }).reverse();
 	}
@@ -1484,7 +1484,7 @@ var processTextBoxChildren = function(children) {
 			var childNodeName = child.nodeName.toLowerCase();
 			if (childNodeName==="img")
 				result += processSymbol(child.getAttribute("alt"));
-			else if (childNodeName==="i" || childNodeName==="b" || childNodeName==="u" || childNodeName==="a")
+			else if (childNodeName==="i" || childNodeName==="b" || childNodeName==="u" || childNodeName==="a" || childNodeName==="autocard")
 				result += processTextBoxChildren(child.childNodes);
 			else if (childNodeName==="<")
 				result += "<";

--- a/shared/shared.js
+++ b/shared/shared.js
@@ -459,6 +459,11 @@ exports.performSetCorrections = function(setCorrections, fullSet)
 
 		card.rulings.forEach(function(ruling)
 		{
+			// Fix bugs on Gatherer with {PW} and {CHAOS} symbols in rulings.
+			ruling.text = ruling.text.replaceAll("roll \\{P\\}\\{W\\}", "roll {PW}");
+			ruling.text = ruling.text.replaceAll("roll \\{C\\}", "roll {CHAOS}");
+			ruling.text = ruling.text.replaceAll("rolling \\{C\\}", "rolling {CHAOS}");
+
 			Object.forEach(C.SYMBOL_MANA, function(manaSymbol)
 			{
 				var newText = ruling.text.replaceAll("\\{" + manaSymbol.toUpperCase() + "\\]", "{" + manaSymbol.toUpperCase() + "}");


### PR DESCRIPTION
The latest Gatherer update changes rulings to include mana symbols as images rther than text.  Card names are also included in <autocard> tags.  This commit accounts for these changes.  It also works around a bug with current rulings where the {PW} and {CHAOS} symbols are incorrectly represented by a phyrexian and white symbol, and a colorless mana symbol.

Gatherer has one existing bug that isn’t worked around.  Cards with hybrid mana in their rulings have these as two separate mana symbols, e.g., Athreos, God of Passage has the {B/G} symbol incorrectly as the black and green mana symbol.