### PR TITLE
Add magicCardsInfoCode to Kaladesh Inventions

### DIFF
--- a/shared/C.js
+++ b/shared/C.js
@@ -3154,6 +3154,7 @@ Array.prototype.pushAll = function(otherArray) {
       ],
       code : "MPS",
       magicCardsInfoCode:"mpskld",
+      gathererCode: "MPS_KLD",
       releaseDate : "2016-09-30",
       border : "black",
       type : "masterpiece"

--- a/shared/C.js
+++ b/shared/C.js
@@ -3153,6 +3153,7 @@ Array.prototype.pushAll = function(otherArray) {
         'Kaladesh Inventions'
       ],
       code : "MPS",
+      magicCardsInfoCode:"mpskld",
       releaseDate : "2016-09-30",
       border : "black",
       type : "masterpiece"


### PR DESCRIPTION
For the first time since Morningtide, Magiccards.info has diverged from the official set code, listing `MPS` (Kaladesh Inventions) as `MPSKLD`.

As they do not provide an automatic redirect from (MPS)[http://magiccards.info/mps/en.html] to (MPSKLD)[http://magiccards.info/mpskld/en.html] (As they do with some of the older set code mismatches), I figured it was worth adding the magicCardsInfoCode attribute to this set.