### PR TITLE
Add a changelog update check to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ node_js:
   - 8
   - 6
 
+script:
+  - npm test
+  - util/travis.sh
+
 env:
   - CXX=g++-4.8
 addons:

--- a/util/travis.sh
+++ b/util/travis.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# make sure pull requests include a changelog
+if [[ x"$TRAVIS_PULL_REQUEST" != x'false' ]]; then
+    if git diff --quiet master HEAD -- web/changelog.json; then
+        echo 'All pull requests must update the changelog.'
+        exit 1
+    fi
+fi


### PR DESCRIPTION
This should make Travis CI fail if a pull request is submitted but does not update the changelog.

Since this pull request does not update the changelog, it will serve as a self-test. I will update the changelog once this test succeeds.