### PR TITLE
Fixes for errors in Gatherer rulings updates.

### DIFF
--- a/build/rip.js
+++ b/build/rip.js
@@ -96,9 +96,20 @@ var SYMBOL_CONVERSION_MAP = {
     "bp"                 : "B/P",
     "rp"                 : "R/P",
     "gp"                 : "G/P",
+    "white or blue"      : "W/U",
+    "white or black"     : "W/B",
+    "blue or red"        : "U/R",
+    "blue or black"      : "U/B",
+    "black or red"       : "B/R",
+    "black or green"     : "B/G",
+    "red or green"       : "R/G",
+    "red or white"       : "R/W",
+    "green or white"     : "G/W",
+    "green or blue"      : "G/U",
     // Planechase Planes
-    "chaos"              : "C",
-    "[chaos]"            : "C",
+    "chaos"              : "CHAOS",
+    "[chaos]"            : "CHAOS",
+    "planeswalk"         : "PW",
     // Unglued, Unhinged
     "100"                : "100",
     "500"                : "500",
@@ -1476,6 +1487,7 @@ var processTextBlocks = function(textBlocks) {
 	});
 
 	result = result.replaceAll("\u2028", "\n");
+	result = result.replaceAll("&amp;", "&");
 
 	while(result.contains("\n\n")) {
 		result = result.replaceAll("\n\n", "\n");
@@ -1541,7 +1553,9 @@ var getTextContent = function(item) {
 			}
 			return('{' + SYMBOL_CONVERSION_MAP[alt.toLowerCase()] + '}');
 		})
-		.replace(/<[^>]*>/g, '');
+		.replace(/<[^>]*>/g, '')
+		.replaceAll("&amp;", "&")
+		.replaceAll("&nbsp;", " ");
 	}
 	return(ret);
 };

--- a/shared/C.js
+++ b/shared/C.js
@@ -4757,7 +4757,7 @@ var base = require("xbase");
 		[
 			"recalculateStandard",
 			{ match : {name : "Draco"}, replace : {text : "Domain — Draco costs {2} less to cast for each basic land type among lands you control.\nFlying\nDomain — At the beginning of your upkeep, sacrifice Draco unless you pay {10}. This cost is reduced by {2} for each basic land type among lands you control."}},
-			{ match : {name : "Spawnsire of Ulamog"}, replace : {text : "Annihilator 1 (Whenever this creature attacks, defending player sacrifices a permanent.)\n{4}: Put two 0/1 colorless Eldrazi Spawn creature tokens onto the battlefield. They have \"Sacrifice this creature: Add {C} to your mana pool.\"\n{20}: Cast any number of Eldrazi cards you own from outside the game without paying their mana costs."}},
+			{ match : {name : "Spawnsire of Ulamog"}, replace : {text : "Annihilator 1 (Whenever this creature attacks, defending player sacrifices a permanent.)\n{4}: Create two 0/1 colorless Eldrazi Spawn creature tokens. They have \"Sacrifice this creature: Add {C} to your mana pool.\"\n{20}: Cast any number of Eldrazi cards you own from outside the game without paying their mana costs."}},
 			{ match : {name : "Jade Statue"}, remove : ["power", "toughness"] },
 			{ match : {name : "Ghostfire"}, remove : ["colors"] },
 			{ match : {name : "Will-O'-The-Wisp"}, replace : {name : "Will-o'-the-Wisp"}},


### PR DESCRIPTION
The latest Gatherer rulings use images for {PW}, {CHAOS} and hybrid mana
symbols.  Some rulings also include HTML ampersands (&amp;) and/or
non-breaking spaces (&nbsp;).  This patch addresses these changes.