### PR TITLE
Fix mciNumber on a number of sets and cards

### DIFF
--- a/build/rip.js
+++ b/build/rip.js
@@ -850,11 +850,11 @@ var compareCardsToMCI = function(set, cb) {
 			var mciCardLinks = Array.toArray(listDoc.querySelectorAll("table tr td a"));
 			async.each(set.cards, function (card, subcb) {
 				if (card.variations) {
-					base.warn("VARIATIONS: Could not find MagicCards.info match for card: %s", card.name)
+					base.warn("VARIATIONS: Could not find MagicCards.info match for card: %s", card.name);
 					return setImmediate(subcb);
 				}
 				if (card.layout==="token") {
-					base.warn("TOKEN: Cannot match MagicCards.info for token: %s", card.name)
+					base.warn("TOKEN: Cannot match MagicCards.info for token: %s", card.name);
 					return setImmediate(subcb);
 				}
 

--- a/build/rip.js
+++ b/build/rip.js
@@ -848,9 +848,15 @@ var compareCardsToMCI = function(set, cb) {
 		},
 		function processSetCardList(listDoc) {
 			var mciCardLinks = Array.toArray(listDoc.querySelectorAll("table tr td a"));
-			async.eachSeries(set.cards, function (card, subcb) {
-				if (card.variations || card.layout==="token")
+			async.each(set.cards, function (card, subcb) {
+				if (card.variations) {
+					base.warn("VARIATIONS: Could not find MagicCards.info match for card: %s", card.name)
 					return setImmediate(subcb);
+				}
+				if (card.layout==="token") {
+					base.warn("TOKEN: Cannot match MagicCards.info for token: %s", card.name)
+					return setImmediate(subcb);
+				}
 
 				var mciCardLink = mciCardLinks.filter(function (link) { return link.textContent.trim().toLowerCase()===createMCICardName(card).toLowerCase(); });
                 if (card.layout==="meld")

--- a/build/rip.js
+++ b/build/rip.js
@@ -1045,7 +1045,7 @@ var ripMCISet = function(set, cb) {
 			var cards = [];
 			var self = this;
 
-			async.eachSeries(mciCardLinks, function(mciCardLink, subcb) {
+			async.each(mciCardLinks, function(mciCardLink, subcb) {
 				var href = mciCardLink.getAttribute("href");
 				if (!href || !href.startsWith("/" + set.magicCardsInfoCode.toLowerCase() + "/en/"))
 					return setImmediate(subcb);

--- a/json/AER.json
+++ b/json/AER.json
@@ -1,6 +1,7 @@
 {
   "name": "Aether Revolt",
   "code": "AER",
+  "magicCardsInfoCode": "aer",
   "releaseDate": "2017-01-20",
   "border": "black",
   "block": "Kaladesh",
@@ -118,6 +119,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "1",
       "multiverseid": 423668,
       "name": "Aerial Modification",
       "number": "1",
@@ -234,6 +236,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "2",
       "multiverseid": 423669,
       "name": "Aeronaut Admiral",
       "number": "2",
@@ -346,6 +349,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "3",
       "multiverseid": 423670,
       "name": "Aether Inspector",
       "number": "3",
@@ -489,6 +493,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "4",
       "multiverseid": 423671,
       "name": "Aethergeode Miner",
       "number": "4",
@@ -632,6 +637,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "5",
       "multiverseid": 423672,
       "name": "Airdrop Aeronauts",
       "number": "5",
@@ -767,6 +773,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "6",
       "multiverseid": 423673,
       "name": "Alley Evasion",
       "number": "6",
@@ -874,6 +881,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "7",
       "multiverseid": 423674,
       "name": "Audacious Infiltrator",
       "number": "7",
@@ -987,6 +995,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "8",
       "multiverseid": 423675,
       "name": "Bastion Enforcer",
       "number": "8",
@@ -1098,6 +1107,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "9",
       "multiverseid": 423676,
       "name": "Call for Unity",
       "number": "9",
@@ -1227,6 +1237,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "10",
       "multiverseid": 423677,
       "name": "Caught in the Brights",
       "number": "10",
@@ -1347,6 +1358,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "11",
       "multiverseid": 423678,
       "name": "Consulate Crackdown",
       "number": "11",
@@ -1485,6 +1497,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "12",
       "multiverseid": 423679,
       "name": "Conviction",
       "number": "12",
@@ -1603,6 +1616,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "13",
       "multiverseid": 423680,
       "name": "Countless Gears Renegade",
       "number": "13",
@@ -1738,6 +1752,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "14",
       "multiverseid": 423681,
       "name": "Dawnfeather Eagle",
       "number": "14",
@@ -1860,6 +1875,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "15",
       "multiverseid": 423682,
       "name": "Deadeye Harpooner",
       "number": "15",
@@ -1995,6 +2011,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "16",
       "multiverseid": 423683,
       "name": "Decommission",
       "number": "16",
@@ -2128,6 +2145,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "17",
       "multiverseid": 423684,
       "name": "Deft Dismissal",
       "number": "17",
@@ -2245,6 +2263,7 @@
         }
       ],
       "manaCost": "{5}{W}{W}",
+      "mciNumber": "18",
       "multiverseid": 423685,
       "name": "Exquisite Archangel",
       "number": "18",
@@ -2391,6 +2410,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "19",
       "multiverseid": 423686,
       "name": "Felidar Guardian",
       "number": "19",
@@ -2514,6 +2534,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "20",
       "multiverseid": 423687,
       "name": "Ghirapur Osprey",
       "number": "20",
@@ -2626,6 +2647,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "21",
       "multiverseid": 423688,
       "name": "Restoration Specialist",
       "number": "21",
@@ -2745,6 +2767,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "22",
       "multiverseid": 423689,
       "name": "Solemn Recruit",
       "number": "22",
@@ -2880,6 +2903,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "23",
       "multiverseid": 423690,
       "name": "Sram, Senior Edificer",
       "number": "23",
@@ -3002,6 +3026,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "24",
       "multiverseid": 423691,
       "name": "Sram's Expertise",
       "number": "24",
@@ -3139,6 +3164,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "25",
       "multiverseid": 423692,
       "name": "Thopter Arrest",
       "number": "25",
@@ -3267,6 +3293,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "26",
       "multiverseid": 423693,
       "name": "Aether Swooper",
       "number": "26",
@@ -3410,6 +3437,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "27",
       "multiverseid": 423694,
       "name": "Aethertide Whale",
       "number": "27",
@@ -3548,6 +3576,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "28",
       "multiverseid": 423695,
       "name": "Baral, Chief of Compliance",
       "number": "28",
@@ -3678,6 +3707,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "29",
       "multiverseid": 423696,
       "name": "Baral's Expertise",
       "number": "29",
@@ -3823,6 +3853,7 @@
         }
       ],
       "manaCost": "{5}{U}",
+      "mciNumber": "30",
       "multiverseid": 423697,
       "name": "Bastion Inventor",
       "number": "30",
@@ -3970,6 +4001,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "31",
       "multiverseid": 423698,
       "name": "Disallow",
       "number": "31",
@@ -4104,6 +4136,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "32",
       "multiverseid": 423699,
       "name": "Dispersal Technician",
       "number": "32",
@@ -4217,6 +4250,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "33",
       "multiverseid": 423700,
       "name": "Efficient Construction",
       "number": "33",
@@ -4330,6 +4364,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "34",
       "multiverseid": 423701,
       "name": "Hinterland Drake",
       "number": "34",
@@ -4442,6 +4477,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "35",
       "multiverseid": 423702,
       "name": "Ice Over",
       "number": "35",
@@ -4558,6 +4594,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "36",
       "multiverseid": 423703,
       "name": "Illusionist's Stratagem",
       "number": "36",
@@ -4687,6 +4724,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "37",
       "multiverseid": 423704,
       "name": "Leave in the Dust",
       "number": "37",
@@ -4800,6 +4838,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "38",
       "multiverseid": 423705,
       "name": "Mechanized Production",
       "number": "38",
@@ -4956,6 +4995,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "39",
       "multiverseid": 423706,
       "name": "Metallic Rebuke",
       "number": "39",
@@ -5109,6 +5149,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "40",
       "multiverseid": 423707,
       "name": "Negate",
       "number": "40",
@@ -5235,6 +5276,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "41",
       "multiverseid": 423708,
       "name": "Quicksmith Spy",
       "number": "41",
@@ -5366,6 +5408,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "42",
       "multiverseid": 423709,
       "name": "Reverse Engineer",
       "number": "42",
@@ -5507,6 +5550,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "43",
       "multiverseid": 423710,
       "name": "Salvage Scuttler",
       "number": "43",
@@ -5625,6 +5669,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "44",
       "multiverseid": 423711,
       "name": "Shielded Aether Thief",
       "number": "44",
@@ -5768,6 +5813,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "45",
       "multiverseid": 423712,
       "name": "Shipwreck Moray",
       "number": "45",
@@ -5906,6 +5952,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "46",
       "multiverseid": 423713,
       "name": "Skyship Plunderer",
       "number": "46",
@@ -6033,6 +6080,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "47",
       "multiverseid": 423714,
       "name": "Take into Custody",
       "number": "47",
@@ -6146,6 +6194,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "48",
       "multiverseid": 423715,
       "name": "Trophy Mage",
       "number": "48",
@@ -6264,6 +6313,7 @@
         }
       ],
       "manaCost": "{X}{U}{U}{U}",
+      "mciNumber": "49",
       "multiverseid": 423716,
       "name": "Whir of Invention",
       "number": "49",
@@ -6409,6 +6459,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "50",
       "multiverseid": 423717,
       "name": "Wind-Kin Raiders",
       "number": "50",
@@ -6555,6 +6606,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "51",
       "multiverseid": 423718,
       "name": "Aether Poisoner",
       "number": "51",
@@ -6698,6 +6750,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "52",
       "multiverseid": 423719,
       "name": "Alley Strangler",
       "number": "52",
@@ -6811,6 +6864,7 @@
         }
       ],
       "manaCost": "{X}{B}",
+      "mciNumber": "53",
       "multiverseid": 423720,
       "name": "Battle at the Bridge",
       "number": "53",
@@ -6965,6 +7019,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "54",
       "multiverseid": 423721,
       "name": "Cruel Finality",
       "number": "54",
@@ -7078,6 +7133,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "55",
       "multiverseid": 423722,
       "name": "Daring Demolition",
       "number": "55",
@@ -7185,6 +7241,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "56",
       "multiverseid": 423723,
       "name": "Defiant Salvager",
       "number": "56",
@@ -7307,6 +7364,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "57",
       "multiverseid": 423724,
       "name": "Fatal Push",
       "number": "57",
@@ -7440,6 +7498,7 @@
         }
       ],
       "manaCost": "{6}{B}",
+      "mciNumber": "58",
       "multiverseid": 423725,
       "name": "Fen Hauler",
       "number": "58",
@@ -7586,6 +7645,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "59",
       "multiverseid": 423726,
       "name": "Foundry Hornet",
       "number": "59",
@@ -7712,6 +7772,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "60",
       "multiverseid": 423727,
       "name": "Fourth Bridge Prowler",
       "number": "60",
@@ -7831,6 +7892,7 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "61",
       "multiverseid": 423728,
       "name": "Gifted Aetherborn",
       "number": "61",
@@ -7943,6 +8005,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "62",
       "multiverseid": 423729,
       "name": "Glint-Sleeve Siphoner",
       "number": "62",
@@ -8090,6 +8153,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "63",
       "multiverseid": 423730,
       "name": "Gonti's Machinations",
       "number": "63",
@@ -8234,6 +8298,7 @@
         }
       ],
       "manaCost": "{5}{B}{B}",
+      "mciNumber": "64",
       "multiverseid": 423731,
       "name": "Herald of Anguish",
       "number": "64",
@@ -8380,6 +8445,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "65",
       "multiverseid": 423732,
       "name": "Ironclad Revolutionary",
       "number": "65",
@@ -8506,6 +8572,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "66",
       "multiverseid": 423733,
       "name": "Midnight Entourage",
       "number": "66",
@@ -8633,6 +8700,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "67",
       "multiverseid": 423734,
       "name": "Night Market Aeronaut",
       "number": "67",
@@ -8764,6 +8832,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "68",
       "multiverseid": 423735,
       "name": "Perilous Predicament",
       "number": "68",
@@ -8881,6 +8950,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "69",
       "multiverseid": 423736,
       "name": "Renegade's Getaway",
       "number": "69",
@@ -8998,6 +9068,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "70",
       "multiverseid": 423737,
       "name": "Resourceful Return",
       "number": "70",
@@ -9115,6 +9186,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "71",
       "multiverseid": 423738,
       "name": "Secret Salvage",
       "number": "71",
@@ -9221,6 +9293,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "72",
       "multiverseid": 423739,
       "name": "Sly Requisitioner",
       "number": "72",
@@ -9372,6 +9445,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "73",
       "multiverseid": 423740,
       "name": "Vengeful Rebel",
       "number": "73",
@@ -9507,6 +9581,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "74",
       "multiverseid": 423741,
       "name": "Yahenni, Undying Partisan",
       "number": "74",
@@ -9629,6 +9704,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "75",
       "multiverseid": 423742,
       "name": "Yahenni's Expertise",
       "number": "75",
@@ -9769,6 +9845,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "76",
       "multiverseid": 423743,
       "name": "Aether Chaser",
       "number": "76",
@@ -9912,6 +9989,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "77",
       "multiverseid": 423744,
       "name": "Chandra's Revolution",
       "number": "77",
@@ -10025,6 +10103,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "78",
       "multiverseid": 423745,
       "name": "Destructive Tampering",
       "number": "78",
@@ -10142,6 +10221,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "79",
       "multiverseid": 423746,
       "name": "Embraal Gear-Smasher",
       "number": "79",
@@ -10261,6 +10341,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "80",
       "multiverseid": 423747,
       "name": "Enraged Giant",
       "number": "80",
@@ -10407,6 +10488,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "81",
       "multiverseid": 423748,
       "name": "Freejam Regent",
       "number": "81",
@@ -10553,6 +10635,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "82",
       "multiverseid": 423749,
       "name": "Frontline Rebel",
       "number": "82",
@@ -10671,6 +10754,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "83",
       "multiverseid": 423750,
       "name": "Gremlin Infestation",
       "number": "83",
@@ -10787,6 +10871,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "84",
       "multiverseid": 423751,
       "name": "Hungry Flames",
       "number": "84",
@@ -10899,6 +10984,7 @@
         }
       ],
       "manaCost": "{X}{R}{R}{R}",
+      "mciNumber": "85",
       "multiverseid": 423752,
       "name": "Indomitable Creativity",
       "number": "85",
@@ -11028,6 +11114,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "86",
       "multiverseid": 423753,
       "name": "Invigorated Rampage",
       "number": "86",
@@ -11141,6 +11228,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "87",
       "multiverseid": 423754,
       "name": "Kari Zev, Skyship Raider",
       "number": "87",
@@ -11271,6 +11359,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "88",
       "multiverseid": 423755,
       "name": "Kari Zev's Expertise",
       "number": "88",
@@ -11416,6 +11505,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "89",
       "multiverseid": 423756,
       "name": "Lathnu Sailback",
       "number": "89",
@@ -11526,6 +11616,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "90",
       "multiverseid": 423757,
       "name": "Lightning Runner",
       "number": "90",
@@ -11673,6 +11764,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "91",
       "multiverseid": 423758,
       "name": "Pia's Revolution",
       "number": "91",
@@ -11803,6 +11895,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "92",
       "multiverseid": 423759,
       "name": "Precise Strike",
       "number": "92",
@@ -11910,6 +12003,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "93",
       "multiverseid": 423760,
       "name": "Quicksmith Rebel",
       "number": "93",
@@ -12041,6 +12135,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "94",
       "multiverseid": 423761,
       "name": "Ravenous Intruder",
       "number": "94",
@@ -12153,6 +12248,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "95",
       "multiverseid": 423762,
       "name": "Reckless Racer",
       "number": "95",
@@ -12276,6 +12372,7 @@
         }
       ],
       "manaCost": "{X}{X}{R}",
+      "mciNumber": "96",
       "multiverseid": 423763,
       "name": "Release the Gremlins",
       "number": "96",
@@ -12396,6 +12493,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "97",
       "multiverseid": 423764,
       "name": "Scrapper Champion",
       "number": "97",
@@ -12547,6 +12645,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "98",
       "multiverseid": 423765,
       "name": "Shock",
       "number": "98",
@@ -12668,6 +12767,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "99",
       "multiverseid": 423766,
       "name": "Siege Modification",
       "number": "99",
@@ -12784,6 +12884,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "100",
       "multiverseid": 423767,
       "name": "Sweatworks Brawler",
       "number": "100",
@@ -12931,6 +13032,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "101",
       "multiverseid": 423768,
       "name": "Wrangle",
       "number": "101",
@@ -13047,6 +13149,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "102",
       "multiverseid": 423769,
       "name": "Aether Herder",
       "number": "102",
@@ -13190,6 +13293,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "103",
       "multiverseid": 423770,
       "name": "Aetherstream Leopard",
       "number": "103",
@@ -13332,6 +13436,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}{G}",
+      "mciNumber": "104",
       "multiverseid": 423771,
       "name": "Aetherwind Basker",
       "number": "104",
@@ -13477,6 +13582,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "105",
       "multiverseid": 423772,
       "name": "Aid from the Cowl",
       "number": "105",
@@ -13618,6 +13724,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "106",
       "multiverseid": 423773,
       "name": "Druid of the Cowl",
       "number": "106",
@@ -13731,6 +13838,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "107",
       "multiverseid": 423774,
       "name": "Greenbelt Rampager",
       "number": "107",
@@ -13877,6 +13985,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "108",
       "multiverseid": 423775,
       "name": "Greenwheel Liberator",
       "number": "108",
@@ -14008,6 +14117,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "109",
       "multiverseid": 423776,
       "name": "Heroic Intervention",
       "number": "109",
@@ -14121,6 +14231,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "110",
       "multiverseid": 423777,
       "name": "Hidden Herbalists",
       "number": "110",
@@ -14256,6 +14367,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "111",
       "multiverseid": 423778,
       "name": "Highspire Infusion",
       "number": "111",
@@ -14393,6 +14505,7 @@
         }
       ],
       "manaCost": "{X}{G}",
+      "mciNumber": "112",
       "multiverseid": 423779,
       "name": "Lifecraft Awakening",
       "number": "112",
@@ -14518,6 +14631,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "113",
       "multiverseid": 423780,
       "name": "Lifecraft Cavalry",
       "number": "113",
@@ -14649,6 +14763,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "114",
       "multiverseid": 423781,
       "name": "Lifecrafter's Gift",
       "number": "114",
@@ -14773,6 +14888,7 @@
         }
       ],
       "manaCost": "{1}{G}{G}",
+      "mciNumber": "115",
       "multiverseid": 423782,
       "name": "Maulfist Revolutionary",
       "number": "115",
@@ -14900,6 +15016,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "116",
       "multiverseid": 423783,
       "name": "Monstrous Onslaught",
       "number": "116",
@@ -15025,6 +15142,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "117",
       "multiverseid": 423784,
       "name": "Narnam Renegade",
       "number": "117",
@@ -15156,6 +15274,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "118",
       "multiverseid": 423785,
       "name": "Natural Obsolescence",
       "number": "118",
@@ -15263,6 +15382,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "119",
       "multiverseid": 423786,
       "name": "Peema Aether-Seer",
       "number": "119",
@@ -15426,6 +15546,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "120",
       "multiverseid": 423787,
       "name": "Prey Upon",
       "number": "120",
@@ -15544,6 +15665,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "121",
       "multiverseid": 423788,
       "name": "Ridgescale Tusker",
       "number": "121",
@@ -15656,6 +15778,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "122",
       "multiverseid": 423789,
       "name": "Rishkar, Peema Renegade",
       "number": "122",
@@ -15786,6 +15909,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "123",
       "multiverseid": 423790,
       "name": "Rishkar's Expertise",
       "number": "123",
@@ -15935,6 +16059,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "124",
       "multiverseid": 423791,
       "name": "Scrounging Bandar",
       "number": "124",
@@ -16058,6 +16183,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "125",
       "multiverseid": 423792,
       "name": "Silkweaver Elite",
       "number": "125",
@@ -16193,6 +16319,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "126",
       "multiverseid": 423793,
       "name": "Unbridled Growth",
       "number": "126",
@@ -16305,6 +16432,7 @@
       ],
       "loyalty": 4,
       "manaCost": "{4}{G}{W}",
+      "mciNumber": "127",
       "multiverseid": 423794,
       "name": "Ajani Unyielding",
       "number": "127",
@@ -16428,6 +16556,7 @@
         }
       ],
       "manaCost": "{2}{U}{B}{R}",
+      "mciNumber": "128",
       "multiverseid": 423795,
       "name": "Dark Intimations",
       "number": "128",
@@ -16567,6 +16696,7 @@
         }
       ],
       "manaCost": "{W}{B}",
+      "mciNumber": "129",
       "multiverseid": 423796,
       "name": "Hidden Stockpile",
       "number": "129",
@@ -16697,6 +16827,7 @@
         }
       ],
       "manaCost": "{3}{U}{R}",
+      "mciNumber": "130",
       "multiverseid": 423797,
       "name": "Maverick Thopterist",
       "number": "130",
@@ -16812,6 +16943,7 @@
         }
       ],
       "manaCost": "{G}{W}",
+      "mciNumber": "131",
       "multiverseid": 423798,
       "name": "Oath of Ajani",
       "number": "131",
@@ -16924,6 +17056,7 @@
         }
       ],
       "manaCost": "{2}{R}{G}",
+      "mciNumber": "132",
       "multiverseid": 423799,
       "name": "Outland Boar",
       "number": "132",
@@ -17044,6 +17177,7 @@
         }
       ],
       "manaCost": "{1}{G}{W}",
+      "mciNumber": "133",
       "multiverseid": 423800,
       "name": "Renegade Rallier",
       "number": "133",
@@ -17201,6 +17335,7 @@
         }
       ],
       "manaCost": "{1}{R}{W}",
+      "mciNumber": "134",
       "multiverseid": 423801,
       "name": "Renegade Wheelsmith",
       "number": "134",
@@ -17326,6 +17461,7 @@
         }
       ],
       "manaCost": "{1}{G}{U}",
+      "mciNumber": "135",
       "multiverseid": 423802,
       "name": "Rogue Refiner",
       "number": "135",
@@ -17467,6 +17603,7 @@
         }
       ],
       "manaCost": "{2}{W}{U}",
+      "mciNumber": "136",
       "multiverseid": 423803,
       "name": "Spire Patrol",
       "number": "136",
@@ -17588,6 +17725,7 @@
       ],
       "loyalty": 5,
       "manaCost": "{2}{U}{B}",
+      "mciNumber": "137",
       "multiverseid": 423804,
       "name": "Tezzeret the Schemer",
       "number": "137",
@@ -17725,6 +17863,7 @@
         }
       ],
       "manaCost": "{1}{U}{B}",
+      "mciNumber": "138",
       "multiverseid": 423805,
       "name": "Tezzeret's Touch",
       "number": "138",
@@ -17859,6 +17998,7 @@
         }
       ],
       "manaCost": "{1}{B}{R}",
+      "mciNumber": "139",
       "multiverseid": 423806,
       "name": "Weldfast Engineer",
       "number": "139",
@@ -17973,6 +18113,7 @@
         }
       ],
       "manaCost": "{B}{G}",
+      "mciNumber": "140",
       "multiverseid": 423807,
       "name": "Winding Constrictor",
       "number": "140",
@@ -18112,6 +18253,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "141",
       "multiverseid": 423808,
       "name": "Aegis Automaton",
       "number": "141",
@@ -18218,6 +18360,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "142",
       "multiverseid": 423809,
       "name": "Aethersphere Harvester",
       "number": "142",
@@ -18405,6 +18548,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "143",
       "multiverseid": 423810,
       "name": "Augmenting Automaton",
       "number": "143",
@@ -18512,6 +18656,7 @@
         }
       ],
       "manaCost": "{7}",
+      "mciNumber": "144",
       "multiverseid": 423811,
       "name": "Barricade Breaker",
       "number": "144",
@@ -18657,6 +18802,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "145",
       "multiverseid": 423812,
       "name": "Cogwork Assembler",
       "number": "145",
@@ -18786,6 +18932,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "146",
       "multiverseid": 423813,
       "name": "Consulate Dreadnought",
       "number": "146",
@@ -18942,6 +19089,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "147",
       "multiverseid": 423814,
       "name": "Consulate Turret",
       "number": "147",
@@ -19069,6 +19217,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "148",
       "multiverseid": 423815,
       "name": "Crackdown Construct",
       "number": "148",
@@ -19193,6 +19342,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "149",
       "multiverseid": 423816,
       "name": "Daredevil Dragster",
       "number": "149",
@@ -19365,6 +19515,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "150",
       "multiverseid": 423817,
       "name": "Filigree Crawler",
       "number": "150",
@@ -19472,6 +19623,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "151",
       "multiverseid": 423818,
       "name": "Foundry Assembler",
       "number": "151",
@@ -19613,6 +19765,7 @@
         }
       ],
       "manaCost": "{6}",
+      "mciNumber": "152",
       "multiverseid": 423819,
       "name": "Gonti's Aether Heart",
       "number": "152",
@@ -19742,6 +19895,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "153",
       "multiverseid": 423820,
       "name": "Heart of Kiran",
       "number": "153",
@@ -19905,6 +20059,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "154",
       "multiverseid": 423821,
       "name": "Hope of Ghirapur",
       "number": "154",
@@ -20040,6 +20195,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "155",
       "multiverseid": 423822,
       "name": "Implement of Combustion",
       "number": "155",
@@ -20154,6 +20310,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "156",
       "multiverseid": 423823,
       "name": "Implement of Examination",
       "number": "156",
@@ -20267,6 +20424,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "157",
       "multiverseid": 423824,
       "name": "Implement of Ferocity",
       "number": "157",
@@ -20381,6 +20539,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "158",
       "multiverseid": 423825,
       "name": "Implement of Improvement",
       "number": "158",
@@ -20494,6 +20653,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "159",
       "multiverseid": 423826,
       "name": "Implement of Malice",
       "number": "159",
@@ -20605,6 +20765,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "160",
       "multiverseid": 423827,
       "name": "Inspiring Statuary",
       "number": "160",
@@ -20752,6 +20913,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "161",
       "multiverseid": 423828,
       "name": "Irontread Crusher",
       "number": "161",
@@ -20911,6 +21073,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "162",
       "multiverseid": 423829,
       "name": "Lifecrafter's Bestiary",
       "number": "162",
@@ -21029,6 +21192,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "163",
       "multiverseid": 423830,
       "name": "Merchant's Dockhand",
       "number": "163",
@@ -21149,6 +21313,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "164",
       "multiverseid": 423831,
       "name": "Metallic Mimic",
       "number": "164",
@@ -21277,6 +21442,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "165",
       "multiverseid": 423832,
       "name": "Mobile Garrison",
       "number": "165",
@@ -21441,6 +21607,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "166",
       "multiverseid": 423833,
       "name": "Night Market Guard",
       "number": "166",
@@ -21552,6 +21719,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "167",
       "multiverseid": 423834,
       "name": "Ornithopter",
       "number": "167",
@@ -21671,6 +21839,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "168",
       "multiverseid": 423835,
       "name": "Pacification Array",
       "number": "168",
@@ -21786,6 +21955,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "169",
       "multiverseid": 423836,
       "name": "Paradox Engine",
       "number": "169",
@@ -21900,6 +22070,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "170",
       "multiverseid": 423837,
       "name": "Peacewalker Colossus",
       "number": "170",
@@ -22056,6 +22227,7 @@
         }
       ],
       "manaCost": "{6}",
+      "mciNumber": "171",
       "multiverseid": 423838,
       "name": "Planar Bridge",
       "number": "171",
@@ -22167,6 +22339,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "172",
       "multiverseid": 423839,
       "name": "Prizefighter Construct",
       "number": "172",
@@ -22272,6 +22445,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "173",
       "multiverseid": 423840,
       "name": "Renegade Map",
       "number": "173",
@@ -22373,6 +22547,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "174",
       "multiverseid": 423841,
       "name": "Reservoir Walker",
       "number": "174",
@@ -22505,6 +22680,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "175",
       "multiverseid": 423842,
       "name": "Scrap Trawler",
       "number": "175",
@@ -22630,6 +22806,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "176",
       "multiverseid": 423843,
       "name": "Servo Schematic",
       "number": "176",
@@ -22736,6 +22913,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "177",
       "multiverseid": 423844,
       "name": "Treasure Keeper",
       "number": "177",
@@ -22857,6 +23035,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "178",
       "multiverseid": 423845,
       "name": "Universal Solvent",
       "number": "178",
@@ -22958,6 +23137,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "179",
       "multiverseid": 423846,
       "name": "Untethered Express",
       "number": "179",
@@ -23121,6 +23301,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "180",
       "multiverseid": 423847,
       "name": "Verdant Automaton",
       "number": "180",
@@ -23227,6 +23408,7 @@
         }
       ],
       "manaCost": "{X}{X}",
+      "mciNumber": "181",
       "multiverseid": 423848,
       "name": "Walking Ballista",
       "number": "181",
@@ -23347,6 +23529,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "182",
       "multiverseid": 423849,
       "name": "Watchful Automaton",
       "number": "182",
@@ -23463,6 +23646,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "183",
       "multiverseid": 423850,
       "name": "Welder Automaton",
       "number": "183",
@@ -23574,6 +23758,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "184",
       "multiverseid": 423851,
       "name": "Spire of Industry",
       "number": "184",
@@ -23683,6 +23868,7 @@
       ],
       "loyalty": 4,
       "manaCost": "{4}{G}{W}",
+      "mciNumber": "185",
       "multiverseid": 425692,
       "name": "Ajani, Valiant Protector",
       "number": "185",
@@ -23803,6 +23989,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "186",
       "multiverseid": 425693,
       "name": "Inspiring Roar",
       "number": "186",
@@ -23910,6 +24097,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "187",
       "multiverseid": 425694,
       "name": "Ajani's Comrade",
       "number": "187",
@@ -24024,6 +24212,7 @@
         }
       ],
       "manaCost": "{2}{G}{W}",
+      "mciNumber": "188",
       "multiverseid": 425695,
       "name": "Ajani's Aid",
       "number": "188",
@@ -24145,6 +24334,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "189",
       "multiverseid": 425696,
       "name": "Tranquil Expanse",
       "number": "189",
@@ -24256,6 +24446,7 @@
       ],
       "loyalty": 5,
       "manaCost": "{4}{U}{B}",
+      "mciNumber": "190",
       "multiverseid": 425697,
       "name": "Tezzeret, Master of Metal",
       "number": "190",
@@ -24378,6 +24569,7 @@
         }
       ],
       "manaCost": "{3}{U}{B}",
+      "mciNumber": "191",
       "multiverseid": 425698,
       "name": "Tezzeret's Betrayal",
       "number": "191",
@@ -24485,6 +24677,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "192",
       "multiverseid": 425699,
       "name": "Pendulum of Patterns",
       "number": "192",
@@ -24586,6 +24779,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "193",
       "multiverseid": 425700,
       "name": "Tezzeret's Simulacrum",
       "number": "193",
@@ -24703,6 +24897,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "194",
       "multiverseid": 425701,
       "name": "Submerged Boneyard",
       "number": "194",

--- a/json/AKH.json
+++ b/json/AKH.json
@@ -1,6 +1,7 @@
 {
   "name": "Amonkhet",
   "code": "AKH",
+  "magicCardsInfoCode": "akh",
   "releaseDate": "2017-04-28",
   "border": "black",
   "block": "Amonkhet",
@@ -118,6 +119,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "1",
       "multiverseid": 426703,
       "name": "Angel of Sanctions",
       "number": "1",
@@ -276,6 +278,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "2",
       "multiverseid": 426704,
       "name": "Anointed Procession",
       "number": "2",
@@ -409,6 +412,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "3",
       "multiverseid": 426705,
       "name": "Anointer Priest",
       "number": "3",
@@ -555,6 +559,7 @@
         }
       ],
       "manaCost": "{6}{W}",
+      "mciNumber": "4",
       "multiverseid": 426706,
       "name": "Approach of the Second Sun",
       "number": "4",
@@ -692,6 +697,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "5",
       "multiverseid": 426707,
       "name": "Aven Mindcensor",
       "number": "5",
@@ -825,6 +831,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "6",
       "multiverseid": 426708,
       "name": "Binding Mummy",
       "number": "6",
@@ -936,6 +943,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "7",
       "multiverseid": 426709,
       "name": "Cartouche of Solidarity",
       "number": "7",
@@ -1060,6 +1068,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "8",
       "multiverseid": 426710,
       "name": "Cast Out",
       "number": "8",
@@ -1189,6 +1198,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "9",
       "multiverseid": 426711,
       "name": "Compulsory Rest",
       "number": "9",
@@ -1304,6 +1314,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "10",
       "multiverseid": 426712,
       "name": "Devoted Crop-Mate",
       "number": "10",
@@ -1455,6 +1466,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "11",
       "multiverseid": 426713,
       "name": "Djeru's Resolve",
       "number": "11",
@@ -1572,6 +1584,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "12",
       "multiverseid": 426714,
       "name": "Fan Bearer",
       "number": "12",
@@ -1684,6 +1697,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "13",
       "multiverseid": 426715,
       "name": "Forsake the Worldly",
       "number": "13",
@@ -1791,6 +1805,7 @@
       ],
       "loyalty": 3,
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "14",
       "multiverseid": 426716,
       "name": "Gideon of the Trials",
       "number": "14",
@@ -1938,6 +1953,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "15",
       "multiverseid": 426717,
       "name": "Gideon's Intervention",
       "number": "15",
@@ -2064,6 +2080,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "16",
       "multiverseid": 426718,
       "name": "Glory-Bound Initiate",
       "number": "16",
@@ -2195,6 +2212,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "17",
       "multiverseid": 426719,
       "name": "Gust Walker",
       "number": "17",
@@ -2330,6 +2348,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "18",
       "multiverseid": 426720,
       "name": "Impeccable Timing",
       "number": "18",
@@ -2438,6 +2457,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "19",
       "multiverseid": 426721,
       "name": "In Oketra's Name",
       "number": "19",
@@ -2555,6 +2575,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "20",
       "multiverseid": 426722,
       "name": "Mighty Leap",
       "number": "20",
@@ -2675,6 +2696,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "21",
       "multiverseid": 426723,
       "name": "Oketra the True",
       "number": "21",
@@ -2800,6 +2822,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "22",
       "multiverseid": 426724,
       "name": "Oketra's Attendant",
       "number": "22",
@@ -2935,6 +2958,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "23",
       "multiverseid": 426725,
       "name": "Protection of the Hekma",
       "number": "23",
@@ -3056,6 +3080,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "24",
       "multiverseid": 426726,
       "name": "Regal Caracal",
       "number": "24",
@@ -3182,6 +3207,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "25",
       "multiverseid": 426727,
       "name": "Renewed Faith",
       "number": "25",
@@ -3322,6 +3348,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "26",
       "multiverseid": 426728,
       "name": "Rhet-Crop Spearmaster",
       "number": "26",
@@ -3452,6 +3479,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "27",
       "multiverseid": 426729,
       "name": "Sacred Cat",
       "number": "27",
@@ -3586,6 +3614,7 @@
         }
       ],
       "manaCost": "{5}{W}{W}",
+      "mciNumber": "28",
       "multiverseid": 426730,
       "name": "Seraph of the Suns",
       "number": "28",
@@ -3698,6 +3727,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "29",
       "multiverseid": 426731,
       "name": "Sparring Mummy",
       "number": "29",
@@ -3810,6 +3840,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "30",
       "multiverseid": 426732,
       "name": "Supply Caravan",
       "number": "30",
@@ -3931,6 +3962,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "31",
       "multiverseid": 426733,
       "name": "Tah-Crop Elite",
       "number": "31",
@@ -4062,6 +4094,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "32",
       "multiverseid": 426734,
       "name": "Those Who Serve",
       "number": "32",
@@ -4172,6 +4205,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "33",
       "multiverseid": 426735,
       "name": "Time to Reflect",
       "number": "33",
@@ -4289,6 +4323,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "34",
       "multiverseid": 426736,
       "name": "Trial of Solidarity",
       "number": "34",
@@ -4409,6 +4444,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "35",
       "multiverseid": 426737,
       "name": "Trueheart Duelist",
       "number": "35",
@@ -4543,6 +4579,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "36",
       "multiverseid": 426738,
       "name": "Unwavering Initiate",
       "number": "36",
@@ -4677,6 +4714,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "37",
       "multiverseid": 426739,
       "name": "Vizier of Deferment",
       "number": "37",
@@ -4804,6 +4842,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "38",
       "multiverseid": 426740,
       "name": "Vizier of Remedies",
       "number": "38",
@@ -4939,6 +4978,7 @@
         }
       ],
       "manaCost": "{5}{W}",
+      "mciNumber": "39",
       "multiverseid": 426741,
       "name": "Winged Shepherd",
       "number": "39",
@@ -5055,6 +5095,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "40",
       "multiverseid": 426742,
       "name": "Ancient Crab",
       "number": "40",
@@ -5166,6 +5207,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "41",
       "multiverseid": 426743,
       "name": "Angler Drake",
       "number": "41",
@@ -5277,6 +5319,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "42",
       "multiverseid": 426744,
       "name": "As Foretold",
       "number": "42",
@@ -5413,6 +5456,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "43",
       "multiverseid": 426745,
       "name": "Aven Initiate",
       "number": "43",
@@ -5568,6 +5612,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "44",
       "multiverseid": 426746,
       "name": "Cancel",
       "number": "44",
@@ -5690,6 +5735,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "45",
       "multiverseid": 426747,
       "name": "Cartouche of Knowledge",
       "number": "45",
@@ -5815,6 +5861,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "46",
       "multiverseid": 426748,
       "name": "Censor",
       "number": "46",
@@ -5922,6 +5969,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "47",
       "multiverseid": 426749,
       "name": "Compelling Argument",
       "number": "47",
@@ -6029,6 +6077,7 @@
         }
       ],
       "manaCost": "{5}{U}{U}",
+      "mciNumber": "48",
       "multiverseid": 426750,
       "name": "Cryptic Serpent",
       "number": "48",
@@ -6155,6 +6204,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "49",
       "multiverseid": 426751,
       "name": "Curator of Mysteries",
       "number": "49",
@@ -6285,6 +6335,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "50",
       "multiverseid": 426752,
       "name": "Decision Paralysis",
       "number": "50",
@@ -6392,6 +6443,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "51",
       "multiverseid": 426753,
       "name": "Drake Haven",
       "number": "51",
@@ -6521,6 +6573,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "52",
       "multiverseid": 426754,
       "name": "Essence Scatter",
       "number": "52",
@@ -6638,6 +6691,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "53",
       "multiverseid": 426755,
       "name": "Floodwaters",
       "number": "53",
@@ -6745,6 +6799,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "54",
       "multiverseid": 426756,
       "name": "Galestrike",
       "number": "54",
@@ -6857,6 +6912,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "55",
       "multiverseid": 426757,
       "name": "Glyph Keeper",
       "number": "55",
@@ -6991,6 +7047,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "56",
       "multiverseid": 426758,
       "name": "Hekma Sentinels",
       "number": "56",
@@ -7122,6 +7179,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "57",
       "multiverseid": 426759,
       "name": "Hieroglyphic Illumination",
       "number": "57",
@@ -7229,6 +7287,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "58",
       "multiverseid": 426760,
       "name": "Illusory Wrappings",
       "number": "58",
@@ -7348,6 +7407,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "59",
       "multiverseid": 426761,
       "name": "Kefnet the Mindful",
       "number": "59",
@@ -7473,6 +7533,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "60",
       "multiverseid": 426762,
       "name": "Labyrinth Guardian",
       "number": "60",
@@ -7616,6 +7677,7 @@
         }
       ],
       "manaCost": "{5}{U}{U}",
+      "mciNumber": "61",
       "multiverseid": 426763,
       "name": "Lay Claim",
       "number": "61",
@@ -7732,6 +7794,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "62",
       "multiverseid": 426764,
       "name": "Naga Oracle",
       "number": "62",
@@ -7845,6 +7908,7 @@
         }
       ],
       "manaCost": "{5}{U}",
+      "mciNumber": "63",
       "multiverseid": 426765,
       "name": "New Perspectives",
       "number": "63",
@@ -7966,6 +8030,7 @@
         }
       ],
       "manaCost": "{X}{U}{U}",
+      "mciNumber": "64",
       "multiverseid": 426766,
       "name": "Open into Wonder",
       "number": "64",
@@ -8073,6 +8138,7 @@
         }
       ],
       "manaCost": "{X}{U}{U}",
+      "mciNumber": "65",
       "multiverseid": 426767,
       "name": "Pull from Tomorrow",
       "number": "65",
@@ -8180,6 +8246,7 @@
         }
       ],
       "manaCost": "{5}{U}",
+      "mciNumber": "66",
       "multiverseid": 426768,
       "name": "River Serpent",
       "number": "66",
@@ -8298,6 +8365,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "67",
       "multiverseid": 426769,
       "name": "Sacred Excavation",
       "number": "67",
@@ -8411,6 +8479,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "68",
       "multiverseid": 426770,
       "name": "Scribe of the Mindful",
       "number": "68",
@@ -8524,6 +8593,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "69",
       "multiverseid": 426771,
       "name": "Seeker of Insight",
       "number": "69",
@@ -8643,6 +8713,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "70",
       "multiverseid": 426772,
       "name": "Shimmerscale Drake",
       "number": "70",
@@ -8755,6 +8826,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "71",
       "multiverseid": 426773,
       "name": "Slither Blade",
       "number": "71",
@@ -8868,6 +8940,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "72",
       "multiverseid": 426774,
       "name": "Tah-Crop Skirmisher",
       "number": "72",
@@ -9002,6 +9075,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "73",
       "multiverseid": 426775,
       "name": "Trial of Knowledge",
       "number": "73",
@@ -9114,6 +9188,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "74",
       "multiverseid": 426776,
       "name": "Vizier of Many Faces",
       "number": "74",
@@ -9281,6 +9356,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "75",
       "multiverseid": 426777,
       "name": "Vizier of Tumbling Sands",
       "number": "75",
@@ -9408,6 +9484,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "76",
       "multiverseid": 426778,
       "name": "Winds of Rebuke",
       "number": "76",
@@ -9521,6 +9598,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "77",
       "multiverseid": 426779,
       "name": "Zenith Seeker",
       "number": "77",
@@ -9655,6 +9733,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "78",
       "multiverseid": 426780,
       "name": "Archfiend of Ifnir",
       "number": "78",
@@ -9785,6 +9864,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "79",
       "multiverseid": 426781,
       "name": "Baleful Ammit",
       "number": "79",
@@ -9898,6 +9978,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "80",
       "multiverseid": 426782,
       "name": "Blighted Bat",
       "number": "80",
@@ -10011,6 +10092,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "81",
       "multiverseid": 426783,
       "name": "Bone Picker",
       "number": "81",
@@ -10136,6 +10218,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "82",
       "multiverseid": 426784,
       "name": "Bontu the Glorified",
       "number": "82",
@@ -10269,6 +10352,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "83",
       "multiverseid": 426785,
       "name": "Cartouche of Ambition",
       "number": "83",
@@ -10398,6 +10482,7 @@
         }
       ],
       "manaCost": "{5}{B}{B}",
+      "mciNumber": "84",
       "multiverseid": 426786,
       "name": "Cruel Reality",
       "number": "84",
@@ -10524,6 +10609,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "85",
       "multiverseid": 426787,
       "name": "Cursed Minotaur",
       "number": "85",
@@ -10636,6 +10722,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "86",
       "multiverseid": 426788,
       "name": "Dispossess",
       "number": "86",
@@ -10743,6 +10830,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "87",
       "multiverseid": 426789,
       "name": "Doomed Dissenter",
       "number": "87",
@@ -10854,6 +10942,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "88",
       "multiverseid": 426790,
       "name": "Dread Wanderer",
       "number": "88",
@@ -10967,6 +11056,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "89",
       "multiverseid": 426791,
       "name": "Dune Beetle",
       "number": "89",
@@ -11077,6 +11167,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "90",
       "multiverseid": 426792,
       "name": "Faith of the Devoted",
       "number": "90",
@@ -11194,6 +11285,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "91",
       "multiverseid": 426793,
       "name": "Festering Mummy",
       "number": "91",
@@ -11306,6 +11398,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "92",
       "multiverseid": 426794,
       "name": "Final Reward",
       "number": "92",
@@ -11421,6 +11514,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "93",
       "multiverseid": 426795,
       "name": "Gravedigger",
       "number": "93",
@@ -11558,6 +11652,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "94",
       "multiverseid": 426796,
       "name": "Grim Strider",
       "number": "94",
@@ -11680,6 +11775,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "95",
       "multiverseid": 426797,
       "name": "Horror of the Broken Lands",
       "number": "95",
@@ -11810,6 +11906,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "96",
       "multiverseid": 426798,
       "name": "Lay Bare the Heart",
       "number": "96",
@@ -11917,6 +12014,7 @@
       ],
       "loyalty": 5,
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "97",
       "multiverseid": 426799,
       "name": "Liliana, Death's Majesty",
       "number": "97",
@@ -12033,6 +12131,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "98",
       "multiverseid": 426800,
       "name": "Liliana's Mastery",
       "number": "98",
@@ -12140,6 +12239,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "99",
       "multiverseid": 426801,
       "name": "Lord of the Accursed",
       "number": "99",
@@ -12252,6 +12352,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "100",
       "multiverseid": 426802,
       "name": "Miasmic Mummy",
       "number": "100",
@@ -12371,6 +12472,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "101",
       "multiverseid": 426803,
       "name": "Nest of Scarabs",
       "number": "101",
@@ -12488,6 +12590,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "102",
       "multiverseid": 426804,
       "name": "Painful Lesson",
       "number": "102",
@@ -12594,6 +12697,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "103",
       "multiverseid": 426805,
       "name": "Pitiless Vizier",
       "number": "103",
@@ -12724,6 +12828,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "104",
       "multiverseid": 426806,
       "name": "Plague Belcher",
       "number": "104",
@@ -12847,6 +12952,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "105",
       "multiverseid": 426807,
       "name": "Ruthless Sniper",
       "number": "105",
@@ -12982,6 +13088,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "106",
       "multiverseid": 426808,
       "name": "Scarab Feast",
       "number": "106",
@@ -13089,6 +13196,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "107",
       "multiverseid": 426809,
       "name": "Shadow of the Grave",
       "number": "107",
@@ -13205,6 +13313,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "108",
       "multiverseid": 426810,
       "name": "Soulstinger",
       "number": "108",
@@ -13324,6 +13433,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "109",
       "multiverseid": 426811,
       "name": "Splendid Agony",
       "number": "109",
@@ -13440,6 +13550,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "110",
       "multiverseid": 426812,
       "name": "Stir the Sands",
       "number": "110",
@@ -13561,6 +13672,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "111",
       "multiverseid": 426813,
       "name": "Supernatural Stamina",
       "number": "111",
@@ -13674,6 +13786,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "112",
       "multiverseid": 426814,
       "name": "Trespasser's Curse",
       "number": "112",
@@ -13790,6 +13903,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "113",
       "multiverseid": 426815,
       "name": "Trial of Ambition",
       "number": "113",
@@ -13907,6 +14021,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "114",
       "multiverseid": 426816,
       "name": "Unburden",
       "number": "114",
@@ -14021,6 +14136,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "115",
       "multiverseid": 426817,
       "name": "Wander in Death",
       "number": "115",
@@ -14128,6 +14244,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "116",
       "multiverseid": 426818,
       "name": "Wasteland Scorpion",
       "number": "116",
@@ -14240,6 +14357,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "117",
       "multiverseid": 426819,
       "name": "Ahn-Crop Crasher",
       "number": "117",
@@ -14374,6 +14492,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "118",
       "multiverseid": 426820,
       "name": "Battlefield Scavenger",
       "number": "118",
@@ -14509,6 +14628,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "119",
       "multiverseid": 426821,
       "name": "Blazing Volley",
       "number": "119",
@@ -14616,6 +14736,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "120",
       "multiverseid": 426822,
       "name": "Bloodlust Inciter",
       "number": "120",
@@ -14729,6 +14850,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "121",
       "multiverseid": 426823,
       "name": "Bloodrage Brawler",
       "number": "121",
@@ -14852,6 +14974,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "122",
       "multiverseid": 426824,
       "name": "Brute Strength",
       "number": "122",
@@ -14960,6 +15083,7 @@
         }
       ],
       "manaCost": "{X}{R}",
+      "mciNumber": "123",
       "multiverseid": 426825,
       "name": "By Force",
       "number": "123",
@@ -15074,6 +15198,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "124",
       "multiverseid": 426826,
       "name": "Cartouche of Zeal",
       "number": "124",
@@ -15198,6 +15323,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "125",
       "multiverseid": 426827,
       "name": "Combat Celebrant",
       "number": "125",
@@ -15349,6 +15475,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "126",
       "multiverseid": 426828,
       "name": "Consuming Fervor",
       "number": "126",
@@ -15468,6 +15595,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "127",
       "multiverseid": 426829,
       "name": "Deem Worthy",
       "number": "127",
@@ -15589,6 +15717,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "128",
       "multiverseid": 426830,
       "name": "Desert Cerodon",
       "number": "128",
@@ -15701,6 +15830,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "129",
       "multiverseid": 426831,
       "name": "Electrify",
       "number": "129",
@@ -15808,6 +15938,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "130",
       "multiverseid": 426832,
       "name": "Emberhorn Minotaur",
       "number": "130",
@@ -15939,6 +16070,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "131",
       "multiverseid": 426833,
       "name": "Flameblade Adept",
       "number": "131",
@@ -16078,6 +16210,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "132",
       "multiverseid": 426834,
       "name": "Fling",
       "number": "132",
@@ -16210,6 +16343,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "133",
       "multiverseid": 426835,
       "name": "Glorious End",
       "number": "133",
@@ -16339,6 +16473,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "134",
       "multiverseid": 426836,
       "name": "Glorybringer",
       "number": "134",
@@ -16473,6 +16608,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "135",
       "multiverseid": 426837,
       "name": "Harsh Mentor",
       "number": "135",
@@ -16599,6 +16735,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "136",
       "multiverseid": 426838,
       "name": "Hazoret the Fervent",
       "number": "136",
@@ -16725,6 +16862,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "137",
       "multiverseid": 426839,
       "name": "Hazoret's Favor",
       "number": "137",
@@ -16831,6 +16969,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "138",
       "multiverseid": 426840,
       "name": "Heart-Piercer Manticore",
       "number": "138",
@@ -16985,6 +17124,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "139",
       "multiverseid": 426841,
       "name": "Hyena Pack",
       "number": "139",
@@ -17095,6 +17235,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "140",
       "multiverseid": 426842,
       "name": "Limits of Solidarity",
       "number": "140",
@@ -17210,6 +17351,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "141",
       "multiverseid": 426843,
       "name": "Magma Spray",
       "number": "141",
@@ -17327,6 +17469,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "142",
       "multiverseid": 426844,
       "name": "Manticore of the Gauntlet",
       "number": "142",
@@ -17449,6 +17592,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "143",
       "multiverseid": 426845,
       "name": "Minotaur Sureshot",
       "number": "143",
@@ -17562,6 +17706,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "144",
       "multiverseid": 426846,
       "name": "Nef-Crop Entangler",
       "number": "144",
@@ -17693,6 +17838,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "145",
       "multiverseid": 426847,
       "name": "Nimble-Blade Khenra",
       "number": "145",
@@ -17806,6 +17952,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "146",
       "multiverseid": 426848,
       "name": "Pathmaker Initiate",
       "number": "146",
@@ -17925,6 +18072,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "147",
       "multiverseid": 426849,
       "name": "Pursue Glory",
       "number": "147",
@@ -18031,6 +18179,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "148",
       "multiverseid": 426850,
       "name": "Soul-Scar Mage",
       "number": "148",
@@ -18162,6 +18311,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "149",
       "multiverseid": 426851,
       "name": "Sweltering Suns",
       "number": "149",
@@ -18269,6 +18419,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "150",
       "multiverseid": 426852,
       "name": "Thresher Lizard",
       "number": "150",
@@ -18395,6 +18546,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "151",
       "multiverseid": 426853,
       "name": "Tormenting Voice",
       "number": "151",
@@ -18512,6 +18664,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "152",
       "multiverseid": 426854,
       "name": "Trial of Zeal",
       "number": "152",
@@ -18625,6 +18778,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "153",
       "multiverseid": 426855,
       "name": "Trueheart Twins",
       "number": "153",
@@ -18760,6 +18914,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "154",
       "multiverseid": 426856,
       "name": "Violent Impact",
       "number": "154",
@@ -18867,6 +19022,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "155",
       "multiverseid": 426857,
       "name": "Warfire Javelineer",
       "number": "155",
@@ -18986,6 +19142,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "156",
       "multiverseid": 426858,
       "name": "Benefaction of Rhonas",
       "number": "156",
@@ -19099,6 +19256,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "157",
       "multiverseid": 426859,
       "name": "Bitterblade Warrior",
       "number": "157",
@@ -19229,6 +19387,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "158",
       "multiverseid": 426860,
       "name": "Cartouche of Strength",
       "number": "158",
@@ -19366,6 +19525,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "159",
       "multiverseid": 426861,
       "name": "Champion of Rhonas",
       "number": "159",
@@ -19504,6 +19664,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "160",
       "multiverseid": 426862,
       "name": "Channeler Initiate",
       "number": "160",
@@ -19617,6 +19778,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "161",
       "multiverseid": 426863,
       "name": "Colossapede",
       "number": "161",
@@ -19727,6 +19889,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "162",
       "multiverseid": 426864,
       "name": "Crocodile of the Crossing",
       "number": "162",
@@ -19838,6 +20001,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "163",
       "multiverseid": 426865,
       "name": "Defiant Greatmaw",
       "number": "163",
@@ -19960,6 +20124,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "164",
       "multiverseid": 426866,
       "name": "Dissenter's Deliverance",
       "number": "164",
@@ -20067,6 +20232,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "165",
       "multiverseid": 426867,
       "name": "Exemplar of Strength",
       "number": "165",
@@ -20186,6 +20352,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "166",
       "multiverseid": 426868,
       "name": "Giant Spider",
       "number": "166",
@@ -20323,6 +20490,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "167",
       "multiverseid": 426869,
       "name": "Gift of Paradise",
       "number": "167",
@@ -20433,6 +20601,7 @@
         }
       ],
       "manaCost": "{5}{G}{G}",
+      "mciNumber": "168",
       "multiverseid": 426870,
       "name": "Greater Sandwurm",
       "number": "168",
@@ -20551,6 +20720,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "169",
       "multiverseid": 426871,
       "name": "Hapatra's Mark",
       "number": "169",
@@ -20664,6 +20834,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "170",
       "multiverseid": 426872,
       "name": "Harvest Season",
       "number": "170",
@@ -20771,6 +20942,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "171",
       "multiverseid": 426873,
       "name": "Haze of Pollen",
       "number": "171",
@@ -20878,6 +21050,7 @@
         }
       ],
       "manaCost": "{5}{G}",
+      "mciNumber": "172",
       "multiverseid": 426874,
       "name": "Honored Hydra",
       "number": "172",
@@ -21013,6 +21186,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "173",
       "multiverseid": 426875,
       "name": "Hooded Brawler",
       "number": "173",
@@ -21144,6 +21318,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "174",
       "multiverseid": 426876,
       "name": "Initiate's Companion",
       "number": "174",
@@ -21256,6 +21431,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "175",
       "multiverseid": 426877,
       "name": "Manglehorn",
       "number": "175",
@@ -21374,6 +21550,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "176",
       "multiverseid": 426878,
       "name": "Naga Vitalist",
       "number": "176",
@@ -21505,6 +21682,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "177",
       "multiverseid": 426879,
       "name": "Oashra Cultivator",
       "number": "177",
@@ -21618,6 +21796,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "178",
       "multiverseid": 426880,
       "name": "Ornery Kudu",
       "number": "178",
@@ -21730,6 +21909,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "179",
       "multiverseid": 426881,
       "name": "Pouncing Cheetah",
       "number": "179",
@@ -21842,6 +22022,7 @@
         }
       ],
       "manaCost": "{1}{G}{G}",
+      "mciNumber": "180",
       "multiverseid": 426882,
       "name": "Prowling Serpopard",
       "number": "180",
@@ -21961,6 +22142,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "181",
       "multiverseid": 426883,
       "name": "Quarry Hauler",
       "number": "181",
@@ -22078,6 +22260,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "182",
       "multiverseid": 426884,
       "name": "Rhonas the Indomitable",
       "number": "182",
@@ -22204,6 +22387,7 @@
         }
       ],
       "manaCost": "{6}{G}{G}",
+      "mciNumber": "183",
       "multiverseid": 426885,
       "name": "Sandwurm Convergence",
       "number": "183",
@@ -22317,6 +22501,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "184",
       "multiverseid": 426886,
       "name": "Scaled Behemoth",
       "number": "184",
@@ -22429,6 +22614,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "185",
       "multiverseid": 426887,
       "name": "Shed Weakness",
       "number": "185",
@@ -22535,6 +22721,7 @@
         }
       ],
       "manaCost": "{5}{G}",
+      "mciNumber": "186",
       "multiverseid": 426888,
       "name": "Shefet Monitor",
       "number": "186",
@@ -22661,6 +22848,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "187",
       "multiverseid": 426889,
       "name": "Sixth Sense",
       "number": "187",
@@ -22775,6 +22963,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "188",
       "multiverseid": 426890,
       "name": "Spidery Grasp",
       "number": "188",
@@ -22889,6 +23078,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "189",
       "multiverseid": 426891,
       "name": "Stinging Shot",
       "number": "189",
@@ -22996,6 +23186,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "190",
       "multiverseid": 426892,
       "name": "Synchronized Strike",
       "number": "190",
@@ -23121,6 +23312,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "191",
       "multiverseid": 426893,
       "name": "Trial of Strength",
       "number": "191",
@@ -23233,6 +23425,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "192",
       "multiverseid": 426894,
       "name": "Vizier of the Menagerie",
       "number": "192",
@@ -23372,6 +23565,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "193",
       "multiverseid": 426895,
       "name": "Watchful Naga",
       "number": "193",
@@ -23505,6 +23699,7 @@
         }
       ],
       "manaCost": "{2}{G}{W}",
+      "mciNumber": "194",
       "multiverseid": 426896,
       "name": "Ahn-Crop Champion",
       "number": "194",
@@ -23649,6 +23844,7 @@
         }
       ],
       "manaCost": "{2}{W}{U}",
+      "mciNumber": "195",
       "multiverseid": 426897,
       "name": "Aven Wind Guide",
       "number": "195",
@@ -23785,6 +23981,7 @@
         }
       ],
       "manaCost": "{2}{G}{U}",
+      "mciNumber": "196",
       "multiverseid": 426898,
       "name": "Bounty of the Luxa",
       "number": "196",
@@ -23903,6 +24100,7 @@
         }
       ],
       "manaCost": "{3}{B}{G}",
+      "mciNumber": "197",
       "multiverseid": 426899,
       "name": "Decimator Beetle",
       "number": "197",
@@ -24027,6 +24225,7 @@
         }
       ],
       "manaCost": "{1}{U}{R}",
+      "mciNumber": "198",
       "multiverseid": 426900,
       "name": "Enigma Drake",
       "number": "198",
@@ -24151,6 +24350,7 @@
         }
       ],
       "manaCost": "{B}{G}",
+      "mciNumber": "199",
       "multiverseid": 426901,
       "name": "Hapatra, Vizier of Poisons",
       "number": "199",
@@ -24283,6 +24483,7 @@
         }
       ],
       "manaCost": "{R}{W}",
+      "mciNumber": "200",
       "multiverseid": 426902,
       "name": "Honored Crop-Captain",
       "number": "200",
@@ -24398,6 +24599,7 @@
         }
       ],
       "manaCost": "{1}{R}{G}",
+      "mciNumber": "201",
       "multiverseid": 426903,
       "name": "Khenra Charioteer",
       "number": "201",
@@ -24513,6 +24715,7 @@
         }
       ],
       "manaCost": "{2}{B}{R}",
+      "mciNumber": "202",
       "multiverseid": 426904,
       "name": "Merciless Javelineer",
       "number": "202",
@@ -24637,6 +24840,7 @@
         }
       ],
       "manaCost": "{1}{B}{R}",
+      "mciNumber": "203",
       "multiverseid": 426905,
       "name": "Neheb, the Worthy",
       "number": "203",
@@ -24765,6 +24969,7 @@
       ],
       "loyalty": null,
       "manaCost": "{X}{G}{U}",
+      "mciNumber": "204",
       "multiverseid": 426906,
       "name": "Nissa, Steward of Elements",
       "number": "204",
@@ -24900,6 +25105,7 @@
         }
       ],
       "manaCost": "{3}{R}{G}",
+      "mciNumber": "205",
       "multiverseid": 426907,
       "name": "Samut, Voice of Dissent",
       "number": "205",
@@ -25018,6 +25224,7 @@
         }
       ],
       "manaCost": "{U}{B}",
+      "mciNumber": "206",
       "multiverseid": 426908,
       "name": "Shadowstorm Vizier",
       "number": "206",
@@ -25150,6 +25357,7 @@
         }
       ],
       "manaCost": "{W}{U}",
+      "mciNumber": "207",
       "multiverseid": 426909,
       "name": "Temmet, Vizier of Naktamun",
       "number": "207",
@@ -25290,6 +25498,7 @@
         }
       ],
       "manaCost": "{W}{B}",
+      "mciNumber": "208",
       "multiverseid": 426910,
       "name": "Wayward Servant",
       "number": "208",
@@ -25414,6 +25623,7 @@
         }
       ],
       "manaCost": "{1}{G}{U}",
+      "mciNumber": "209",
       "multiverseid": 426911,
       "name": "Weaver of Currents",
       "number": "209",
@@ -29613,6 +29823,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "225",
       "multiverseid": 426927,
       "name": "Bontu's Monument",
       "number": "225",
@@ -29738,6 +29949,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "226",
       "multiverseid": 426928,
       "name": "Edifice of Authority",
       "number": "226",
@@ -29853,6 +30065,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "227",
       "multiverseid": 426929,
       "name": "Embalmer's Tools",
       "number": "227",
@@ -29967,6 +30180,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "228",
       "multiverseid": 426930,
       "name": "Gate to the Afterlife",
       "number": "228",
@@ -30078,6 +30292,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "229",
       "multiverseid": 426931,
       "name": "Hazoret's Monument",
       "number": "229",
@@ -30200,6 +30415,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "230",
       "multiverseid": 426932,
       "name": "Honed Khopesh",
       "number": "230",
@@ -30304,6 +30520,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "231",
       "multiverseid": 426933,
       "name": "Kefnet's Monument",
       "number": "231",
@@ -30430,6 +30647,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "232",
       "multiverseid": 426934,
       "name": "Luxa River Shrine",
       "number": "232",
@@ -30531,6 +30749,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "233",
       "multiverseid": 426935,
       "name": "Oketra's Monument",
       "number": "233",
@@ -30652,6 +30871,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "234",
       "multiverseid": 426936,
       "name": "Oracle's Vault",
       "number": "234",
@@ -30787,6 +31007,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "235",
       "multiverseid": 426937,
       "name": "Pyramid of the Pantheon",
       "number": "235",
@@ -30888,6 +31109,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "236",
       "multiverseid": 426938,
       "name": "Rhonas's Monument",
       "number": "236",
@@ -31014,6 +31236,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "237",
       "multiverseid": 426939,
       "name": "Throne of the God-Pharaoh",
       "number": "237",
@@ -31132,6 +31355,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "238",
       "multiverseid": 426940,
       "name": "Watchers of the Dead",
       "number": "238",
@@ -31250,6 +31474,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "239",
       "multiverseid": 426941,
       "name": "Canyon Slough",
       "number": "239",
@@ -31353,6 +31578,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "240",
       "multiverseid": 426942,
       "name": "Cascading Cataracts",
       "number": "240",
@@ -31452,6 +31678,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "241",
       "multiverseid": 426943,
       "name": "Cradle of the Accursed",
       "number": "241",
@@ -31576,6 +31803,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "242",
       "multiverseid": 426944,
       "name": "Evolving Wilds",
       "number": "242",
@@ -31700,6 +31928,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "243",
       "multiverseid": 426945,
       "name": "Fetid Pools",
       "number": "243",
@@ -31802,6 +32031,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "244",
       "multiverseid": 426946,
       "name": "Grasping Dunes",
       "number": "244",
@@ -31913,6 +32143,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "245",
       "multiverseid": 426947,
       "name": "Irrigated Farmland",
       "number": "245",
@@ -32016,6 +32247,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "246",
       "multiverseid": 426948,
       "name": "Painted Bluffs",
       "number": "246",
@@ -32127,6 +32359,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "247",
       "multiverseid": 426949,
       "name": "Scattered Groves",
       "number": "247",
@@ -32233,6 +32466,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "248",
       "multiverseid": 426950,
       "name": "Sheltered Thicket",
       "number": "248",
@@ -32336,6 +32570,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "249",
       "multiverseid": 426951,
       "name": "Sunscorched Desert",
       "number": "249",
@@ -40100,6 +40335,7 @@
       ],
       "loyalty": 5,
       "manaCost": "{4}{W}",
+      "mciNumber": "270",
       "multiverseid": 429662,
       "name": "Gideon, Martial Paragon",
       "number": "270",
@@ -40236,6 +40472,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "271",
       "multiverseid": 429663,
       "name": "Companion of the Trials",
       "number": "271",
@@ -40354,6 +40591,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "272",
       "multiverseid": 429664,
       "name": "Gideon's Resolve",
       "number": "272",
@@ -40461,6 +40699,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "273",
       "multiverseid": 429665,
       "name": "Graceful Cat",
       "number": "273",
@@ -40577,6 +40816,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "274",
       "multiverseid": 429666,
       "name": "Stone Quarry",
       "number": "274",
@@ -40686,6 +40926,7 @@
       ],
       "loyalty": 5,
       "manaCost": "{5}{B}{B}",
+      "mciNumber": "275",
       "multiverseid": 429667,
       "name": "Liliana, Death Wielder",
       "number": "275",
@@ -40796,6 +41037,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "276",
       "multiverseid": 429668,
       "name": "Desiccated Naga",
       "number": "276",
@@ -40908,6 +41150,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "277",
       "multiverseid": 429669,
       "name": "Liliana's Influence",
       "number": "277",
@@ -41015,6 +41258,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "278",
       "multiverseid": 429670,
       "name": "Tattered Mummy",
       "number": "278",
@@ -41138,6 +41382,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "279",
       "multiverseid": 429671,
       "name": "Foul Orchard",
       "number": "279",
@@ -41246,6 +41491,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "280",
       "multiverseid": 429672,
       "name": "Cinder Barrens",
       "number": "280",
@@ -41355,6 +41601,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "281",
       "multiverseid": 429673,
       "name": "Forsaken Sanctuary",
       "number": "281",
@@ -41463,6 +41710,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "282",
       "multiverseid": 429674,
       "name": "Highland Lake",
       "number": "282",
@@ -41571,6 +41819,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "283",
       "multiverseid": 429675,
       "name": "Meandering River",
       "number": "283",
@@ -41683,6 +41932,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "284",
       "multiverseid": 429676,
       "name": "Submerged Boneyard",
       "number": "284",
@@ -41792,6 +42042,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "285",
       "multiverseid": 429677,
       "name": "Timber Gorge",
       "number": "285",
@@ -41904,6 +42155,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "286",
       "multiverseid": 429678,
       "name": "Tranquil Expanse",
       "number": "286",
@@ -42017,6 +42269,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "287",
       "multiverseid": 429679,
       "name": "Woodland Stream",
       "number": "287",

--- a/json/ATH.json
+++ b/json/ATH.json
@@ -2,68 +2,48 @@
   "name": "Anthologies",
   "code": "ATH",
   "magicCardsInfoCode": "at",
+  "isMCISet": true,
   "releaseDate": "1998-11-01",
   "border": "white",
   "type": "box",
+  "mkm_name": "Anthologies",
+  "mkm_id": 75,
   "cards": [
     {
-      "artist": "Ruth Thompson",
-      "cmc": 3,
-      "flavor": "\"A fine example of the rewards of artifice: a thoroughly obedient steed with wings of Soldevi steel.\"\n—Arcum Dagsson,\nSoldevi Machinist",
-      "id": "ba87156e255008b617bdf0224b114d96932f2d41",
-      "imageName": "aesthir glider",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ice Age Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{3}",
-      "name": "Aesthir Glider",
-      "originalText": "Flying\nAesthir Glider cannot block.",
-      "originalType": "Artifact Creature",
-      "power": "2",
-      "printings": [
-        "ALL",
-        "ATH",
-        "ME4"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Bird"
-      ],
-      "text": "Flying\nAesthir Glider can't block.",
-      "toughness": "1",
-      "type": "Artifact Creature — Bird",
-      "types": [
-        "Artifact",
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Jesper Myrfors",
+      "artist": "Mark Tedin",
       "cmc": 4,
-      "colorIdentity": [
-        "W"
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "妮维亚洛之碟"
+        },
+        {
+          "language": "French",
+          "name": "Disque de Nevinyrral"
+        },
+        {
+          "language": "German",
+          "name": "Nevinyrrals Wunderscheibe"
+        },
+        {
+          "language": "Italian",
+          "name": "Disco di Nevinyrral"
+        },
+        {
+          "language": "Japanese",
+          "name": "ネビニラルの円盤"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Disco de Nevinyrral"
+        },
+        {
+          "language": "Spanish",
+          "name": "Disco de Nevinyrral"
+        }
       ],
-      "colors": [
-        "White"
-      ],
-      "id": "6a29a2efea9e63ceed0dc497a14b012fdccda778",
-      "imageName": "armageddon",
+      "id": "b971d3ee149c95f17447e14a463ad1be77296679",
+      "imageName": "nevinyrral's disk",
       "layout": "normal",
       "legalities": [
         {
@@ -79,10 +59,10 @@
           "legality": "Legal"
         }
       ],
-      "manaCost": "{3}{W}",
-      "name": "Armageddon",
-      "originalText": "Destroy all lands.",
-      "originalType": "Sorcery",
+      "manaCost": "{4}",
+      "mciNumber": "1",
+      "name": "Nevinyrral's Disk",
+      "number": "1",
       "printings": [
         "LEA",
         "LEB",
@@ -92,36 +72,82 @@
         "3ED",
         "4ED",
         "5ED",
-        "POR",
-        "pJGP",
-        "PO2",
         "ATH",
-        "6ED",
-        "S99",
         "MED",
-        "ME4",
+        "V10",
+        "C13",
         "VMA",
-        "V14"
+        "C14",
+        "EMA",
+        "C16"
       ],
       "rarity": "Special",
-      "text": "Destroy all lands.",
-      "type": "Sorcery",
+      "rulings": [
+        {
+          "date": "2016-06-08",
+          "text": "You don't sacrifice Nevinyrral's Disk to activate its ability. It's destroyed as part of the ability's resolution if it's still on the battlefield. If an effect gives Nevinyrral's Disk indestructible or regenerates it, it stays on the battlefield."
+        }
+      ],
+      "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
+      "type": "Artifact",
       "types": [
-        "Sorcery"
+        "Artifact"
       ]
     },
     {
-      "artist": "Andrew Robinson",
-      "cmc": 2,
+      "artist": "Jesper Myrfors",
+      "cmc": 3,
       "colorIdentity": [
-        "W"
+        "R"
       ],
       "colors": [
-        "White"
+        "Red"
       ],
-      "flavor": "Asked how it survived a run-in with a bog imp, the pegasus just shook its mane and burped.",
-      "id": "067eae77cb14bef5932842ee6e39fdcb6671fa0e",
-      "imageName": "armored pegasus",
+      "flavor": "To be king, Numsgil did in Blog, who did in Unkful, who did in Viddle, who did in Loll, who did in Alrok... .",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "精灵王"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "鬼怪王"
+        },
+        {
+          "language": "French",
+          "name": "Roi des gobelins"
+        },
+        {
+          "language": "German",
+          "name": "Goblinkönig"
+        },
+        {
+          "language": "Italian",
+          "name": "Re dei Goblin"
+        },
+        {
+          "language": "Japanese",
+          "name": "ゴブリンの王"
+        },
+        {
+          "language": "Korean",
+          "name": ""
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Rei dos Goblins"
+        },
+        {
+          "language": "Russian",
+          "name": "Король Гоблинов"
+        },
+        {
+          "language": "Spanish",
+          "name": "Rey trasgo"
+        }
+      ],
+      "id": "e387619fa70309c98dfc504cad9a5d3fa6eee50c",
+      "imageName": "goblin king",
       "layout": "normal",
       "legalities": [
         {
@@ -133,7 +159,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Tempest Block",
+          "format": "Modern",
           "legality": "Legal"
         },
         {
@@ -141,44 +167,170 @@
           "legality": "Legal"
         }
       ],
-      "manaCost": "{1}{W}",
-      "name": "Armored Pegasus",
-      "originalText": "Flying",
-      "originalType": "Creature — Pegasus",
-      "power": "1",
+      "manaCost": "{1}{R}{R}",
+      "mciNumber": "2",
+      "name": "Goblin King",
+      "number": "2",
+      "originalText": "All goblins get +1/+1 and gain mountainwalk. (If defending player controls a mountain, those creatures are unblockable.)",
+      "originalType": "Summon — Lord",
+      "power": "2",
       "printings": [
-        "POR",
-        "pPOD",
-        "TMP",
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "5ED",
         "ATH",
         "6ED",
-        "BRB",
-        "S00",
-        "TPR"
+        "7ED",
+        "8ED",
+        "9ED",
+        "10E"
       ],
       "rarity": "Special",
-      "subtypes": [
-        "Pegasus"
+      "rulings": [
+        {
+          "date": "2005-08-01",
+          "text": "Goblin King now has the Goblin creature type and its ability has been reworded to affect *other* Goblins. This means that if two Goblin Kings are on the battlefield, each gives the other a bonus."
+        }
       ],
-      "text": "Flying",
+      "subtypes": [
+        "Goblin"
+      ],
+      "text": "Other Goblin creatures get +1/+1 and have mountainwalk. (They can't be blocked as long as defending player controls a Mountain.)",
       "toughness": "2",
-      "type": "Creature — Pegasus",
+      "type": "Creature — Goblin",
       "types": [
         "Creature"
       ]
     },
     {
-      "artist": "Zina Saunders",
+      "artist": "Dan Frazier",
       "cmc": 3,
       "colorIdentity": [
-        "W"
+        "R"
       ],
       "colors": [
-        "White"
+        "Red"
       ],
-      "flavor": "\"We called them ‘armored lightning.'\"\n—Gerrard of the Weatherlight",
-      "id": "5955512dfffdfcf6743389f3b8c6f3d5603ec753",
-      "imageName": "benalish knight",
+      "flavor": "\"Goblins bred underground, their numbers hidden from the enemy until it was too late.\"\n—Sarpadian Empires, vol. IV",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Terriers de gobelins"
+        },
+        {
+          "language": "German",
+          "name": "Goblinbaracken"
+        },
+        {
+          "language": "Italian",
+          "name": "Asilo dei Goblin"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Viveiro de Goblins"
+        },
+        {
+          "language": "Spanish",
+          "name": "Barracones trasgos"
+        }
+      ],
+      "id": "408a12f3ae6f15e837d0104b25066d502ab9f51d",
+      "imageName": "goblin warrens",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{2}{R}",
+      "mciNumber": "3",
+      "name": "Goblin Warrens",
+      "number": "3",
+      "originalText": "{2}{R}, Sacrifice two Goblins: Put three Goblin tokens into play. Treat these tokens as 1/1 red creatures.",
+      "printings": [
+        "FEM",
+        "5ED",
+        "ATH",
+        "6ED",
+        "ME4"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2004-10-04",
+          "text": "The token Goblins can be sacrificed to the Warrens to generate new Goblins."
+        }
+      ],
+      "text": "{2}{R}, Sacrifice two Goblins: Create three 1/1 red Goblin creature tokens.",
+      "type": "Enchantment",
+      "types": [
+        "Enchantment"
+      ]
+    },
+    {
+      "artist": "Janine Johnston",
+      "cmc": 6,
+      "colorIdentity": [
+        "R"
+      ],
+      "colors": [
+        "Red"
+      ],
+      "flavor": "Speed and fire are always a deadly combination.",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "火山龙"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "火山龍"
+        },
+        {
+          "language": "French",
+          "name": "Dragon des volcans"
+        },
+        {
+          "language": "German",
+          "name": "Vulkandrache"
+        },
+        {
+          "language": "Italian",
+          "name": "Drago Vulcanico"
+        },
+        {
+          "language": "Japanese",
+          "name": "火山のドラゴン"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Dragão Vulcânico"
+        },
+        {
+          "language": "Russian",
+          "name": "Вулканический Дракон"
+        },
+        {
+          "language": "Spanish",
+          "name": "Dragón volcánico"
+        }
+      ],
+      "id": "e14234e2aaa3c887f9a783ab993fb2468e7e42ab",
+      "imageName": "volcanic dragon",
       "layout": "normal",
       "legalities": [
         {
@@ -202,24 +354,147 @@
           "legality": "Legal"
         }
       ],
-      "manaCost": "{2}{W}",
-      "name": "Benalish Knight",
-      "originalText": "First strike\nYou may play Benalish Knight any time you could play an instant.",
-      "originalType": "Summon — Knight",
-      "power": "2",
+      "manaCost": "{4}{R}{R}",
+      "mciNumber": "4",
+      "name": "Volcanic Dragon",
+      "number": "4",
+      "originalText": "Flying\nVolcanic Dragon is unaffected by summoning sickness.",
+      "power": "4",
       "printings": [
-        "WTH",
+        "MIR",
+        "POR",
         "ATH",
-        "10E"
+        "6ED",
+        "S99",
+        "M12"
       ],
       "rarity": "Special",
       "subtypes": [
-        "Human",
-        "Knight"
+        "Dragon"
       ],
-      "text": "Flash (You may cast this spell any time you could cast an instant.)\nFirst strike (This creature deals combat damage before creatures without first strike.)",
-      "toughness": "2",
-      "type": "Creature — Human Knight",
+      "text": "Flying\nHaste (This creature can attack and {T} as soon as it comes under your control.)",
+      "toughness": "4",
+      "type": "Creature — Dragon",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Daniel Gelon",
+      "flavor": "Unlike previous conflicts, the war between Urza and Mishra made Dominia itself a casualty of war.",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Mine des morts-terrains"
+        },
+        {
+          "language": "German",
+          "name": "Tagebaumine"
+        },
+        {
+          "language": "Italian",
+          "name": "Miniera a Cielo Aperto"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Mina de Superfície"
+        },
+        {
+          "language": "Spanish",
+          "name": "Cantera"
+        }
+      ],
+      "id": "008fdf3572fc32d718f21af1e75c6d0c7c093298",
+      "imageName": "strip mine",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Banned"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Restricted"
+        }
+      ],
+      "mciNumber": "5",
+      "name": "Strip Mine",
+      "number": "5",
+      "originalText": "{T}: Add one colors mana to your mana pool.\n{T}, Sacrifice Strip Mine: Destroy target land.",
+      "printings": [
+        "ATQ",
+        "4ED",
+        "ATH",
+        "V09",
+        "ME4",
+        "VMA",
+        "EXP"
+      ],
+      "rarity": "Special",
+      "text": "{T}: Add {C} to your mana pool.\n{T}, Sacrifice Strip Mine: Destroy target land.",
+      "type": "Land",
+      "types": [
+        "Land"
+      ]
+    },
+    {
+      "artist": "Sandra Everingham",
+      "cmc": 7,
+      "colorIdentity": [
+        "B",
+        "R"
+      ],
+      "colors": [
+        "Black",
+        "Red"
+      ],
+      "flavor": "\"I do not remember what he said to her. I remember her fiery eyes, fixed upon him for an instant. I remember a flash, and the hot breath of sudden flames made me turn away. When I looked again, Angus was gone.\"\n—A Wayfarer, on meeting Lady Orca",
+      "foreignNames": [
+        {
+          "language": "Italian",
+          "name": "Lady Orca"
+        }
+      ],
+      "id": "a7110b099f792aee1cffde053301bc1f3ec324d8",
+      "imageName": "lady orca",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{5}{B}{R}",
+      "mciNumber": "6",
+      "name": "Lady Orca",
+      "number": "6",
+      "power": "7",
+      "printings": [
+        "LEG",
+        "ATH",
+        "ME3"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Demon"
+      ],
+      "supertypes": [
+        "Legendary"
+      ],
+      "toughness": "4",
+      "type": "Legendary Creature — Demon",
       "types": [
         "Creature"
       ]
@@ -233,7 +508,45 @@
       "colors": [
         "Black"
       ],
-      "flavor": "Battle doesn't need a purpose; the battle is its own purpose. You don't ask why a plague spreads or a field burns. Don't ask why I fight.",
+      "flavor": "\"Battle doesn't need a purpose; the battle is its own purpose. You don't ask why a plague spreads or a field burns. Don't ask why I fight.\"",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "黑骑士"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "黑騎士"
+        },
+        {
+          "language": "French",
+          "name": "Chevalier noir"
+        },
+        {
+          "language": "German",
+          "name": "Schwarzer Ritter"
+        },
+        {
+          "language": "Italian",
+          "name": "Cavaliere Nero"
+        },
+        {
+          "language": "Japanese",
+          "name": "黒騎士"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Cavaleiro Negro"
+        },
+        {
+          "language": "Russian",
+          "name": "Черный Рыцарь"
+        },
+        {
+          "language": "Spanish",
+          "name": "Caballero negro"
+        }
+      ],
       "id": "11cb386458e540534339e0375f3d97fa077c8744",
       "imageName": "black knight",
       "layout": "normal",
@@ -256,9 +569,9 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "7",
       "name": "Black Knight",
-      "originalText": "First strike, protection from white",
-      "originalType": "Summon — Knight",
+      "number": "7",
       "power": "2",
       "printings": [
         "LEA",
@@ -289,13 +602,665 @@
       ]
     },
     {
-      "artist": "Bryon Wackwitz",
+      "artist": "Douglas Shuler",
+      "cmc": 3,
       "colorIdentity": [
-        "G",
-        "W"
+        "B"
       ],
-      "id": "3fdf73405ffac1b00861be1eeafa21996350d325",
-      "imageName": "brushland",
+      "colors": [
+        "Black"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "催眠幽灵"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "催眠幽靈"
+        },
+        {
+          "language": "French",
+          "name": "Spectre hypnotiseur"
+        },
+        {
+          "language": "German",
+          "name": "Hypnotisierendes Gespenst"
+        },
+        {
+          "language": "Italian",
+          "name": "Spettro Ipnotico"
+        },
+        {
+          "language": "Japanese",
+          "name": "惑乱の死霊"
+        },
+        {
+          "language": "Korean",
+          "name": ""
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Espectro Hipnótico"
+        },
+        {
+          "language": "Russian",
+          "name": "Усыпляющий Призрак"
+        },
+        {
+          "language": "Spanish",
+          "name": "Espectro hipnótico"
+        }
+      ],
+      "id": "1f04f7554a1fce3402db711a8a830612955f4b69",
+      "imageName": "hypnotic specter",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{1}{B}{B}",
+      "mciNumber": "8",
+      "name": "Hypnotic Specter",
+      "number": "8",
+      "originalText": "Flying\nWhenever Hypnotic Specter successfully deals damage to an opponent, that player discards a card at random from his or her hand.",
+      "power": "2",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "ATH",
+        "pMPR",
+        "9ED",
+        "10E",
+        "M10"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2008-08-01",
+          "text": "The ability triggers even if the Specter's damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
+        }
+      ],
+      "subtypes": [
+        "Specter"
+      ],
+      "text": "Flying\nWhenever Hypnotic Specter deals damage to an opponent, that player discards a card at random.",
+      "toughness": "2",
+      "type": "Creature — Specter",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Mark Poole",
+      "cmc": 2,
+      "colorIdentity": [
+        "B"
+      ],
+      "colors": [
+        "Black"
+      ],
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Chevalier de Stromgald"
+        },
+        {
+          "language": "German",
+          "name": "Ritter von Stromgald"
+        },
+        {
+          "language": "Italian",
+          "name": "Cavaliere di Stromgald"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Cavaleiro de Stromgald"
+        },
+        {
+          "language": "Spanish",
+          "name": "Caballero de Stromgald"
+        }
+      ],
+      "id": "d92b724d606e999868668c40fe2c33f57266a89a",
+      "imageName": "knight of stromgald",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{B}{B}",
+      "mciNumber": "9",
+      "name": "Knight of Stromgald",
+      "number": "9",
+      "originalText": "Protection from white\n{B}: Knight of Stromgald gains first strike until end of turn.\n{B}{B}: Knight of Stromgald gets +1/+0 until end of turn.",
+      "power": "2",
+      "printings": [
+        "ICE",
+        "5ED",
+        "ATH",
+        "ME2"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Human",
+        "Knight"
+      ],
+      "text": "Protection from white\n{B}: Knight of Stromgald gains first strike until end of turn.\n{B}{B}: Knight of Stromgald gets +1/+0 until end of turn.",
+      "toughness": "1",
+      "type": "Creature — Human Knight",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Christopher Rush",
+      "cmc": 6,
+      "colorIdentity": [
+        "B"
+      ],
+      "colors": [
+        "Black"
+      ],
+      "flavor": "\"Ihsan, the weak. Ihsan, the fallen. Ihsan, the betrayer. He has brought shame to the Serra Paladins where none existed before. May his suffering equal his betrayal.\"\n—Baris, Serra inquisitor",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "L'ombre d'Ihssân"
+        },
+        {
+          "language": "German",
+          "name": "Ihsans Schatten"
+        },
+        {
+          "language": "Italian",
+          "name": "Spettro di Ihsan"
+        },
+        {
+          "language": "Japanese",
+          "name": "イーサンの影"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "A Sombra de Ihsan"
+        },
+        {
+          "language": "Spanish",
+          "name": "Sombra de Ihsan"
+        }
+      ],
+      "id": "379352ea1f63fc4fcc08497c21d5c200ffd84896",
+      "imageName": "ihsan's shade",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{3}{B}{B}{B}",
+      "mciNumber": "10",
+      "name": "Ihsan's Shade",
+      "number": "10",
+      "power": "5",
+      "printings": [
+        "HML",
+        "ATH",
+        "ME2"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Shade",
+        "Knight"
+      ],
+      "supertypes": [
+        "Legendary"
+      ],
+      "text": "Protection from white",
+      "toughness": "5",
+      "type": "Legendary Creature — Shade Knight",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Andi Rusu",
+      "cmc": 1,
+      "colorIdentity": [
+        "R"
+      ],
+      "colors": [
+        "Red"
+      ],
+      "flavor": "\"From up here we can drop rocks and arrows and more rocks!\" \"Uh, yeah boss, but how do we get down?\"",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "鬼怪热气球旅"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "鬼怪熱氣球旅"
+        },
+        {
+          "language": "French",
+          "name": "Aérostiers gobelins"
+        },
+        {
+          "language": "German",
+          "name": "Ballonbrigade der Goblins"
+        },
+        {
+          "language": "Italian",
+          "name": "Brigata Aerostatica dei Goblin"
+        },
+        {
+          "language": "Japanese",
+          "name": "ゴブリン気球部隊"
+        },
+        {
+          "language": "Korean",
+          "name": ""
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Brigada Baloeira Goblin"
+        },
+        {
+          "language": "Russian",
+          "name": "Гоблинский Воздушный Экипаж"
+        },
+        {
+          "language": "Spanish",
+          "name": "Trasgos aeronautas"
+        }
+      ],
+      "id": "12ffb2eecba7e80ea931dab18b7fd3f82026eb3b",
+      "imageName": "goblin balloon brigade",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{R}",
+      "mciNumber": "11",
+      "name": "Goblin Balloon Brigade",
+      "number": "11",
+      "originalText": "{R}: Goblin Balloon Brigade gains flying until end of turn.",
+      "power": "1",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "ATH",
+        "9ED",
+        "M11",
+        "CN2"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2008-08-01",
+          "text": "You can activate the ability repeatedly during a turn. This generally has no additional effect, unless some other effect (like that from Adarkar Windform has caused it to lose flying since the last time the ability resolved."
+        },
+        {
+          "date": "2010-08-15",
+          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade's ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won't change that."
+        }
+      ],
+      "subtypes": [
+        "Goblin",
+        "Warrior"
+      ],
+      "text": "{R}: Goblin Balloon Brigade gains flying until end of turn.",
+      "toughness": "1",
+      "type": "Creature — Goblin Warrior",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Daniel Gelon",
+      "cmc": 4,
+      "colorIdentity": [
+        "R"
+      ],
+      "colors": [
+        "Red"
+      ],
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Mutant gobelin"
+        },
+        {
+          "language": "German",
+          "name": "Goblinmutant"
+        },
+        {
+          "language": "Italian",
+          "name": "Goblin Mutante"
+        },
+        {
+          "language": "Japanese",
+          "name": "ゴブリンの突然変異"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Mutante Goblin"
+        },
+        {
+          "language": "Spanish",
+          "name": "Trasgo mutante"
+        }
+      ],
+      "id": "8b7b7d82d8667d0e0aad3093cb257931ffc4387d",
+      "imageName": "goblin mutant",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{2}{R}{R}",
+      "mciNumber": "12",
+      "name": "Goblin Mutant",
+      "number": "12",
+      "originalText": "Trample\nGoblin Mutant cannot attack if defending player controls an untapped creature with power 3 or more.\nGoblin Mutant cannot block a creature with power 3 or more.",
+      "power": "5",
+      "printings": [
+        "ICE",
+        "ATH",
+        "DKM",
+        "MED"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Goblin",
+        "Mutant"
+      ],
+      "text": "Trample\nGoblin Mutant can't attack if defending player controls an untapped creature with power 3 or greater.\nGoblin Mutant can't block creatures with power 3 or greater.",
+      "toughness": "3",
+      "type": "Creature — Goblin Mutant",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Carl Critchlow",
+      "cmc": 3,
+      "colorIdentity": [
+        "R"
+      ],
+      "colors": [
+        "Red"
+      ],
+      "flavor": "They certainly are.",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Offensive gobeline"
+        },
+        {
+          "language": "German",
+          "name": "Großoffensive"
+        },
+        {
+          "language": "Italian",
+          "name": "Assalto dei Goblin"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Ofensiva de Goblins"
+        },
+        {
+          "language": "Spanish",
+          "name": "Ofensiva trasgo"
+        }
+      ],
+      "id": "0ef641c701e9d1428e945f10d1f5eda37f77f040",
+      "imageName": "goblin offensive",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Urza Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{X}{1}{R}{R}",
+      "mciNumber": "13",
+      "name": "Goblin Offensive",
+      "number": "13",
+      "printings": [
+        "USG",
+        "ATH",
+        "HOP"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2004-10-04",
+          "text": "The tokens are named \"Goblin\" and are of creature type \"Goblin\"."
+        }
+      ],
+      "text": "Create X 1/1 red Goblin creature tokens.",
+      "type": "Sorcery",
+      "types": [
+        "Sorcery"
+      ]
+    },
+    {
+      "artist": "Scott Kirschner",
+      "cmc": 2,
+      "colorIdentity": [
+        "R"
+      ],
+      "colors": [
+        "Red"
+      ],
+      "flavor": "\"Next!\"",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Recruteur gobelin"
+        },
+        {
+          "language": "German",
+          "name": "Goblin-Anwerber"
+        },
+        {
+          "language": "Italian",
+          "name": "Goblin Reclutatore"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Recrutador Goblin"
+        },
+        {
+          "language": "Spanish",
+          "name": "Reclutador trasgo"
+        }
+      ],
+      "id": "6421c4fd9f8fd4cdf4595de928bd14e883f03849",
+      "imageName": "goblin recruiter",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Banned"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{1}{R}",
+      "mciNumber": "14",
+      "name": "Goblin Recruiter",
+      "number": "14",
+      "originalText": "When Goblin Recruiter comes into play, search your library for any number of Goblin cards and reveal them to all players. Shuffle your library, then put the revealed cards on top of it in any order.",
+      "originalType": "Summon — Goblin",
+      "power": "1",
+      "printings": [
+        "VIS",
+        "ATH",
+        "6ED"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2008-04-01",
+          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type \"Summon Goblin\" and \"Summon Goblins\" also count. You can't search for cards that have Goblin in the name but don't have the creature type Goblin."
+        }
+      ],
+      "subtypes": [
+        "Goblin"
+      ],
+      "text": "When Goblin Recruiter enters the battlefield, search your library for any number of Goblin cards and reveal those cards. Shuffle your library, then put them on top of it in any order.",
+      "toughness": "1",
+      "type": "Creature — Goblin",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Daniel Gelon",
+      "cmc": 4,
+      "colorIdentity": [
+        "R"
+      ],
+      "colors": [
+        "Red"
+      ],
+      "flavor": "\"Strength in numbers? Right.\"\n—Ib Halfheart, goblin tactician",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "精灵雪人"
+        },
+        {
+          "language": "French",
+          "name": "Bonhomme de neige gobelin"
+        },
+        {
+          "language": "German",
+          "name": "Goblinschneemann"
+        },
+        {
+          "language": "Italian",
+          "name": "Pupazzo di Neve dei Goblin"
+        },
+        {
+          "language": "Japanese",
+          "name": "ゴブリンの雪だるま"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Boneco de Neve dos Goblins"
+        },
+        {
+          "language": "Russian",
+          "name": "Гоблин Снеговик"
+        },
+        {
+          "language": "Spanish",
+          "name": "Muñeco de nieve trasgo"
+        }
+      ],
+      "id": "637be9b3ee3cd68ff27ea9d12e9e5377aa6c1737",
+      "imageName": "goblin snowman",
       "layout": "normal",
       "legalities": [
         {
@@ -315,41 +1280,175 @@
           "legality": "Legal"
         },
         {
+          "format": "Time Spiral Block",
+          "legality": "Legal"
+        },
+        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
-      "name": "Brushland",
-      "originalText": "{T}: Add one colorless mana to your mana pool.\n{T}: Add {G} or {W} to your mana pool. Brushland deals 1 damage to you.",
-      "originalType": "Land",
+      "manaCost": "{3}{R}",
+      "mciNumber": "15",
+      "name": "Goblin Snowman",
+      "number": "15",
+      "originalText": "When Goblin Snowman blocks, it does not deal or receive combat damage that turn.\n{T}: Goblin Snowman deals 1 damage to target creature it is blocking.",
+      "power": "1",
       "printings": [
         "ICE",
-        "5ED",
         "ATH",
-        "6ED",
-        "7ED",
-        "9ED",
-        "10E"
+        "TSB"
       ],
       "rarity": "Special",
-      "text": "{T}: Add {C} to your mana pool.\n{T}: Add {G} or {W} to your mana pool. Brushland deals 1 damage to you.",
-      "type": "Land",
+      "subtypes": [
+        "Goblin"
+      ],
+      "text": "Whenever Goblin Snowman blocks, prevent all combat damage that would be dealt to and dealt by it this turn.\n{T}: Goblin Snowman deals 1 damage to target creature it's blocking.",
+      "toughness": "1",
+      "type": "Creature — Goblin",
       "types": [
-        "Land"
+        "Creature"
       ]
     },
     {
-      "artist": "Christopher Rush",
-      "cmc": 2,
+      "artist": "Ron Spencer",
+      "cmc": 6,
       "colorIdentity": [
-        "G"
+        "R"
       ],
       "colors": [
-        "Green"
+        "Red"
       ],
-      "flavor": "\"We know our place in the cycle of life—and it is not as flies.\"\n—Eladamri, Lord of Leaves",
-      "id": "60d4bb538360b746c181725b7b436580de271956",
-      "imageName": "canopy spider",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "驾驭爆焰"
+        },
+        {
+          "language": "French",
+          "name": "Pyrokinésie"
+        },
+        {
+          "language": "German",
+          "name": "Pyrokinese"
+        },
+        {
+          "language": "Italian",
+          "name": "Pirocinesi"
+        },
+        {
+          "language": "Japanese",
+          "name": "紅蓮操作"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Pirocinesia"
+        },
+        {
+          "language": "Spanish",
+          "name": "Piroquinesis"
+        }
+      ],
+      "id": "302233538b6e47d3e35276021a6ff167c7d323a9",
+      "imageName": "pyrokinesis",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{4}{R}{R}",
+      "mciNumber": "16",
+      "name": "Pyrokinesis",
+      "number": "16",
+      "originalText": "You may remove a red card in your hand from the game instead of paying Pyrokinesis's casting cost.\nPyrokinesis deals 4 damage divided any way you choose among any number of target creatures.",
+      "printings": [
+        "ALL",
+        "ATH",
+        "ME2",
+        "DDL",
+        "EMA"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2016-06-08",
+          "text": "The number of targets must be at least one and at most four. Each target must be assigned at least 1 damage."
+        },
+        {
+          "date": "2016-06-08",
+          "text": "You divide the damage as you cast Pyrokinesis, not as it resolves. If any of the targets become illegal, damage is dealt to the other targets as originally assigned. If all targets are illegal, Pyrokinesis is countered."
+        },
+        {
+          "date": "2016-06-08",
+          "text": "If another effect causes Pyrokinesis to cost more, you must pay that additional cost even if you pay its alternative cost."
+        }
+      ],
+      "text": "You may exile a red card from your hand rather than pay Pyrokinesis's mana cost.\nPyrokinesis deals 4 damage divided as you choose among any number of target creatures.",
+      "type": "Instant",
+      "types": [
+        "Instant"
+      ]
+    },
+    {
+      "artist": "Douglas Shuler",
+      "cmc": 3,
+      "colorIdentity": [
+        "R"
+      ],
+      "colors": [
+        "Red"
+      ],
+      "flavor": "\"Oi oi oi, me gotta hurt in 'ere,/ Oi oi oi, me smell a ting is near,/ Gonna bosh 'n gonna nosh/ 'n da hurt'll disappear.\"\n—Troll chant",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "宇轩巨魔"
+        },
+        {
+          "language": "French",
+          "name": "Troll d'Uthden"
+        },
+        {
+          "language": "German",
+          "name": "Uthden-Troll"
+        },
+        {
+          "language": "Italian",
+          "name": "Troll di Uthden"
+        },
+        {
+          "language": "Japanese",
+          "name": "ウスデン・トロール"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Trol de Uthden"
+        },
+        {
+          "language": "Russian",
+          "name": "Узденский Тролль"
+        },
+        {
+          "language": "Spanish",
+          "name": "Trol de Uthden"
+        }
+      ],
+      "id": "6602c8c42e157da105ebd0d1949309d98285f3bf",
+      "imageName": "uthden troll",
       "layout": "normal",
       "legalities": [
         {
@@ -365,7 +1464,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Tempest Block",
+          "format": "Time Spiral Block",
           "legality": "Legal"
         },
         {
@@ -373,48 +1472,226 @@
           "legality": "Legal"
         }
       ],
-      "manaCost": "{1}{G}",
-      "name": "Canopy Spider",
-      "originalText": "Canopy Spider can block creatures with flying.",
-      "originalType": "Summon — Spider",
-      "power": "1",
+      "manaCost": "{2}{R}",
+      "mciNumber": "17",
+      "name": "Uthden Troll",
+      "number": "17",
+      "originalText": "{R}: Regenerate Uthden Troll.",
+      "power": "2",
       "printings": [
-        "TMP",
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
         "ATH",
-        "7ED",
-        "8ED",
-        "10E",
-        "TPR"
+        "BRB",
+        "TSB"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Troll"
+      ],
+      "text": "{R}: Regenerate Uthden Troll.",
+      "toughness": "2",
+      "type": "Creature — Troll",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Ruth Thompson",
+      "cmc": 3,
+      "flavor": "\"A fine example of the rewards of artifice: a thoroughly obedient steed with wings of Soldevi steel.\"\n—Arcum Dagsson, Soldevi machinist",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Planeur d'aeszir"
+        },
+        {
+          "language": "German",
+          "name": "Aesthirgleiter"
+        },
+        {
+          "language": "Italian",
+          "name": "Aliante Aesthir"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Planador de Aesthir"
+        },
+        {
+          "language": "Spanish",
+          "name": "Planeador aesthir"
+        }
+      ],
+      "id": "ba87156e255008b617bdf0224b114d96932f2d41",
+      "imageName": "aesthir glider",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{3}",
+      "mciNumber": "19",
+      "name": "Aesthir Glider",
+      "number": "19",
+      "originalText": "Flying\nAesthir Glider cannot block.",
+      "power": "2",
+      "printings": [
+        "ALL",
+        "ATH",
+        "ME4"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Bird"
+      ],
+      "text": "Flying\nAesthir Glider can't block.",
+      "toughness": "1",
+      "type": "Artifact Creature — Bird",
+      "types": [
+        "Artifact",
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Stephen Daniele",
+      "colorIdentity": [
+        "B"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "污泥沼"
+        },
+        {
+          "language": "French",
+          "name": "Fondrière polluée"
+        },
+        {
+          "language": "German",
+          "name": "Schmutziges Schlammloch"
+        },
+        {
+          "language": "Italian",
+          "name": "Palude Inquinata"
+        },
+        {
+          "language": "Japanese",
+          "name": "汚染されたぬかるみ"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Lamaçal Poluído"
+        },
+        {
+          "language": "Spanish",
+          "name": "Cenagal contaminado"
+        }
+      ],
+      "id": "a48c4dc1b4d6aab805ac2036dcb311e3dc2dfabc",
+      "imageName": "polluted mire",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Urza Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "mciNumber": "20",
+      "name": "Polluted Mire",
+      "number": "20",
+      "printings": [
+        "USG",
+        "ATH",
+        "BRB",
+        "BTD",
+        "DDD",
+        "PD3",
+        "C14",
+        "DD3_GVL",
+        "C15",
+        "CMA"
       ],
       "rarity": "Special",
       "rulings": [
         {
-          "date": "2008-04-01",
-          "text": "This card now uses the Reach keyword ability to enable the blocking of flying creatures. This works because a creature with flying can only be blocked by creatures with flying or reach."
+          "date": "2008-10-01",
+          "text": "Cycling is an activated ability. Effects that interact with activated abilities (such as Stifle or Rings of Brighthearth) will interact with cycling. Effects that interact with spells (such as Remove Soul or Faerie Tauntings) will not."
         }
       ],
-      "subtypes": [
-        "Spider"
-      ],
-      "text": "Reach (This creature can block creatures with flying.)",
-      "toughness": "3",
-      "type": "Creature — Spider",
+      "text": "Polluted Mire enters the battlefield tapped.\n{T}: Add {B} to your mana pool.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+      "type": "Land",
       "types": [
-        "Creature"
+        "Land"
       ]
     },
     {
-      "artist": "Quinton Hoover",
-      "cmc": 4,
+      "artist": "Mark Tedin",
       "colorIdentity": [
-        "G"
+        "R"
       ],
-      "colors": [
-        "Green"
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "闷燃火山口"
+        },
+        {
+          "language": "French",
+          "name": "Cratère fumant"
+        },
+        {
+          "language": "German",
+          "name": "Dampfender Krater"
+        },
+        {
+          "language": "Italian",
+          "name": "Cratere Fumante"
+        },
+        {
+          "language": "Japanese",
+          "name": "薄煙の火口"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Cratera Fumegante"
+        },
+        {
+          "language": "Spanish",
+          "name": "Cráter ardiente"
+        }
       ],
-      "flavor": "\"It had a mouth like that of a great beast, and gnashed its teeth as it strained to reach us. I am thankful it possessed no means of locomotion.\"\n—Vervamon the Elder",
-      "id": "22b27a49c31e3c402063651bfcacebac9a1739f2",
-      "imageName": "carnivorous plant",
+      "id": "1b8cd48b740a6cbd2f33549995f9589d45b74696",
+      "imageName": "smoldering crater",
       "layout": "normal",
       "legalities": [
         {
@@ -426,52 +1703,7 @@
           "legality": "Legal"
         },
         {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{3}{G}",
-      "name": "Carnivorous Plant",
-      "originalType": "Summon — Wall",
-      "power": "4",
-      "printings": [
-        "DRK",
-        "4ED",
-        "ATH",
-        "MED"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Plant",
-        "Wall"
-      ],
-      "text": "Defender",
-      "toughness": "5",
-      "type": "Creature — Plant Wall",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Liz Danforth",
-      "cmc": 3,
-      "colorIdentity": [
-        "W"
-      ],
-      "colors": [
-        "White"
-      ],
-      "flavor": "\"Without Combat Medics, Icatia would probably not have withstood the forces of chaos as long as it did.\"\n—Sarpadian Empires, vol. VI",
-      "id": "960d7aa53350c6b00d4e6603b51d4820d9adcae1",
-      "imageName": "combat medic",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
+          "format": "Urza Block",
           "legality": "Legal"
         },
         {
@@ -479,27 +1711,28 @@
           "legality": "Legal"
         }
       ],
-      "manaCost": "{2}{W}",
-      "name": "Combat Medic",
-      "originalText": "{1}{W}: Prevent 1 damage to a creature or player.",
-      "originalType": "Summon — Soldier",
-      "power": "0",
+      "mciNumber": "21",
+      "name": "Smoldering Crater",
+      "number": "21",
       "printings": [
-        "FEM",
+        "USG",
         "ATH",
-        "ME2"
+        "BTD",
+        "C13",
+        "C14",
+        "C15"
       ],
       "rarity": "Special",
-      "subtypes": [
-        "Human",
-        "Cleric",
-        "Soldier"
+      "rulings": [
+        {
+          "date": "2008-10-01",
+          "text": "Cycling is an activated ability. Effects that interact with activated abilities (such as Stifle or Rings of Brighthearth) will interact with cycling. Effects that interact with spells (such as Remove Soul or Faerie Tauntings) will not."
+        }
       ],
-      "text": "{1}{W}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
-      "toughness": "2",
-      "type": "Creature — Human Cleric Soldier",
+      "text": "Smoldering Crater enters the battlefield tapped.\n{T}: Add {R} to your mana pool.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+      "type": "Land",
       "types": [
-        "Creature"
+        "Land"
       ]
     },
     {
@@ -510,6 +1743,12 @@
       ],
       "colors": [
         "Black"
+      ],
+      "foreignNames": [
+        {
+          "language": "Italian",
+          "name": "Streghe Cuombajj"
+        }
       ],
       "id": "f8931ad4d35d11150c5bfdd66b600c3dfdb06754",
       "imageName": "cuombajj witches",
@@ -529,9 +1768,10 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "22",
       "name": "Cuombajj Witches",
+      "number": "22",
       "originalText": "{T}: Cuombajj Witches deals 1 damage to target creature or player of your choice and 1 damage to target creature or player of an opponent's choice. (Choose your target first.)",
-      "originalType": "Summon — Witches",
       "power": "1",
       "printings": [
         "ARN",
@@ -570,224 +1810,6 @@
       ]
     },
     {
-      "artist": "Amy Weber",
-      "cmc": 2,
-      "colorIdentity": [
-        "W"
-      ],
-      "colors": [
-        "White"
-      ],
-      "id": "d606b8404491a4662a5bd4be08e323be5946bfce",
-      "imageName": "disenchant",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ice Age Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Urza Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{1}{W}",
-      "name": "Disenchant",
-      "originalText": "Destroy target enchantment or artifact.",
-      "originalType": "Instant",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "ICE",
-        "pARL",
-        "MIR",
-        "5ED",
-        "TMP",
-        "USG",
-        "ATH",
-        "6ED",
-        "MMQ",
-        "BRB",
-        "pFNM",
-        "S00",
-        "7ED",
-        "pMPR",
-        "CST",
-        "TSB",
-        "ME2",
-        "ME3",
-        "TPR",
-        "CN2"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2004-10-04",
-          "text": "This is not modal. If the target changes from an artifact to an enchantment or vice versa, this still destroys it."
-        }
-      ],
-      "text": "Destroy target artifact or enchantment.",
-      "type": "Instant",
-      "types": [
-        "Instant"
-      ]
-    },
-    {
-      "artist": "Bob Eggleton",
-      "colorIdentity": [
-        "W"
-      ],
-      "id": "7e3061490fcc2d3ea5435bc183d5d0a7336f4d46",
-      "imageName": "drifting meadow",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Urza Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "name": "Drifting Meadow",
-      "originalText": "Drifting Meadow comes into play tapped.\n{T}: Add {W} to your mana pool.\nCycling {2} (You may pay {2} and discard this card from your hand to draw a card. Play this ability as an instant.)",
-      "originalType": "Land",
-      "printings": [
-        "USG",
-        "ATH",
-        "BRB",
-        "C13",
-        "C14",
-        "C15"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2008-10-01",
-          "text": "Cycling is an activated ability. Effects that interact with activated abilities (such as Stifle or Rings of Brighthearth) will interact with cycling. Effects that interact with spells (such as Remove Soul or Faerie Tauntings) will not."
-        }
-      ],
-      "text": "Drifting Meadow enters the battlefield tapped.\n{T}: Add {W} to your mana pool.\nCycling {2} ({2}, Discard this card: Draw a card.)",
-      "type": "Land",
-      "types": [
-        "Land"
-      ]
-    },
-    {
-      "artist": "Ken Meyer, Jr.",
-      "cmc": 4,
-      "colorIdentity": [
-        "G"
-      ],
-      "colors": [
-        "Green"
-      ],
-      "id": "4fdd63969d85dee4a2cd84c1ed5399fcebe237af",
-      "imageName": "erhnam djinn",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{3}{G}",
-      "name": "Erhnam Djinn",
-      "originalText": "During your upkeep, target non-Wall creature an opponent controls gains forestwalk until your next turn. (If defending player controls a forest, that creature is unblockable.)",
-      "originalType": "Summon — Djinn",
-      "power": "4",
-      "printings": [
-        "ARN",
-        "CHR",
-        "ATH",
-        "BTD",
-        "JUD",
-        "VMA"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2004-10-04",
-          "text": "In multiplayer games you can choose a different player's creature each upkeep. You are forced to pick a creature that some opponent controls if there is at least one creature on the battlefield that is a legal target."
-        },
-        {
-          "date": "2004-10-04",
-          "text": "If you have more than one Djinn, you can have all of them target the same creature with their ability."
-        },
-        {
-          "date": "2004-10-04",
-          "text": "If there are no creatures your opponent controls to target at the beginning of your upkeep, ignore this ability."
-        }
-      ],
-      "subtypes": [
-        "Djinn"
-      ],
-      "text": "At the beginning of your upkeep, target non-Wall creature an opponent controls gains forestwalk until your next upkeep. (It can't be blocked as long as defending player controls a Forest.)",
-      "toughness": "5",
-      "type": "Creature — Djinn",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
       "artist": "Dennis Detwiller",
       "cmc": 4,
       "colorIdentity": [
@@ -797,6 +1819,28 @@
         "Black"
       ],
       "flavor": "\"Could there be a fouler act? No doubt the baron knows of one.\"\n—Autumn Willow",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Dévoration de la licorne"
+        },
+        {
+          "language": "German",
+          "name": "Einhornschlachtfest"
+        },
+        {
+          "language": "Italian",
+          "name": "Festino dell'Unicorno"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Festim de Unicórnio"
+        },
+        {
+          "language": "Spanish",
+          "name": "Banquete del unicornio"
+        }
+      ],
       "id": "b55c5c3757d52d513818a36b1e35dee077f951d7",
       "imageName": "feast of the unicorn",
       "layout": "normal",
@@ -815,9 +1859,10 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "23",
       "name": "Feast of the Unicorn",
+      "number": "23",
       "originalText": "Target creature gets +4/+0.",
-      "originalType": "Enchant Creature",
       "printings": [
         "HML",
         "ATH",
@@ -834,6 +1879,276 @@
       ]
     },
     {
+      "artist": "Liz Danforth",
+      "cmc": 2,
+      "colorIdentity": [
+        "B"
+      ],
+      "colors": [
+        "Black"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "妥拉克赞歌"
+        },
+        {
+          "language": "Japanese",
+          "name": "トーラックへの賛歌"
+        }
+      ],
+      "id": "a5d7b8d56a06a62ed230909318c679b4bdcf8828",
+      "imageName": "hymn to tourach",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{B}{B}",
+      "mciNumber": "24",
+      "name": "Hymn to Tourach",
+      "number": "24",
+      "originalText": "Target player discards two cards at random from his or her hand. (If that player has only one card, he or she discards it.)",
+      "printings": [
+        "FEM",
+        "ATH",
+        "MED",
+        "V13",
+        "VMA",
+        "EMA"
+      ],
+      "rarity": "Special",
+      "text": "Target player discards two cards at random.",
+      "type": "Sorcery",
+      "types": [
+        "Sorcery"
+      ]
+    },
+    {
+      "artist": "Ron Spencer",
+      "cmc": 2,
+      "colorIdentity": [
+        "B"
+      ],
+      "colors": [
+        "Black"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "惊骇"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "驚駭"
+        },
+        {
+          "language": "French",
+          "name": "Terreur"
+        },
+        {
+          "language": "German",
+          "name": "Terror"
+        },
+        {
+          "language": "Italian",
+          "name": "Terrore"
+        },
+        {
+          "language": "Japanese",
+          "name": "恐怖"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Terror"
+        },
+        {
+          "language": "Russian",
+          "name": "Террор"
+        },
+        {
+          "language": "Spanish",
+          "name": "Terror"
+        }
+      ],
+      "id": "fdb47d0e4b7b67ee3b55bb770501c34b95ff7c5c",
+      "imageName": "terror",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{1}{B}",
+      "mciNumber": "25",
+      "name": "Terror",
+      "number": "25",
+      "originalText": "Destroy target nonartifact, nonblack creature. That creature cannot be regenerated this turn.",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "RQS",
+        "ITP",
+        "5ED",
+        "ATH",
+        "6ED",
+        "BRB",
+        "pFNM",
+        "S00",
+        "BTD",
+        "pMPR",
+        "MRD",
+        "10E",
+        "DPA",
+        "ME4"
+      ],
+      "rarity": "Special",
+      "text": "Destroy target nonartifact, nonblack creature. It can't be regenerated.",
+      "type": "Instant",
+      "types": [
+        "Instant"
+      ]
+    },
+    {
+      "artist": "Douglas Shuler",
+      "cmc": 1,
+      "colorIdentity": [
+        "B"
+      ],
+      "colors": [
+        "Black"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "不洁之力"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "不潔之力"
+        },
+        {
+          "language": "French",
+          "name": "Force impie"
+        },
+        {
+          "language": "German",
+          "name": "Unheilige Stärke"
+        },
+        {
+          "language": "Italian",
+          "name": "Forza Diabolica"
+        },
+        {
+          "language": "Japanese",
+          "name": "邪悪なる力"
+        },
+        {
+          "language": "Korean",
+          "name": ""
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Força Profana"
+        },
+        {
+          "language": "Russian",
+          "name": "Нечистая Сила"
+        },
+        {
+          "language": "Spanish",
+          "name": "Fuerza impía"
+        }
+      ],
+      "id": "8044ac11fcdab08c8689eb035606468a0f45937f",
+      "imageName": "unholy strength",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{B}",
+      "mciNumber": "26",
+      "name": "Unholy Strength",
+      "number": "26",
+      "originalText": "Enchanted creature gets +2/+1.",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "5ED",
+        "ATH",
+        "7ED",
+        "8ED",
+        "9ED",
+        "10E",
+        "DDC",
+        "M10",
+        "DPA",
+        "M11",
+        "DD3_DVD"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Aura"
+      ],
+      "text": "Enchant creature\nEnchanted creature gets +2/+1.",
+      "type": "Enchantment — Aura",
+      "types": [
+        "Enchantment"
+      ]
+    },
+    {
       "artist": "Mark Tedin",
       "cmc": 1,
       "colorIdentity": [
@@ -841,6 +2156,44 @@
       ],
       "colors": [
         "Red"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "火球"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "火球"
+        },
+        {
+          "language": "French",
+          "name": "Boule de feu"
+        },
+        {
+          "language": "German",
+          "name": "Feuerball"
+        },
+        {
+          "language": "Italian",
+          "name": "Palla di Fuoco"
+        },
+        {
+          "language": "Japanese",
+          "name": "火の玉"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Bola de Fogo"
+        },
+        {
+          "language": "Russian",
+          "name": "Огненный Шар"
+        },
+        {
+          "language": "Spanish",
+          "name": "Bola de fuego"
+        }
       ],
       "id": "df215ad3b782da0b0ec41726d6b16116faaed7f5",
       "imageName": "fireball",
@@ -868,9 +2221,10 @@
         }
       ],
       "manaCost": "{X}{R}",
+      "mciNumber": "27",
       "name": "Fireball",
+      "number": "27",
       "originalText": "At the time you play Fireball, pay an additional {1} for each target beyond the first.\nFireball deals X damage divided evenly, rounded down, among any number of target creatures and/or players.",
-      "originalType": "Sorcery",
       "printings": [
         "LEA",
         "LEB",
@@ -906,7 +2260,7 @@
         },
         {
           "date": "2004-12-01",
-          "text": "If, for example, X is 5 and you choose three target creatures, Fireball has a total cost of {R}). If those creatures are all still legal targets as Fireball resolves, it deals 1 damage to each of them."
+          "text": "If, for example, X is 5 and you choose three target creatures, Fireball has a total cost of {7}{R} (even though its mana cost is just {5}{R}). If those creatures are all still legal targets as Fireball resolves, it deals 1 damage to each of them."
         },
         {
           "date": "2009-05-01",
@@ -928,550 +2282,6 @@
       ]
     },
     {
-      "artist": "Quinton Hoover",
-      "colorIdentity": [
-        "G"
-      ],
-      "id": "e3b1e2c8ffcd51735577f129439602bf3d427eaf",
-      "imageName": "forest1",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Amonkhet Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Battle for Zendikar Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ice Age Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Innistrad Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Invasion Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Kaladesh Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Kamigawa Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Khans of Tarkir Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Lorwyn-Shadowmoor Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Masques Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirrodin Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Return to Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Scars of Mirrodin Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Shadows over Innistrad Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Shards of Alara Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Standard",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Theros Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Un-Sets",
-          "legality": "Legal"
-        },
-        {
-          "format": "Urza Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        },
-        {
-          "format": "Zendikar Block",
-          "legality": "Legal"
-        }
-      ],
-      "name": "Forest",
-      "originalText": "G",
-      "originalType": "Land",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "ICE",
-        "RQS",
-        "pARL",
-        "MIR",
-        "ITP",
-        "5ED",
-        "POR",
-        "TMP",
-        "pJGP",
-        "PO2",
-        "UGL",
-        "pALP",
-        "USG",
-        "ATH",
-        "6ED",
-        "PTK",
-        "pGRU",
-        "S99",
-        "MMQ",
-        "BRB",
-        "pELP",
-        "S00",
-        "BTD",
-        "INV",
-        "7ED",
-        "ODY",
-        "DKM",
-        "ONS",
-        "8ED",
-        "MRD",
-        "CHK",
-        "UNH",
-        "9ED",
-        "RAV",
-        "CST",
-        "TSP",
-        "10E",
-        "MED",
-        "LRW",
-        "EVG",
-        "SHM",
-        "ALA",
-        "M10",
-        "HOP",
-        "ME3",
-        "ZEN",
-        "DDD",
-        "H09",
-        "DDE",
-        "ROE",
-        "DPA",
-        "ARC",
-        "M11",
-        "SOM",
-        "MBS",
-        "DDG",
-        "NPH",
-        "CMD",
-        "M12",
-        "DDH",
-        "ISD",
-        "AVR",
-        "PC2",
-        "M13",
-        "DDJ",
-        "RTR",
-        "M14",
-        "DDL",
-        "THS",
-        "C13",
-        "DDM",
-        "M15",
-        "KTK",
-        "C14",
-        "DD3_EVG",
-        "DD3_GVL",
-        "FRF",
-        "DDO",
-        "DTK",
-        "TPR",
-        "ORI",
-        "DDP",
-        "BFZ",
-        "C15",
-        "SOI",
-        "DDR",
-        "KLD",
-        "C16",
-        "PCA",
-        "CMA",
-        "E01",
-        "HOU"
-      ],
-      "rarity": "Basic Land",
-      "subtypes": [
-        "Forest"
-      ],
-      "supertypes": [
-        "Basic"
-      ],
-      "type": "Basic Land — Forest",
-      "types": [
-        "Land"
-      ]
-    },
-    {
-      "artist": "Una Fricker",
-      "cmc": 2,
-      "colorIdentity": [
-        "W"
-      ],
-      "colors": [
-        "White"
-      ],
-      "flavor": "\"That does it! I'm going back to hunting chickens!\"\n—Rhirhok, goblin archer",
-      "id": "16585147a3adeb06f4aa5c522e19d0b3b1e6d2f2",
-      "imageName": "freewind falcon",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Freeform",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{1}{W}",
-      "name": "Freewind Falcon",
-      "originalText": "Flying, protection from red",
-      "originalType": "Summon — Falcon",
-      "power": "1",
-      "printings": [
-        "VIS",
-        "ATH"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Bird"
-      ],
-      "text": "Flying, protection from red",
-      "toughness": "1",
-      "type": "Creature — Bird",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Sandra Everingham",
-      "cmc": 1,
-      "colorIdentity": [
-        "G"
-      ],
-      "colors": [
-        "Green"
-      ],
-      "id": "cd1f9831cfbc90141548e7acbf2e316294cc9723",
-      "imageName": "giant growth",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ice Age Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Return to Ravnica Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{G}",
-      "name": "Giant Growth",
-      "originalText": "Target creature gets +3/+3 until end of turn.",
-      "originalType": "Instant",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "ICE",
-        "5ED",
-        "ATH",
-        "6ED",
-        "BRB",
-        "pSUS",
-        "pFNM",
-        "S00",
-        "BTD",
-        "7ED",
-        "pMPR",
-        "DKM",
-        "8ED",
-        "9ED",
-        "10E",
-        "EVG",
-        "ME2",
-        "M10",
-        "ME3",
-        "DDD",
-        "DPA",
-        "M11",
-        "ME4",
-        "RTR",
-        "M14",
-        "DD3_EVG",
-        "DD3_GVL"
-      ],
-      "rarity": "Special",
-      "text": "Target creature gets +3/+3 until end of turn.",
-      "type": "Instant",
-      "types": [
-        "Instant"
-      ]
-    },
-    {
-      "artist": "Sandra Everingham",
-      "cmc": 4,
-      "colorIdentity": [
-        "G"
-      ],
-      "colors": [
-        "Green"
-      ],
-      "flavor": "While it possesses potent venom, the Giant Spider often chooses not to paralyze its victims. Perhaps the creature enjoys the gentle rocking motion caused by its captives' struggles to escape its web.",
-      "id": "d87d02381b53f9c5ce360d5feaddb227807e725a",
-      "imageName": "giant spider",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{3}{G}",
-      "name": "Giant Spider",
-      "originalText": "Giant Spider can block creatures with flying.",
-      "originalType": "Summon — Spider",
-      "power": "2",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "5ED",
-        "POR",
-        "ATH",
-        "6ED",
-        "7ED",
-        "8ED",
-        "9ED",
-        "10E",
-        "M10",
-        "DPA",
-        "M11",
-        "M12",
-        "M14"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2008-04-01",
-          "text": "This card now uses the Reach keyword ability to enable the blocking of flying creatures. This works because a creature with flying can only be blocked by creatures with flying or reach."
-        }
-      ],
-      "subtypes": [
-        "Spider"
-      ],
-      "text": "Reach (This creature can block creatures with flying.)",
-      "toughness": "4",
-      "type": "Creature — Spider",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Andi Rusu",
-      "cmc": 1,
-      "colorIdentity": [
-        "R"
-      ],
-      "colors": [
-        "Red"
-      ],
-      "flavor": "\"From up here we can drop rocks and arrows and more rocks!\"\n\"Uh, yeah boss, but how do we get down?\"",
-      "id": "12ffb2eecba7e80ea931dab18b7fd3f82026eb3b",
-      "imageName": "goblin balloon brigade",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{R}",
-      "name": "Goblin Balloon Brigade",
-      "originalText": "{R}: Goblin Balloon Brigade gains flying until end of turn.",
-      "originalType": "Summon — Goblins",
-      "power": "1",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "ATH",
-        "9ED",
-        "M11",
-        "CN2"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2008-08-01",
-          "text": "You can activate the ability repeatedly during a turn. This generally has no additional effect, unless some other effect (like that from Adarkar Windform has caused it to lose flying since the last time the ability resolved."
-        },
-        {
-          "date": "2010-08-15",
-          "text": "For flying to work as an evasion ability, an attacking Goblin Balloon Brigade's ability must be activated before the declare blockers step begins. Once Goblin Balloon Brigade has become blocked, giving it flying won't change that."
-        }
-      ],
-      "subtypes": [
-        "Goblin",
-        "Warrior"
-      ],
-      "text": "{R}: Goblin Balloon Brigade gains flying until end of turn.",
-      "toughness": "1",
-      "type": "Creature — Goblin Warrior",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
       "artist": "Phil Foglio",
       "cmc": 1,
       "colorIdentity": [
@@ -1480,7 +2290,29 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"From down here we can make the whole wall collapse!\"\n\"Uh, yeah, boss, but how do we get out?\"",
+      "flavor": "\"From down here we can make the whole wall collapse!\" \"Uh, yeah, boss, but how do we get out?\"",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Équipe de minage gobeline"
+        },
+        {
+          "language": "German",
+          "name": "Buddelbrigade der Goblins"
+        },
+        {
+          "language": "Italian",
+          "name": "Squadra di Genieri Goblin"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Grupo de Goblins Escavadores"
+        },
+        {
+          "language": "Spanish",
+          "name": "Zapadores trasgos"
+        }
+      ],
       "id": "9ce499f63e0a9d654273d69a45d7411d68bafcb8",
       "imageName": "goblin digging team",
       "layout": "normal",
@@ -1499,8 +2331,9 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "28",
       "name": "Goblin Digging Team",
-      "originalText": "{T}, Sacrifice Goblin Digging Team: Destroy target Wall.",
+      "number": "28",
       "originalType": "Summon — Goblins",
       "power": "1",
       "printings": [
@@ -1531,7 +2364,45 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"I don't suppose we could teach them to throw the cursed things?\"\n—Ivra Jursdotter",
+      "flavor": "\"I don't suppose we could teach them to throw the cursed things?' —Ivra Jursdotter",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "鬼怪手榴弹"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "鬼怪手榴彈"
+        },
+        {
+          "language": "French",
+          "name": "Grenade gobeline"
+        },
+        {
+          "language": "German",
+          "name": "Goblingranate"
+        },
+        {
+          "language": "Italian",
+          "name": "Granata Goblin"
+        },
+        {
+          "language": "Japanese",
+          "name": "ゴブリンの手投げ弾"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Granada Goblin"
+        },
+        {
+          "language": "Russian",
+          "name": "Гоблинская Граната"
+        },
+        {
+          "language": "Spanish",
+          "name": "Granada trasgo"
+        }
+      ],
       "id": "3b832fe0ae4d68254e89d96d59ed18715b30db54",
       "imageName": "goblin grenade",
       "layout": "normal",
@@ -1554,9 +2425,10 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "29",
       "name": "Goblin Grenade",
+      "number": "29",
       "originalText": "At the time you play Goblin Grenade, sacrifice a Goblin.\nGoblin Grenade deals 5 damage to target creature or player.",
-      "originalType": "Sorcery",
       "printings": [
         "FEM",
         "ATH",
@@ -1593,7 +2465,29 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"When you're a goblin, you don't have to step forward to be a hero—everyone else just has to step back!\"\n—Biggum Flodrot, goblin veteran",
+      "flavor": "\"When you're a goblin, you don't have to step forward to be a hero-everyone else just has to step back!\"\n—Biggum Flodrot, goblin veteran",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Heros gobelin"
+        },
+        {
+          "language": "German",
+          "name": "Held der Goblins"
+        },
+        {
+          "language": "Italian",
+          "name": "Eroe Goblin"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Herói dos Goblins"
+        },
+        {
+          "language": "Spanish",
+          "name": "Héroe trasgo"
+        }
+      ],
       "id": "a1930e7646717d5d74abf131b6eace169c40a4c0",
       "imageName": "goblin hero",
       "layout": "normal",
@@ -1612,7 +2506,9 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "30",
       "name": "Goblin Hero",
+      "number": "30",
       "originalType": "Summon — Goblin",
       "power": "2",
       "printings": [
@@ -1634,75 +2530,6 @@
       ]
     },
     {
-      "artist": "Jesper Myrfors",
-      "cmc": 3,
-      "colorIdentity": [
-        "R"
-      ],
-      "colors": [
-        "Red"
-      ],
-      "flavor": "To be king, Numsgil did in Blog, who did in Unkful, who did in Viddle, who did in Loll, who did in Alrok . . . .\"",
-      "id": "e387619fa70309c98dfc504cad9a5d3fa6eee50c",
-      "imageName": "goblin king",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{1}{R}{R}",
-      "name": "Goblin King",
-      "originalText": "All goblins get +1/+1 and gain mountainwalk. (If defending player controls a mountain, those creatures are unblockable.)",
-      "originalType": "Summon — Lord",
-      "power": "2",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "5ED",
-        "ATH",
-        "6ED",
-        "7ED",
-        "8ED",
-        "9ED",
-        "10E"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2005-08-01",
-          "text": "Goblin King now has the Goblin creature type and its ability has been reworded to affect *other* Goblins. This means that if two Goblin Kings are on the battlefield, each gives the other a bonus."
-        }
-      ],
-      "subtypes": [
-        "Goblin"
-      ],
-      "text": "Other Goblin creatures get +1/+1 and have mountainwalk. (They can't be blocked as long as defending player controls a Mountain.)",
-      "toughness": "2",
-      "type": "Creature — Goblin",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
       "artist": "Daniel Gelon",
       "cmc": 3,
       "colorIdentity": [
@@ -1710,6 +2537,28 @@
       ],
       "colors": [
         "Red"
+      ],
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Matrone gobeline"
+        },
+        {
+          "language": "German",
+          "name": "Goblin-Matrone"
+        },
+        {
+          "language": "Italian",
+          "name": "Matrona Goblin"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Matrona Goblin"
+        },
+        {
+          "language": "Spanish",
+          "name": "Matrona trasgo"
+        }
       ],
       "id": "315d5b13e02eee2919d1a63695e561d7194dc59b",
       "imageName": "goblin matron",
@@ -1733,9 +2582,10 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "31",
       "name": "Goblin Matron",
+      "number": "31",
       "originalText": "When Goblin Matron comes into play, you may search your library for a Goblin card. If you do, reveal that card, put it into your hand, and shuffle your library afterward.",
-      "originalType": "Creature — Goblin",
       "power": "1",
       "printings": [
         "PO2",
@@ -1768,230 +2618,6 @@
       ]
     },
     {
-      "artist": "Daniel Gelon",
-      "cmc": 4,
-      "colorIdentity": [
-        "R"
-      ],
-      "colors": [
-        "Red"
-      ],
-      "id": "8b7b7d82d8667d0e0aad3093cb257931ffc4387d",
-      "imageName": "goblin mutant",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ice Age Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{2}{R}{R}",
-      "name": "Goblin Mutant",
-      "originalText": "Trample\nGoblin Mutant cannot attack if defending player controls an untapped creature with power 3 or more.\nGoblin Mutant cannot block a creature with power 3 or more.",
-      "originalType": "Summon — Goblin",
-      "power": "5",
-      "printings": [
-        "ICE",
-        "ATH",
-        "DKM",
-        "MED"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Goblin",
-        "Mutant"
-      ],
-      "text": "Trample\nGoblin Mutant can't attack if defending player controls an untapped creature with power 3 or greater.\nGoblin Mutant can't block creatures with power 3 or greater.",
-      "toughness": "3",
-      "type": "Creature — Goblin Mutant",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Carl Critchlow",
-      "cmc": 3,
-      "colorIdentity": [
-        "R"
-      ],
-      "colors": [
-        "Red"
-      ],
-      "flavor": "They certainly are.",
-      "id": "0ef641c701e9d1428e945f10d1f5eda37f77f040",
-      "imageName": "goblin offensive",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Urza Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{X}{1}{R}{R}",
-      "name": "Goblin Offensive",
-      "originalText": "Put X Goblin tokens into play. Treat these tokens as 1/1 red creatures.",
-      "originalType": "Sorcery",
-      "printings": [
-        "USG",
-        "ATH",
-        "HOP"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2004-10-04",
-          "text": "The tokens are named \"Goblin\" and are of creature type \"Goblin\"."
-        }
-      ],
-      "text": "Create X 1/1 red Goblin creature tokens.",
-      "type": "Sorcery",
-      "types": [
-        "Sorcery"
-      ]
-    },
-    {
-      "artist": "Scott Kirschner",
-      "cmc": 2,
-      "colorIdentity": [
-        "R"
-      ],
-      "colors": [
-        "Red"
-      ],
-      "flavor": "\"Next!\"",
-      "id": "6421c4fd9f8fd4cdf4595de928bd14e883f03849",
-      "imageName": "goblin recruiter",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Banned"
-        },
-        {
-          "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{1}{R}",
-      "name": "Goblin Recruiter",
-      "originalText": "When Goblin Recruiter comes into play, search your library for any number of Goblin cards and reveal them to all players. Shuffle your library, then put the revealed cards on top of it in any order.",
-      "originalType": "Summon — Goblin",
-      "power": "1",
-      "printings": [
-        "VIS",
-        "ATH",
-        "6ED"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2008-04-01",
-          "text": "You can search for any card with the creature type Goblin, including Creature or Tribal cards. Older cards of type \"Summon Goblin\" and \"Summon Goblins\" also count. You can't search for cards that have Goblin in the name but don't have the creature type Goblin."
-        }
-      ],
-      "subtypes": [
-        "Goblin"
-      ],
-      "text": "When Goblin Recruiter enters the battlefield, search your library for any number of Goblin cards and reveal those cards. Shuffle your library, then put them on top of it in any order.",
-      "toughness": "1",
-      "type": "Creature — Goblin",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Daniel Gelon",
-      "cmc": 4,
-      "colorIdentity": [
-        "R"
-      ],
-      "colors": [
-        "Red"
-      ],
-      "flavor": "\"Strength in numbers? Right.\"\n—Ib Halfheart, Goblin Tactician",
-      "id": "637be9b3ee3cd68ff27ea9d12e9e5377aa6c1737",
-      "imageName": "goblin snowman",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ice Age Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{3}{R}",
-      "name": "Goblin Snowman",
-      "originalText": "When Goblin Snowman blocks, it does not deal or receive combat damage that turn.\n{T}: Goblin Snowman deals 1 damage to target creature it is blocking.",
-      "originalType": "Summon — Goblins",
-      "power": "1",
-      "printings": [
-        "ICE",
-        "ATH",
-        "TSB"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Goblin"
-      ],
-      "text": "Whenever Goblin Snowman blocks, prevent all combat damage that would be dealt to and dealt by it this turn.\n{T}: Goblin Snowman deals 1 damage to target creature it's blocking.",
-      "toughness": "1",
-      "type": "Creature — Goblin",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
       "artist": "Hannibal King",
       "cmc": 2,
       "colorIdentity": [
@@ -2001,16 +2627,34 @@
         "Red"
       ],
       "flavor": "\"Can they do that?\"\n—Imwita, Zhalfirin artificer, last words",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Bricoleur gobelin"
+        },
+        {
+          "language": "German",
+          "name": "Goblin-Kesselflicker"
+        },
+        {
+          "language": "Italian",
+          "name": "Goblin Tuttofare"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Funileiro Goblin"
+        },
+        {
+          "language": "Spanish",
+          "name": "Chapucero trasgo"
+        }
+      ],
       "id": "4bf523ac850986fa93f33ad277b3afd0196a0cdf",
       "imageName": "goblin tinkerer",
       "layout": "normal",
       "legalities": [
         {
           "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Freeform",
           "legality": "Legal"
         },
         {
@@ -2022,26 +2666,15 @@
           "legality": "Legal"
         },
         {
-          "format": "Prismatic",
-          "legality": "Legal"
-        },
-        {
-          "format": "Singleton 100",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tribal Wars Legacy",
-          "legality": "Legal"
-        },
-        {
           "format": "Vintage",
           "legality": "Legal"
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "32",
       "name": "Goblin Tinkerer",
+      "number": "32",
       "originalText": "{R}, {T}: Destroy target artifact. That artifact deals damage equal to its total casting cost to Goblin Tinkerer.",
-      "originalType": "Summon — Goblin",
       "power": "1",
       "printings": [
         "MIR",
@@ -2068,6 +2701,28 @@
       "colors": [
         "Red"
       ],
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Vandale gobelin"
+        },
+        {
+          "language": "German",
+          "name": "Goblinvandale"
+        },
+        {
+          "language": "Italian",
+          "name": "Vandalo Goblin"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Vândalo Goblin"
+        },
+        {
+          "language": "Spanish",
+          "name": "Vándalo trasgo"
+        }
+      ],
       "id": "a54b2117670d1af38a1e0156c52a6e50994d325e",
       "imageName": "goblin vandal",
       "layout": "normal",
@@ -2090,9 +2745,9 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "33",
       "name": "Goblin Vandal",
-      "originalText": "{R} Destroy target artifact defending player controls. Goblin Vandal deals no combat damage this turn. Use this ability only if Goblin Vandal is attacking and unblocked and only once each turn.",
-      "originalType": "Summon — Goblin",
+      "number": "33",
       "power": "1",
       "printings": [
         "WTH",
@@ -2121,616 +2776,6 @@
       ]
     },
     {
-      "artist": "Dan Frazier",
-      "cmc": 3,
-      "colorIdentity": [
-        "R"
-      ],
-      "colors": [
-        "Red"
-      ],
-      "flavor": "\"Goblins bred underground, their numbers hidden from the enemy until it was too late.\" —Sarpadian Empires, vol. IV",
-      "id": "408a12f3ae6f15e837d0104b25066d502ab9f51d",
-      "imageName": "goblin warrens",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{2}{R}",
-      "name": "Goblin Warrens",
-      "originalText": "{2}{R}, Sacrifice two Goblins: Put three Goblin tokens into play. Treat these tokens as 1/1 red creatures.",
-      "originalType": "Enchantment",
-      "printings": [
-        "FEM",
-        "5ED",
-        "ATH",
-        "6ED",
-        "ME4"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2004-10-04",
-          "text": "The token Goblins can be sacrificed to the Warrens to generate new Goblins."
-        }
-      ],
-      "text": "{2}{R}, Sacrifice two Goblins: Create three 1/1 red Goblin creature tokens.",
-      "type": "Enchantment",
-      "types": [
-        "Enchantment"
-      ]
-    },
-    {
-      "artist": "Quinton Hoover",
-      "cmc": 4,
-      "colorIdentity": [
-        "G"
-      ],
-      "colors": [
-        "Green"
-      ],
-      "flavor": "\"Oh, no—not you again?\"\n—Jaya Ballard, Task Mage",
-      "id": "fa503e2dbdf532961f76faae7423814cb3a4fa4f",
-      "imageName": "gorilla chieftain",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ice Age Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{2}{G}{G}",
-      "name": "Gorilla Chieftain",
-      "originalText": "{1}{G}: Regenerate",
-      "originalType": "Summon — Gorilla",
-      "power": "3",
-      "printings": [
-        "ALL",
-        "ATH",
-        "6ED",
-        "7ED"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Ape"
-      ],
-      "text": "{1}{G}: Regenerate Gorilla Chieftain.",
-      "toughness": "3",
-      "type": "Creature — Ape",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Cornelius Brudi",
-      "cmc": 1,
-      "colorIdentity": [
-        "G"
-      ],
-      "colors": [
-        "Green"
-      ],
-      "flavor": "\"The raging winds . . . , settling on the sea, the surges sweep, / Raise liquid mountains, and disclose the deep.\"\n—Virgil, Aeneid, Book I, trans. Dryden",
-      "id": "e0c9cfa6a7b1a566b3ee453f502e08ff0232cc55",
-      "imageName": "hurricane",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ice Age Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{X}{G}",
-      "name": "Hurricane",
-      "originalText": "Hurricane deals X damage to each creature with flying and each player.",
-      "originalType": "Sorcery",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "ICE",
-        "5ED",
-        "POR",
-        "PO2",
-        "ATH",
-        "6ED",
-        "BRB",
-        "7ED",
-        "DKM",
-        "10E"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2004-10-04",
-          "text": "Whether or not a creature has flying is only checked on resolution."
-        }
-      ],
-      "text": "Hurricane deals X damage to each creature with flying and each player.",
-      "type": "Sorcery",
-      "types": [
-        "Sorcery"
-      ]
-    },
-    {
-      "artist": "Liz Danforth",
-      "cmc": 2,
-      "colorIdentity": [
-        "B"
-      ],
-      "colors": [
-        "Black"
-      ],
-      "id": "a5d7b8d56a06a62ed230909318c679b4bdcf8828",
-      "imageName": "hymn to tourach",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{B}{B}",
-      "name": "Hymn to Tourach",
-      "originalText": "Target player discards two cards at random from his or her hand. (If that player has only one card, he or she discards it.)",
-      "originalType": "Sorcery",
-      "printings": [
-        "FEM",
-        "ATH",
-        "MED",
-        "V13",
-        "VMA",
-        "EMA"
-      ],
-      "rarity": "Special",
-      "text": "Target player discards two cards at random.",
-      "type": "Sorcery",
-      "types": [
-        "Sorcery"
-      ]
-    },
-    {
-      "artist": "Douglas Shuler",
-      "cmc": 3,
-      "colorIdentity": [
-        "B"
-      ],
-      "colors": [
-        "Black"
-      ],
-      "id": "1f04f7554a1fce3402db711a8a830612955f4b69",
-      "imageName": "hypnotic specter",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{1}{B}{B}",
-      "name": "Hypnotic Specter",
-      "originalText": "Flying\nWhenever Hypnotic Specter successfully deals damage to an opponent, that player discards a card at random from his or her hand.",
-      "originalType": "Summon — Specter",
-      "power": "2",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "ATH",
-        "pMPR",
-        "9ED",
-        "10E",
-        "M10"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2008-08-01",
-          "text": "The ability triggers even if the Specter's damage is being redirected to an opponent. It does not trigger if damage that would have been dealt to the opponent is redirected to a nonopponent player or a creature, or if the damage is prevented."
-        }
-      ],
-      "subtypes": [
-        "Specter"
-      ],
-      "text": "Flying\nWhenever Hypnotic Specter deals damage to an opponent, that player discards a card at random.",
-      "toughness": "2",
-      "type": "Creature — Specter",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Edward P. Beard, Jr.",
-      "cmc": 1,
-      "colorIdentity": [
-        "W"
-      ],
-      "colors": [
-        "White"
-      ],
-      "id": "7eb28af8954413c319c83eb124def8c94ad9d09f",
-      "imageName": "icatian javelineers",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{W}",
-      "name": "Icatian Javelineers",
-      "originalText": "When Icatian Javelineers comes into play, put a javelin counter on it.\n{T}, Remove a javelin counter from Icatian Javelineers: Icatian Javelineers deals 1 damage to target creature or player.",
-      "originalType": "Summon — Soldiers",
-      "power": "1",
-      "printings": [
-        "FEM",
-        "ATH",
-        "pGTW",
-        "TSB",
-        "ME2",
-        "DDO"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Human",
-        "Soldier"
-      ],
-      "text": "Icatian Javelineers enters the battlefield with a javelin counter on it.\n{T}, Remove a javelin counter from Icatian Javelineers: Icatian Javelineers deals 1 damage to target creature or player.",
-      "toughness": "1",
-      "type": "Creature — Human Soldier",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Christopher Rush",
-      "cmc": 6,
-      "colorIdentity": [
-        "B"
-      ],
-      "colors": [
-        "Black"
-      ],
-      "flavor": "\"Ihsan, the weak. Ihsan, the fallen. Ihsan, the betrayer. He has brought shame to the Serra Paladins where none existed before. May his suffering equal his betrayal.\"\n—Baris, Serra Inquisitor",
-      "id": "379352ea1f63fc4fcc08497c21d5c200ffd84896",
-      "imageName": "ihsan's shade",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{3}{B}{B}{B}",
-      "name": "Ihsan's Shade",
-      "originalText": "Protection from white",
-      "originalType": "Summon — Legend",
-      "power": "5",
-      "printings": [
-        "HML",
-        "ATH",
-        "ME2"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Shade",
-        "Knight"
-      ],
-      "supertypes": [
-        "Legendary"
-      ],
-      "text": "Protection from white",
-      "toughness": "5",
-      "type": "Legendary Creature — Shade Knight",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Christopher Rush",
-      "cmc": 1,
-      "colorIdentity": [
-        "W"
-      ],
-      "colors": [
-        "White"
-      ],
-      "flavor": "\"The true dishonor for a soldier is surviving the war.\"\n—Telim'Tor",
-      "id": "aca32aa2bd1ae4421868f4ebf48760a47c3390f3",
-      "imageName": "infantry veteran",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{W}",
-      "name": "Infantry Veteran",
-      "originalText": "{T}: Target attacking creature gets +1/+1 until end of turn.",
-      "originalType": "Summon — Soldier",
-      "power": "1",
-      "printings": [
-        "VIS",
-        "ATH",
-        "6ED",
-        "BRB",
-        "9ED",
-        "M11",
-        "DDF",
-        "DDN"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2010-08-15",
-          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
-        }
-      ],
-      "subtypes": [
-        "Human",
-        "Soldier"
-      ],
-      "text": "{T}: Target attacking creature gets +1/+1 until end of turn.",
-      "toughness": "1",
-      "type": "Creature — Human Soldier",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Tom Wänerstrand",
-      "cmc": 3,
-      "flavor": "This timeworn relic was responsible for many of Urza's victories, though he never fully comprehended its mystic runes.",
-      "id": "8f2b260d11249ec2442ca6c0be5c5784355bb3c2",
-      "imageName": "jalum tome",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{3}",
-      "name": "Jalum Tome",
-      "originalText": "{2}, {T}: Draw a card, then choose and discard a card.",
-      "originalType": "Artifact",
-      "printings": [
-        "ATQ",
-        "CHR",
-        "5ED",
-        "ATH",
-        "6ED",
-        "7ED",
-        "C14"
-      ],
-      "rarity": "Special",
-      "text": "{2}, {T}: Draw a card, then discard a card.",
-      "type": "Artifact",
-      "types": [
-        "Artifact"
-      ]
-    },
-    {
-      "artist": "Mark Poole",
-      "cmc": 2,
-      "colorIdentity": [
-        "B"
-      ],
-      "colors": [
-        "Black"
-      ],
-      "id": "d92b724d606e999868668c40fe2c33f57266a89a",
-      "imageName": "knight of stromgald",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ice Age Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{B}{B}",
-      "name": "Knight of Stromgald",
-      "originalText": "Protection from white\n{B}: Knight of Stromgald gains first strike until end of turn.\n{B}{B}: Knight of Stromgald gets +1/+0 until end of turn.",
-      "originalType": "Summon — Knight",
-      "power": "2",
-      "printings": [
-        "ICE",
-        "5ED",
-        "ATH",
-        "ME2"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Human",
-        "Knight"
-      ],
-      "text": "Protection from white\n{B}: Knight of Stromgald gains first strike until end of turn.\n{B}{B}: Knight of Stromgald gets +1/+0 until end of turn.",
-      "toughness": "1",
-      "type": "Creature — Human Knight",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Sandra Everingham",
-      "cmc": 7,
-      "colorIdentity": [
-        "B",
-        "R"
-      ],
-      "colors": [
-        "Black",
-        "Red"
-      ],
-      "flavor": "\"I do not remember what he said to her. I remember her fiery eyes, fixed upon him for an instant. I remember a flash, and the hot breath of sudden flames made me turn away. When I looked again, Angus was gone.\" —A Wayfarer, on meeting Lady Orca",
-      "id": "a7110b099f792aee1cffde053301bc1f3ec324d8",
-      "imageName": "lady orca",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{5}{B}{R}",
-      "name": "Lady Orca",
-      "originalType": "Summon — Legend",
-      "power": "7",
-      "printings": [
-        "LEG",
-        "ATH",
-        "ME3"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Demon"
-      ],
-      "supertypes": [
-        "Legendary"
-      ],
-      "toughness": "4",
-      "type": "Legendary Creature — Demon",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
       "artist": "Christopher Rush",
       "cmc": 1,
       "colorIdentity": [
@@ -2738,6 +2783,44 @@
       ],
       "colors": [
         "Red"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "闪电击"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "閃電擊"
+        },
+        {
+          "language": "French",
+          "name": "Foudre"
+        },
+        {
+          "language": "German",
+          "name": "Blitzschlag"
+        },
+        {
+          "language": "Italian",
+          "name": "Fulmine"
+        },
+        {
+          "language": "Japanese",
+          "name": "稲妻"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Raio"
+        },
+        {
+          "language": "Russian",
+          "name": "Удар Молнии"
+        },
+        {
+          "language": "Spanish",
+          "name": "Relámpago"
+        }
       ],
       "id": "cba2e715d16c6e970285b4ca268252a607bd4337",
       "imageName": "lightning bolt",
@@ -2761,9 +2844,9 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "34",
       "name": "Lightning Bolt",
-      "originalText": "Lightning Bolt deals 3 damage to target creature or player.",
-      "originalType": "Instant",
+      "number": "34",
       "printings": [
         "LEA",
         "LEB",
@@ -2791,142 +2874,6 @@
       ]
     },
     {
-      "artist": "Anson Maddocks",
-      "cmc": 1,
-      "colorIdentity": [
-        "G"
-      ],
-      "colors": [
-        "Green"
-      ],
-      "flavor": "One bone broken for every twig snapped underfoot.\n—Llanowar penalty for trespassing",
-      "id": "3123fa7e63344f84fe2a987ad65732229eff58d6",
-      "imageName": "llanowar elves",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{G}",
-      "name": "Llanowar Elves",
-      "originalText": "{T}: Add {G} to your mana pool. Play this ability as a mana source.",
-      "originalType": "Creature — Elf",
-      "power": "1",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "5ED",
-        "ATH",
-        "6ED",
-        "BRB",
-        "pFNM",
-        "S00",
-        "BTD",
-        "7ED",
-        "9ED",
-        "pGTW",
-        "10E",
-        "EVG",
-        "M10",
-        "M11",
-        "M12",
-        "C14",
-        "DD3_EVG",
-        "EMA",
-        "CMA"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Elf",
-        "Druid"
-      ],
-      "text": "{T}: Add {G} to your mana pool.",
-      "toughness": "1",
-      "type": "Creature — Elf Druid",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Daren Bader",
-      "cmc": 3,
-      "colorIdentity": [
-        "G"
-      ],
-      "colors": [
-        "Green"
-      ],
-      "id": "1dcbbc15027b27b8e504f8e9013ff2cef8aca528",
-      "imageName": "mirri, cat warrior",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{1}{G}{G}",
-      "name": "Mirri, Cat Warrior",
-      "originalText": "Mirri, Cat Warrior counts as a Cat Warrior.\nFirst strike; forestwalk (If defending player controls any forests, this creature is unblockable.)\nAttacking does not cause Mirri to tap.",
-      "originalType": "Summon — Legend",
-      "power": "2",
-      "printings": [
-        "EXO",
-        "ATH",
-        "10E",
-        "TPR"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Cat",
-        "Warrior"
-      ],
-      "supertypes": [
-        "Legendary"
-      ],
-      "text": "First strike, forestwalk, vigilance (This creature deals combat damage before creatures without first strike, it can't be blocked as long as defending player controls a Forest, and attacking doesn't cause this creature to tap.)",
-      "toughness": "3",
-      "type": "Legendary Creature — Cat Warrior",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
       "artist": "Brom",
       "cmc": 1,
       "colorIdentity": [
@@ -2935,7 +2882,45 @@
       "colors": [
         "Red"
       ],
-      "flavor": "\"I got it! I got it! I—\"",
+      "flavor": "\"I got it! I got it! I-\"",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "迷乱莫葛"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "迷亂莫葛"
+        },
+        {
+          "language": "French",
+          "name": "Mogg fanatique"
+        },
+        {
+          "language": "German",
+          "name": "Fanatischer Mogg"
+        },
+        {
+          "language": "Italian",
+          "name": "Mogg Fanatico"
+        },
+        {
+          "language": "Japanese",
+          "name": "モグの狂信者"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Mogg Fanático"
+        },
+        {
+          "language": "Russian",
+          "name": "Могг-Фанатик"
+        },
+        {
+          "language": "Spanish",
+          "name": "Fanático mogg"
+        }
+      ],
       "id": "c6a49d9d5742e0551722ec3f70a44706a77e31a6",
       "imageName": "mogg fanatic",
       "layout": "normal",
@@ -2962,9 +2947,9 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "35",
       "name": "Mogg Fanatic",
-      "originalText": "Sacrifice Mogg Fanatic: Mogg Fanatic deals 1 damage to target creature or player.",
-      "originalType": "Summon — Goblin",
+      "number": "35",
       "power": "1",
       "printings": [
         "TMP",
@@ -3004,7 +2989,49 @@
       "colors": [
         "Red"
       ],
-      "flavor": "They'll attack whatever's in front of them—as long as you tell them where that is.",
+      "flavor": "They'll attack whatever's in front of them-as long as you tell them where that is.",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "莫葛跟班"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "莫葛跟班"
+        },
+        {
+          "language": "French",
+          "name": "Moggs bas-de-plafond"
+        },
+        {
+          "language": "German",
+          "name": "Mogg-Versager"
+        },
+        {
+          "language": "Italian",
+          "name": "Mogg Tirapiedi"
+        },
+        {
+          "language": "Japanese",
+          "name": "モグの下働き"
+        },
+        {
+          "language": "Korean",
+          "name": "모그 수위병"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Moggs Confusos"
+        },
+        {
+          "language": "Russian",
+          "name": "Могги-Прислужники"
+        },
+        {
+          "language": "Spanish",
+          "name": "Lacayos mogg"
+        }
+      ],
       "id": "56b3f950048b71b42b368862d17a506d6f2eeb3c",
       "imageName": "mogg flunkies",
       "layout": "normal",
@@ -3031,9 +3058,10 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "36",
       "name": "Mogg Flunkies",
+      "number": "36",
       "originalText": "Mogg Flunkies cannot attack or block unless another creature you control attacks or blocks the same turn.",
-      "originalType": "Summon — Goblins",
       "power": "3",
       "printings": [
         "STH",
@@ -3086,6 +3114,28 @@
         "Red"
       ],
       "flavor": "The evisceration of one mogg always cheers up the rest.",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Maraudeur mogg"
+        },
+        {
+          "language": "German",
+          "name": "Mogg-Plünderer"
+        },
+        {
+          "language": "Italian",
+          "name": "Mogg Predone"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Mogg Salteador"
+        },
+        {
+          "language": "Spanish",
+          "name": "Corsario mogg"
+        }
+      ],
       "id": "73f43d8e1cea796c1c906a28ee49d087182f4fbd",
       "imageName": "mogg raider",
       "layout": "normal",
@@ -3108,9 +3158,9 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "37",
       "name": "Mogg Raider",
-      "originalText": "Sacrifice a Goblin: Target creature gets +1/+1 until end of turn.",
-      "originalType": "Summon — Goblin",
+      "number": "37",
       "power": "1",
       "printings": [
         "TMP",
@@ -3128,9 +3178,282 @@
       ]
     },
     {
-      "artist": "John Avon",
+      "artist": "Anson Maddocks",
+      "cmc": 5,
       "colorIdentity": [
         "R"
+      ],
+      "colors": [
+        "Red"
+      ],
+      "flavor": "\"Hi! ni! ya! Behold the man of flint, that's me! / Four lightnings zigzag from me, strike and return.\"\n—Navajo war chant",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "烟火术"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "煙火術"
+        },
+        {
+          "language": "French",
+          "name": "Pyrotechnie"
+        },
+        {
+          "language": "German",
+          "name": "Pyrotechnik"
+        },
+        {
+          "language": "Italian",
+          "name": "Fuochi d'Artificio"
+        },
+        {
+          "language": "Japanese",
+          "name": "発火"
+        },
+        {
+          "language": "Korean",
+          "name": "화염 조종술"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Pirotécnica"
+        },
+        {
+          "language": "Russian",
+          "name": "Пиротехника"
+        },
+        {
+          "language": "Spanish",
+          "name": "Pirotecnia"
+        }
+      ],
+      "id": "b1d13718e495f53bb90068006c05081f991f4f9d",
+      "imageName": "pyrotechnics",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Khans of Tarkir Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{4}{R}",
+      "mciNumber": "38",
+      "name": "Pyrotechnics",
+      "number": "38",
+      "printings": [
+        "LEG",
+        "4ED",
+        "RQS",
+        "ITP",
+        "5ED",
+        "ATH",
+        "6ED",
+        "7ED",
+        "8ED",
+        "HOP",
+        "FRF"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2014-11-24",
+          "text": "The number of targets chosen for Pyrotechnics must be at least one and at most four. You choose how the damage is divided as you cast the spell, not as it resolves. Each target must be assigned at least 1 damage."
+        },
+        {
+          "date": "2014-11-24",
+          "text": "If some but not all of Pyrotechnics's targets become illegal, you can't change the division of damage. Damage that would have been dealt to illegal targets simply isn't dealt."
+        },
+        {
+          "date": "2014-11-24",
+          "text": "You can't deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can't deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
+        },
+        {
+          "date": "2014-11-24",
+          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can't be changed. The effect that creates the copy may allow you to change the targets, however."
+        }
+      ],
+      "text": "Pyrotechnics deals 4 damage divided as you choose among any number of target creatures and/or players.",
+      "type": "Sorcery",
+      "types": [
+        "Sorcery"
+      ]
+    },
+    {
+      "artist": "Brian Snõddy",
+      "cmc": 1,
+      "colorIdentity": [
+        "R"
+      ],
+      "colors": [
+        "Red"
+      ],
+      "flavor": "Charging alone takes uncommong daring or uncommon stupidity. Or both.",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "愤怒鬼怪"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "憤怒鬼怪"
+        },
+        {
+          "language": "French",
+          "name": "Gobelin enragé"
+        },
+        {
+          "language": "German",
+          "name": "Wütender Goblin"
+        },
+        {
+          "language": "Italian",
+          "name": "Goblin Furioso"
+        },
+        {
+          "language": "Japanese",
+          "name": "怒り狂うゴブリン"
+        },
+        {
+          "language": "Korean",
+          "name": ""
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Goblin Enfurecido"
+        },
+        {
+          "language": "Russian",
+          "name": "Разъяренный Гоблин"
+        },
+        {
+          "language": "Spanish",
+          "name": "Trasgo furioso"
+        }
+      ],
+      "id": "cca07444e35c8ff76f680d64f77f14ae43597044",
+      "imageName": "raging goblin",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{R}",
+      "mciNumber": "39",
+      "name": "Raging Goblin",
+      "number": "39",
+      "originalText": "Raging Goblin is unaffected by summoning sickness.",
+      "power": "1",
+      "printings": [
+        "POR",
+        "EXO",
+        "PO2",
+        "ATH",
+        "6ED",
+        "S99",
+        "BRB",
+        "BTD",
+        "7ED",
+        "8ED",
+        "9ED",
+        "10E",
+        "EVG",
+        "M10",
+        "DD3_EVG"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Goblin",
+        "Berserker"
+      ],
+      "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
+      "toughness": "1",
+      "type": "Creature — Goblin Berserker",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Douglas Shuler",
+      "colorIdentity": [
+        "R"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "山脉"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "山脈"
+        },
+        {
+          "language": "French",
+          "name": "Montagne"
+        },
+        {
+          "language": "German",
+          "name": "Gebirge"
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna"
+        },
+        {
+          "language": "Japanese",
+          "name": "山"
+        },
+        {
+          "language": "Korean",
+          "name": "산"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Montanha"
+        },
+        {
+          "language": "Russian",
+          "name": "Гора"
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña"
+        }
       ],
       "id": "ff24a26c3723c1095c5535434a9c598fcbb2e790",
       "imageName": "mountain1",
@@ -3257,9 +3580,9 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "40",
       "name": "Mountain",
-      "originalText": "R",
-      "originalType": "Land",
+      "number": "40",
       "printings": [
         "LEA",
         "LEB",
@@ -3359,6 +3682,8 @@
         "KLD",
         "C16",
         "PCA",
+        "DDS",
+        "AKH",
         "CMA",
         "E01",
         "HOU"
@@ -3376,441 +3701,54 @@
       ]
     },
     {
-      "artist": "Mark Tedin",
-      "cmc": 4,
-      "id": "b971d3ee149c95f17447e14a463ad1be77296679",
-      "imageName": "nevinyrral's disk",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{4}",
-      "name": "Nevinyrral's Disk",
-      "originalText": "Nevinyrral's Disk comes into play tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
-      "originalType": "Artifact",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "5ED",
-        "ATH",
-        "MED",
-        "V10",
-        "C13",
-        "VMA",
-        "C14",
-        "EMA",
-        "C16"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2016-06-08",
-          "text": "You don't sacrifice Nevinyrral's Disk to activate its ability. It's destroyed as part of the ability's resolution if it's still on the battlefield. If an effect gives Nevinyrral's Disk indestructible or regenerates it, it stays on the battlefield."
-        }
-      ],
-      "text": "Nevinyrral's Disk enters the battlefield tapped.\n{1}, {T}: Destroy all artifacts, creatures, and enchantments.",
-      "type": "Artifact",
-      "types": [
-        "Artifact"
-      ]
-    },
-    {
-      "artist": "Ruth Thompson",
-      "cmc": 2,
+      "artist": "John Avon",
       "colorIdentity": [
-        "W"
+        "R"
       ],
-      "colors": [
-        "White"
-      ],
-      "flavor": "A shield of light admits no shadow.",
-      "id": "4ffa6535637decf7cb5e819d9de1c8bf33381d12",
-      "imageName": "order of the white shield",
-      "layout": "normal",
-      "legalities": [
+      "foreignNames": [
         {
-          "format": "Commander",
-          "legality": "Legal"
+          "language": "Chinese Simplified",
+          "name": "山脉"
         },
         {
-          "format": "Ice Age Block",
-          "legality": "Legal"
+          "language": "Chinese Traditional",
+          "name": "山脈"
         },
         {
-          "format": "Legacy",
-          "legality": "Legal"
+          "language": "French",
+          "name": "Montagne"
         },
         {
-          "format": "Vintage",
-          "legality": "Legal"
+          "language": "German",
+          "name": "Gebirge"
+        },
+        {
+          "language": "Italian",
+          "name": "Montagna"
+        },
+        {
+          "language": "Japanese",
+          "name": "山"
+        },
+        {
+          "language": "Korean",
+          "name": "산"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Montanha"
+        },
+        {
+          "language": "Russian",
+          "name": "Гора"
+        },
+        {
+          "language": "Spanish",
+          "name": "Montaña"
         }
       ],
-      "manaCost": "{W}{W}",
-      "name": "Order of the White Shield",
-      "originalText": "Protection from black\n{W}: Order of the White Shield gains first strike until end of turn.\n{W}{W}: Order of the White Shield gets +1/+0 until end of turn.",
-      "originalType": "Summon — Knights",
-      "power": "2",
-      "printings": [
-        "ICE",
-        "5ED",
-        "ATH",
-        "ME2"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Human",
-        "Knight"
-      ],
-      "text": "Protection from black\n{W}: Order of the White Shield gains first strike until end of turn.\n{W}{W}: Order of the White Shield gets +1/+0 until end of turn.",
-      "toughness": "1",
-      "type": "Creature — Human Knight",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Jeff Miracola",
-      "cmc": 5,
-      "colorIdentity": [
-        "G"
-      ],
-      "colors": [
-        "Green"
-      ],
-      "flavor": "\"You want to know your enemy? Look at your feet while you trample him.\"\n—Tahngarth of the Weatherlight",
-      "id": "e9cd3811b872791637ac118ad5e03bb7e7ae3525",
-      "imageName": "overrun",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Odyssey Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{2}{G}{G}{G}",
-      "name": "Overrun",
-      "originalText": "All creatures you control get +3/+3 and gain trample until end of turn.",
-      "originalType": "Sorcery",
-      "printings": [
-        "TMP",
-        "ATH",
-        "ODY",
-        "10E",
-        "M10",
-        "DDD",
-        "DPA",
-        "M12",
-        "PC2",
-        "C14",
-        "DD3_GVL",
-        "TPR",
-        "C15",
-        "CN2",
-        "PCA",
-        "CMA"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2009-10-01",
-          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
-        }
-      ],
-      "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
-      "type": "Sorcery",
-      "types": [
-        "Sorcery"
-      ]
-    },
-    {
-      "artist": "Robert Bliss",
-      "cmc": 2,
-      "colorIdentity": [
-        "W"
-      ],
-      "colors": [
-        "White"
-      ],
-      "flavor": "For the first time in his life, Grakk felt a little warm and fuzzy inside.",
-      "id": "1ad4adc861c5455868af1b62417566b61c153bfe",
-      "imageName": "pacifism",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Khans of Tarkir Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Onslaught Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Urza Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{1}{W}",
-      "name": "Pacifism",
-      "originalText": "Enchanted creature cannot attack or block.",
-      "originalType": "Enchant Creature",
-      "printings": [
-        "MIR",
-        "TMP",
-        "USG",
-        "ATH",
-        "6ED",
-        "BRB",
-        "7ED",
-        "ONS",
-        "8ED",
-        "9ED",
-        "10E",
-        "DDC",
-        "M10",
-        "M11",
-        "M12",
-        "M13",
-        "M14",
-        "DD3_DVD",
-        "DTK",
-        "TPR",
-        "EMA"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Aura"
-      ],
-      "text": "Enchant creature\nEnchanted creature can't attack or block.",
-      "type": "Enchantment — Aura",
-      "types": [
-        "Enchantment"
-      ]
-    },
-    {
-      "artist": "Val Mayerik",
-      "cmc": 3,
-      "colorIdentity": [
-        "W"
-      ],
-      "colors": [
-        "White"
-      ],
-      "flavor": "\"The clouds came alive and dove to the earth! Hooves flashed among the dark army, who fled before the spectacle of fury.\"\n—Song of All, canto 211",
-      "id": "b63e0d239581ea09ece76215f1bf6da996e6ea59",
-      "imageName": "pegasus charger",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Urza Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{2}{W}",
-      "name": "Pegasus Charger",
-      "originalText": "Flying, first strike",
-      "originalType": "Summon — Pegasus",
-      "power": "2",
-      "printings": [
-        "USG",
-        "ATH",
-        "9ED"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Pegasus"
-      ],
-      "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nFirst strike (This creature deals combat damage before creatures without first strike.)",
-      "toughness": "1",
-      "type": "Creature — Pegasus",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Mark Zug",
-      "cmc": 2,
-      "colorIdentity": [
-        "W"
-      ],
-      "colors": [
-        "White"
-      ],
-      "id": "9bfcf1894f261aa4a60f554204e95ae390f4b4d2",
-      "imageName": "pegasus stampede",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{1}{W}",
-      "name": "Pegasus Stampede",
-      "originalText": "Buyback—Sacrifice a land. (You may sacrifice a land in addition to any other costs when you play this spell. If you do, put Pegasus Stampede into your hand instead of your graveyard as part of the spell's effect.)\nPut a Pegasus token into play. Treat this token as a 1/1 white creature with flying.",
-      "originalType": "Sorcery",
-      "printings": [
-        "EXO",
-        "ATH",
-        "TPR"
-      ],
-      "rarity": "Special",
-      "text": "Buyback—Sacrifice a land. (You may sacrifice a land in addition to any other costs as you cast this spell. If you do, put this card into your hand as it resolves.)\nCreate a 1/1 white Pegasus creature token with flying.",
-      "type": "Sorcery",
-      "types": [
-        "Sorcery"
-      ]
-    },
-    {
-      "artist": "Bryon Wackwitz",
-      "colorIdentity": [
-        "G"
-      ],
-      "flavor": "\"This is the forest primeval. The murmuring pines and the hemlocks . . . / Stand like Druids of old.\" —Henry Wadsworth Longfellow, \"Evangeline\"",
-      "id": "7bc0d56cc0bafc0f0cbf46f4a41e4bd1373365e9",
-      "imageName": "pendelhaven",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "name": "Pendelhaven",
-      "originalText": "{T}: Add {G} to your mana pool\n{T}: Target 1/1 creature gains +1/+2 until end of turn.",
-      "originalType": "Legendary Land",
-      "printings": [
-        "LEG",
-        "ATH",
-        "pFNM",
-        "TSB"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2004-10-04",
-          "text": "The current power/toughness being 1/1 is a targeting requirement so it is checked when announcing and again right before resolving."
-        }
-      ],
-      "supertypes": [
-        "Legendary"
-      ],
-      "text": "{T}: Add {G} to your mana pool.\n{T}: Target 1/1 creature gets +1/+2 until end of turn.",
-      "type": "Legendary Land",
-      "types": [
-        "Land"
-      ]
-    },
-    {
-      "artist": "Tom Wänerstrand",
-      "colorIdentity": [
-        "W"
-      ],
-      "id": "33ead63bca6d2b297ea52916114f928d279e2e51",
-      "imageName": "plains1",
+      "id": "7e98eb95a3d4aa3fa449b8e9ee059eacbf5b3f4e",
+      "imageName": "mountain2",
       "layout": "normal",
       "legalities": [
         {
@@ -3934,15 +3872,16 @@
           "legality": "Legal"
         }
       ],
-      "name": "Plains",
-      "originalText": "W",
-      "originalType": "Land",
+      "mciNumber": "41",
+      "name": "Mountain",
+      "number": "41",
       "printings": [
         "LEA",
         "LEB",
         "2ED",
         "CED",
         "CEI",
+        "ARN",
         "3ED",
         "4ED",
         "ICE",
@@ -3952,7 +3891,6 @@
         "ITP",
         "5ED",
         "POR",
-        "pPRE",
         "TMP",
         "pJGP",
         "PO2",
@@ -3968,9 +3906,11 @@
         "BRB",
         "pELP",
         "S00",
+        "BTD",
         "INV",
         "7ED",
         "ODY",
+        "DKM",
         "ONS",
         "8ED",
         "MRD",
@@ -3983,9 +3923,10 @@
         "10E",
         "MED",
         "LRW",
+        "EVG",
         "SHM",
         "ALA",
-        "DDC",
+        "DD2",
         "M10",
         "HOP",
         "ME3",
@@ -3993,10 +3934,11 @@
         "H09",
         "DDE",
         "ROE",
+        "DPA",
         "ARC",
         "M11",
-        "DDF",
         "SOM",
+        "PD2",
         "MBS",
         "DDG",
         "NPH",
@@ -4008,871 +3950,44 @@
         "AVR",
         "PC2",
         "M13",
+        "DDJ",
         "RTR",
         "DDK",
         "M14",
         "DDL",
         "THS",
         "C13",
-        "MD1",
         "M15",
         "DDN",
         "KTK",
         "C14",
-        "DD3_DVD",
+        "DD3_EVG",
+        "DD3_JVC",
         "FRF",
-        "DDO",
         "DTK",
         "TPR",
         "ORI",
         "DDP",
         "BFZ",
         "C15",
-        "DDQ",
         "SOI",
         "KLD",
         "C16",
         "PCA",
+        "DDS",
+        "AKH",
         "CMA",
         "E01",
         "HOU"
       ],
       "rarity": "Basic Land",
       "subtypes": [
-        "Plains"
+        "Mountain"
       ],
       "supertypes": [
         "Basic"
       ],
-      "type": "Basic Land — Plains",
-      "types": [
-        "Land"
-      ]
-    },
-    {
-      "artist": "Stephen Daniele",
-      "colorIdentity": [
-        "B"
-      ],
-      "id": "a48c4dc1b4d6aab805ac2036dcb311e3dc2dfabc",
-      "imageName": "polluted mire",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Urza Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "name": "Polluted Mire",
-      "originalText": "Polluted Mire comes into play tapped.\n{T}: Add {B} to your mana pool.\nCycling {2} (You may pay {2} and discard this card from your hand to draw a card. Play this ability as an instant.)",
-      "originalType": "Land",
-      "printings": [
-        "USG",
-        "ATH",
-        "BRB",
-        "BTD",
-        "DDD",
-        "PD3",
-        "C14",
-        "DD3_GVL",
-        "C15",
-        "CMA"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2008-10-01",
-          "text": "Cycling is an activated ability. Effects that interact with activated abilities (such as Stifle or Rings of Brighthearth) will interact with cycling. Effects that interact with spells (such as Remove Soul or Faerie Tauntings) will not."
-        }
-      ],
-      "text": "Polluted Mire enters the battlefield tapped.\n{T}: Add {B} to your mana pool.\nCycling {2} ({2}, Discard this card: Draw a card.)",
-      "type": "Land",
-      "types": [
-        "Land"
-      ]
-    },
-    {
-      "artist": "Ron Spencer",
-      "cmc": 6,
-      "colorIdentity": [
-        "R"
-      ],
-      "colors": [
-        "Red"
-      ],
-      "id": "302233538b6e47d3e35276021a6ff167c7d323a9",
-      "imageName": "pyrokinesis",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Ice Age Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{4}{R}{R}",
-      "name": "Pyrokinesis",
-      "originalText": "You may remove a red card in your hand from the game instead of paying Pyrokinesis's casting cost.\nPyrokinesis deals 4 damage divided any way you choose among any number of target creatures.",
-      "originalType": "Instant",
-      "printings": [
-        "ALL",
-        "ATH",
-        "ME2",
-        "DDL",
-        "EMA"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2016-06-08",
-          "text": "The number of targets must be at least one and at most four. Each target must be assigned at least 1 damage."
-        },
-        {
-          "date": "2016-06-08",
-          "text": "You divide the damage as you cast Pyrokinesis, not as it resolves. If any of the targets become illegal, damage is dealt to the other targets as originally assigned. If all targets are illegal, Pyrokinesis is countered."
-        },
-        {
-          "date": "2016-06-08",
-          "text": "If another effect causes Pyrokinesis to cost more, you must pay that additional cost even if you pay its alternative cost."
-        }
-      ],
-      "text": "You may exile a red card from your hand rather than pay Pyrokinesis's mana cost.\nPyrokinesis deals 4 damage divided as you choose among any number of target creatures.",
-      "type": "Instant",
-      "types": [
-        "Instant"
-      ]
-    },
-    {
-      "artist": "Anson Maddocks",
-      "cmc": 5,
-      "colorIdentity": [
-        "R"
-      ],
-      "colors": [
-        "Red"
-      ],
-      "flavor": "\"Hi! ni! ya! Behold the man of flint, that's me! / Four lightnings zigzag from me, strike and return.\"\n—Navajo war chant",
-      "id": "b1d13718e495f53bb90068006c05081f991f4f9d",
-      "imageName": "pyrotechnics",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Khans of Tarkir Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{4}{R}",
-      "name": "Pyrotechnics",
-      "originalText": "Pyrotechnics deals 4 damage divided any way you choose among any number of target creatures and/or players.",
-      "originalType": "Sorcery",
-      "printings": [
-        "LEG",
-        "4ED",
-        "RQS",
-        "ITP",
-        "5ED",
-        "ATH",
-        "6ED",
-        "7ED",
-        "8ED",
-        "HOP",
-        "FRF"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2014-11-24",
-          "text": "The number of targets chosen for Pyrotechnics must be at least one and at most four. You choose how the damage is divided as you cast the spell, not as it resolves. Each target must be assigned at least 1 damage."
-        },
-        {
-          "date": "2014-11-24",
-          "text": "If some but not all of Pyrotechnics's targets become illegal, you can't change the division of damage. Damage that would have been dealt to illegal targets simply isn't dealt."
-        },
-        {
-          "date": "2014-11-24",
-          "text": "You can't deal damage to both a player and a planeswalker that player controls using Pyrotechnics. You also can't deal damage to more than one planeswalker controlled by the same player. If you choose to redirect the damage being dealt to a player to a planeswalker, you must redirect all the damage to a single planeswalker."
-        },
-        {
-          "date": "2014-11-24",
-          "text": "If an effect creates a copy of Pyrotechnics, the number of targets and division of damage can't be changed. The effect that creates the copy may allow you to change the targets, however."
-        }
-      ],
-      "text": "Pyrotechnics deals 4 damage divided as you choose among any number of target creatures and/or players.",
-      "type": "Sorcery",
-      "types": [
-        "Sorcery"
-      ]
-    },
-    {
-      "artist": "Brian Snõddy",
-      "cmc": 1,
-      "colorIdentity": [
-        "R"
-      ],
-      "colors": [
-        "Red"
-      ],
-      "flavor": "Charging alone takes uncommong daring or uncommon stupidity. Or both.",
-      "id": "cca07444e35c8ff76f680d64f77f14ae43597044",
-      "imageName": "raging goblin",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{R}",
-      "name": "Raging Goblin",
-      "originalText": "Raging Goblin is unaffected by summoning sickness.",
-      "originalType": "Summon — Goblin",
-      "power": "1",
-      "printings": [
-        "POR",
-        "PO2",
-        "EXO",
-        "ATH",
-        "6ED",
-        "S99",
-        "BRB",
-        "BTD",
-        "7ED",
-        "8ED",
-        "9ED",
-        "10E",
-        "EVG",
-        "M10",
-        "DD3_EVG"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Goblin",
-        "Berserker"
-      ],
-      "text": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
-      "toughness": "1",
-      "type": "Creature — Goblin Berserker",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Randy Elliott",
-      "cmc": 3,
-      "colorIdentity": [
-        "W",
-        "G"
-      ],
-      "colors": [
-        "White",
-        "Green"
-      ],
-      "flavor": "\"The path of least resistance will seldom lead you beyond your doorstep.\"\n—Oracle en-Vec",
-      "id": "bf6ba2030aea2352002b445f9a24dc3b4b80927c",
-      "imageName": "ranger en-vec",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Tempest Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{1}{G}{W}",
-      "name": "Ranger en-Vec",
-      "originalText": "First strike\n{G}: Regenerate Ranger en-Vec.",
-      "originalType": "Summon — Soldier",
-      "power": "2",
-      "printings": [
-        "TMP",
-        "ATH"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Human",
-        "Soldier",
-        "Archer"
-      ],
-      "text": "First strike\n{G}: Regenerate Ranger en-Vec.",
-      "toughness": "2",
-      "type": "Creature — Human Soldier Archer",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Margaret Organ-Kean",
-      "cmc": 3,
-      "colorIdentity": [
-        "W"
-      ],
-      "colors": [
-        "White"
-      ],
-      "flavor": "\"Do not go there, do not go / unless you rise on wings, unless you walk on hooves.\"\n—\"Song to the Sun,\" Femeref song",
-      "id": "6e2010e47dedbda40223f699628e328244eef544",
-      "imageName": "sacred mesa",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{2}{W}",
-      "name": "Sacred Mesa",
-      "originalText": "During your upkeep, sacrifice a Pegasus or bury Sacred Mesa.\n{1}{W} Put a Wild Pegasus token into play. Treat this token as a 1/1 white creature with flying that counts as a Pegasus.",
-      "originalType": "Enchantment",
-      "printings": [
-        "MIR",
-        "ATH",
-        "TSB",
-        "C14"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2004-10-04",
-          "text": "It can be used during upkeep to create a Pegasus token in time for it to be sacrificed."
-        }
-      ],
-      "text": "At the beginning of your upkeep, sacrifice Sacred Mesa unless you sacrifice a Pegasus.\n{1}{W}: Create a 1/1 white Pegasus creature token with flying.",
-      "type": "Enchantment",
-      "types": [
-        "Enchantment"
-      ]
-    },
-    {
-      "artist": "Tom Wänerstrand",
-      "cmc": 2,
-      "colorIdentity": [
-        "W"
-      ],
-      "colors": [
-        "White"
-      ],
-      "flavor": "Healers ultimately acquire the divine gifts of spiritual and physical wholeness. The most devout are also granted the ability to pass physical wholeness on to others.",
-      "id": "dcbb40c009f8fc6889bd93d0cb3162bc9974269b",
-      "imageName": "samite healer",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{1}{W}",
-      "name": "Samite Healer",
-      "originalText": "{T}: Prevent 1 damage to a creature or player.",
-      "originalType": "Summon — Cleric",
-      "power": "1",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "5ED",
-        "ATH",
-        "6ED",
-        "S00",
-        "7ED",
-        "8ED",
-        "9ED",
-        "10E"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Human",
-        "Cleric"
-      ],
-      "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
-      "toughness": "1",
-      "type": "Creature — Human Cleric",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Dennis Detwiller",
-      "cmc": 1,
-      "colorIdentity": [
-        "G"
-      ],
-      "colors": [
-        "Green"
-      ],
-      "flavor": "String, weapons, wax, or jewels—it makes no difference. Leave nothing unguarded in Scarwood.",
-      "id": "f526b759713a811bb9de415858f8f9c5c7a5000a",
-      "imageName": "scavenger folk",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{G}",
-      "name": "Scavenger Folk",
-      "originalText": "{G}, {T}, Sacrifice Scavenger Folk: Destroy target artifact.",
-      "originalType": "Summon — Scavenger Folk",
-      "power": "1",
-      "printings": [
-        "DRK",
-        "CHR",
-        "5ED",
-        "ATH",
-        "7ED",
-        "ME4"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Human"
-      ],
-      "text": "{G}, {T}, Sacrifice Scavenger Folk: Destroy target artifact.",
-      "toughness": "1",
-      "type": "Creature — Human",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Douglas Shuler",
-      "cmc": 5,
-      "colorIdentity": [
-        "W"
-      ],
-      "colors": [
-        "White"
-      ],
-      "flavor": "Born with wings of light and a sword of faith, this heavenly incarnation embodies both fury and purity.",
-      "id": "028cde0cf3b0918fda9be942fe8595ee0a236217",
-      "imageName": "serra angel",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Standard",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{3}{W}{W}",
-      "name": "Serra Angel",
-      "originalText": "Flying\nAttacking does not cause Serra Angel to tap.",
-      "originalType": "Summon — Angel",
-      "power": "4",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "ATH",
-        "pWOS",
-        "7ED",
-        "8ED",
-        "9ED",
-        "10E",
-        "DDC",
-        "M10",
-        "M11",
-        "ME4",
-        "CMD",
-        "M12",
-        "M13",
-        "M14",
-        "M15",
-        "DD3_DVD",
-        "ORI",
-        "V15",
-        "W16",
-        "EMA",
-        "CMA"
-      ],
-      "rarity": "Special",
-      "starter": true,
-      "subtypes": [
-        "Angel"
-      ],
-      "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nVigilance (Attacking doesn't cause this creature to tap.)",
-      "toughness": "4",
-      "type": "Creature — Angel",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "David A. Cherry",
-      "cmc": 4,
-      "id": "0efb952a4af5688abc046aa4d41b13dc8573fea7",
-      "imageName": "serrated arrows",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{4}",
-      "name": "Serrated Arrows",
-      "originalText": "Serrated Arrows comes into play with three arrowhead counters on it.\nWhen there are no arrowhead counters on Serrated Arrows, destroy it.\n{T}, Remove an arrowhead counter from Serrated Arrows: Put a -1/-1 counter on target creature.",
-      "originalType": "Artifact",
-      "printings": [
-        "HML",
-        "ATH",
-        "pFNM",
-        "TSB",
-        "DDD",
-        "DD3_GVL"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2008-08-01",
-          "text": "The upkeep trigger checks the number of counters at the start of upkeep, and only goes on the stack if there are no arrowhead counters at that time. It will check again on resolution, and will do nothing if you've somehow manage to get a new arrowhead counter on the Arrows."
-        }
-      ],
-      "text": "Serrated Arrows enters the battlefield with three arrowhead counters on it.\nAt the beginning of your upkeep, if there are no arrowhead counters on Serrated Arrows, sacrifice it.\n{T}, Remove an arrowhead counter from Serrated Arrows: Put a -1/-1 counter on target creature.",
-      "type": "Artifact",
-      "types": [
-        "Artifact"
-      ]
-    },
-    {
-      "artist": "Stephen Daniele",
-      "colorIdentity": [
-        "G"
-      ],
-      "id": "20c2e9b7f685121753a1747baa11df79049f4de4",
-      "imageName": "slippery karst",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Urza Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "name": "Slippery Karst",
-      "originalText": "Slippery Karst comes into play tapped.\n{T}: Add {G} to your mana pool.\nCycling {2} (You may pay {2} and discard this card from your hand to draw a card. Play this ability as an instant.)",
-      "originalType": "Land",
-      "printings": [
-        "USG",
-        "ATH",
-        "BRB",
-        "BTD",
-        "DDD",
-        "C13",
-        "C14",
-        "DD3_GVL",
-        "C15",
-        "CMA"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2008-10-01",
-          "text": "Cycling is an activated ability. Effects that interact with activated abilities (such as Stifle or Rings of Brighthearth) will interact with cycling. Effects that interact with spells (such as Remove Soul or Faerie Tauntings) will not."
-        }
-      ],
-      "text": "Slippery Karst enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\nCycling {2} ({2}, Discard this card: Draw a card.)",
-      "type": "Land",
-      "types": [
-        "Land"
-      ]
-    },
-    {
-      "artist": "Mark Tedin",
-      "colorIdentity": [
-        "R"
-      ],
-      "id": "1b8cd48b740a6cbd2f33549995f9589d45b74696",
-      "imageName": "smoldering crater",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Urza Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "name": "Smoldering Crater",
-      "originalText": "Smoldering Crater comes into play tapped.\n{T}: Add {R} to your mana pool.\nCycling {2} (You may pay {2} and discard this card from your hand to draw a card. Play this ability as an instant.)",
-      "originalType": "Land",
-      "printings": [
-        "USG",
-        "ATH",
-        "BTD",
-        "C13",
-        "C14",
-        "C15"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2008-10-01",
-          "text": "Cycling is an activated ability. Effects that interact with activated abilities (such as Stifle or Rings of Brighthearth) will interact with cycling. Effects that interact with spells (such as Remove Soul or Faerie Tauntings) will not."
-        }
-      ],
-      "text": "Smoldering Crater enters the battlefield tapped.\n{T}: Add {R} to your mana pool.\nCycling {2} ({2}, Discard this card: Draw a card.)",
-      "type": "Land",
-      "types": [
-        "Land"
-      ]
-    },
-    {
-      "artist": "Pat Morrissey",
-      "cmc": 2,
-      "colorIdentity": [
-        "G"
-      ],
-      "colors": [
-        "Green"
-      ],
-      "flavor": "\"I hear there are Bears—or spirits—that guard caravans passing through the forest.\" —Gulsen, Abbey Matron",
-      "id": "a486bff3a68518362f42e4857c20e69493e8841a",
-      "imageName": "spectral bears",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{1}{G}",
-      "name": "Spectral Bears",
-      "originalText": "When Spectral Bears attacks, if defending player controls no black cards, Spectral Bears does not untap during your next untap phase.",
-      "originalType": "Summon — Bears",
-      "power": "3",
-      "printings": [
-        "HML",
-        "ATH",
-        "MED"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2008-08-01",
-          "text": "The checks for black cards is made both at the time you declare attackers and as the ability resolves. If there are any at the time attackers are declared, it won't trigger at all. If there are any at the time it resolves, the ability will do nothing."
-        }
-      ],
-      "subtypes": [
-        "Bear",
-        "Spirit"
-      ],
-      "text": "Whenever Spectral Bears attacks, if defending player controls no black nontoken permanents, it doesn't untap during your next untap step.",
-      "toughness": "3",
-      "type": "Creature — Bear Spirit",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Daniel Gelon",
-      "flavor": "Unlike previous conflicts, the war between Urza and Mishra made Dominia itself a casualty of war.",
-      "id": "008fdf3572fc32d718f21af1e75c6d0c7c093298",
-      "imageName": "strip mine",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Banned"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Restricted"
-        }
-      ],
-      "name": "Strip Mine",
-      "originalText": "{T}: Add one colors mana to your mana pool.\n{T}, Sacrifice Strip Mine: Destroy target land.",
-      "originalType": "Land",
-      "printings": [
-        "ATQ",
-        "4ED",
-        "ATH",
-        "V09",
-        "ME4",
-        "VMA",
-        "EXP"
-      ],
-      "rarity": "Special",
-      "text": "{T}: Add {C} to your mana pool.\n{T}, Sacrifice Strip Mine: Destroy target land.",
-      "type": "Land",
+      "type": "Basic Land — Mountain",
       "types": [
         "Land"
       ]
@@ -4881,6 +3996,48 @@
       "artist": "Douglas Shuler",
       "colorIdentity": [
         "B"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "沼泽"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "沼澤"
+        },
+        {
+          "language": "French",
+          "name": "Marais"
+        },
+        {
+          "language": "German",
+          "name": "Sumpf"
+        },
+        {
+          "language": "Italian",
+          "name": "Palude"
+        },
+        {
+          "language": "Japanese",
+          "name": "沼"
+        },
+        {
+          "language": "Korean",
+          "name": "늪"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Pântano"
+        },
+        {
+          "language": "Russian",
+          "name": "Болото"
+        },
+        {
+          "language": "Spanish",
+          "name": "Pantano"
+        }
       ],
       "id": "32759c67e1623df7f6a4607486ff10dae5266190",
       "imageName": "swamp1",
@@ -5007,9 +4164,9 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "42",
       "name": "Swamp",
-      "originalText": "{T}: Add {B} to your mana pool.",
-      "originalType": "Land",
+      "number": "42",
       "printings": [
         "LEA",
         "LEB",
@@ -5109,6 +4266,7 @@
         "KLD",
         "C16",
         "PCA",
+        "AKH",
         "CMA",
         "E01",
         "HOU"
@@ -5126,6 +4284,1590 @@
       ]
     },
     {
+      "artist": "Brom",
+      "colorIdentity": [
+        "B"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "沼泽"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "沼澤"
+        },
+        {
+          "language": "French",
+          "name": "Marais"
+        },
+        {
+          "language": "German",
+          "name": "Sumpf"
+        },
+        {
+          "language": "Italian",
+          "name": "Palude"
+        },
+        {
+          "language": "Japanese",
+          "name": "沼"
+        },
+        {
+          "language": "Korean",
+          "name": "늪"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Pântano"
+        },
+        {
+          "language": "Russian",
+          "name": "Болото"
+        },
+        {
+          "language": "Spanish",
+          "name": "Pantano"
+        }
+      ],
+      "id": "0252812cd64b66066af12f3991592219d87bc9a0",
+      "imageName": "swamp2",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Battle for Zendikar Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Invasion Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kaladesh Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kamigawa Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Khans of Tarkir Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Lorwyn-Shadowmoor Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Masques Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Onslaught Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Return to Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Scars of Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shadows over Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Theros Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Time Spiral Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Un-Sets",
+          "legality": "Legal"
+        },
+        {
+          "format": "Urza Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        },
+        {
+          "format": "Zendikar Block",
+          "legality": "Legal"
+        }
+      ],
+      "mciNumber": "43",
+      "name": "Swamp",
+      "number": "43",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "ICE",
+        "RQS",
+        "pARL",
+        "MIR",
+        "ITP",
+        "5ED",
+        "POR",
+        "TMP",
+        "pJGP",
+        "PO2",
+        "UGL",
+        "pALP",
+        "USG",
+        "ATH",
+        "6ED",
+        "PTK",
+        "pGRU",
+        "S99",
+        "MMQ",
+        "BRB",
+        "pELP",
+        "S00",
+        "BTD",
+        "INV",
+        "7ED",
+        "ODY",
+        "DKM",
+        "ONS",
+        "8ED",
+        "MRD",
+        "CHK",
+        "UNH",
+        "9ED",
+        "RAV",
+        "CST",
+        "TSP",
+        "10E",
+        "MED",
+        "LRW",
+        "SHM",
+        "ALA",
+        "DDC",
+        "M10",
+        "HOP",
+        "ME3",
+        "ZEN",
+        "DDD",
+        "H09",
+        "DDE",
+        "ROE",
+        "DPA",
+        "ARC",
+        "M11",
+        "SOM",
+        "MBS",
+        "NPH",
+        "CMD",
+        "M12",
+        "DDH",
+        "ISD",
+        "PD3",
+        "AVR",
+        "PC2",
+        "M13",
+        "DDJ",
+        "RTR",
+        "DDK",
+        "M14",
+        "THS",
+        "C13",
+        "DDM",
+        "MD1",
+        "M15",
+        "DDN",
+        "KTK",
+        "C14",
+        "DD3_DVD",
+        "DD3_GVL",
+        "FRF",
+        "DTK",
+        "TPR",
+        "ORI",
+        "DDP",
+        "BFZ",
+        "C15",
+        "DDQ",
+        "SOI",
+        "DDR",
+        "KLD",
+        "C16",
+        "PCA",
+        "AKH",
+        "CMA",
+        "E01",
+        "HOU"
+      ],
+      "rarity": "Basic Land",
+      "subtypes": [
+        "Swamp"
+      ],
+      "supertypes": [
+        "Basic"
+      ],
+      "type": "Basic Land — Swamp",
+      "types": [
+        "Land"
+      ]
+    },
+    {
+      "artist": "Bryon Wackwitz",
+      "colorIdentity": [
+        "G",
+        "W"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "矮丛林地"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "矮叢林地"
+        },
+        {
+          "language": "French",
+          "name": "Broussaille"
+        },
+        {
+          "language": "German",
+          "name": "Gestrüppland"
+        },
+        {
+          "language": "Italian",
+          "name": "Boscaglia"
+        },
+        {
+          "language": "Japanese",
+          "name": "低木林地"
+        },
+        {
+          "language": "Korean",
+          "name": ""
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Macegal"
+        },
+        {
+          "language": "Russian",
+          "name": "Пустырь"
+        },
+        {
+          "language": "Spanish",
+          "name": "Matorrales"
+        }
+      ],
+      "id": "3fdf73405ffac1b00861be1eeafa21996350d325",
+      "imageName": "brushland",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "mciNumber": "44",
+      "name": "Brushland",
+      "number": "44",
+      "printings": [
+        "ICE",
+        "5ED",
+        "ATH",
+        "6ED",
+        "7ED",
+        "9ED",
+        "10E"
+      ],
+      "rarity": "Special",
+      "text": "{T}: Add {C} to your mana pool.\n{T}: Add {G} or {W} to your mana pool. Brushland deals 1 damage to you.",
+      "type": "Land",
+      "types": [
+        "Land"
+      ]
+    },
+    {
+      "artist": "Daren Bader",
+      "cmc": 3,
+      "colorIdentity": [
+        "G"
+      ],
+      "colors": [
+        "Green"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "猫战士米丽"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "貓戰士米麗"
+        },
+        {
+          "language": "French",
+          "name": "Mirri, guerrière chat"
+        },
+        {
+          "language": "German",
+          "name": "Mirri die Katzenkriegerin"
+        },
+        {
+          "language": "Italian",
+          "name": "Mirri, Gatta Guerriera"
+        },
+        {
+          "language": "Japanese",
+          "name": "猫族の戦士ミリー"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Mirri, Felina Guerreira"
+        },
+        {
+          "language": "Russian",
+          "name": "Мирри, Кошка-Воин"
+        },
+        {
+          "language": "Spanish",
+          "name": "Mirri, guerrera felina"
+        }
+      ],
+      "id": "1dcbbc15027b27b8e504f8e9013ff2cef8aca528",
+      "imageName": "mirri, cat warrior",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{1}{G}{G}",
+      "mciNumber": "45",
+      "name": "Mirri, Cat Warrior",
+      "number": "45",
+      "power": "2",
+      "printings": [
+        "EXO",
+        "ATH",
+        "10E",
+        "TPR"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Cat",
+        "Warrior"
+      ],
+      "supertypes": [
+        "Legendary"
+      ],
+      "text": "First strike, forestwalk, vigilance (This creature deals combat damage before creatures without first strike, it can't be blocked as long as defending player controls a Forest, and attacking doesn't cause this creature to tap.)",
+      "toughness": "3",
+      "type": "Legendary Creature — Cat Warrior",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Jesper Myrfors",
+      "cmc": 4,
+      "colorIdentity": [
+        "W"
+      ],
+      "colors": [
+        "White"
+      ],
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Armaguedon"
+        },
+        {
+          "language": "German",
+          "name": "Götterdämmerung"
+        },
+        {
+          "language": "Italian",
+          "name": "Armageddon"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Armagedom"
+        },
+        {
+          "language": "Spanish",
+          "name": "Armagedón"
+        }
+      ],
+      "id": "6a29a2efea9e63ceed0dc497a14b012fdccda778",
+      "imageName": "armageddon",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{3}{W}",
+      "mciNumber": "46",
+      "name": "Armageddon",
+      "number": "46",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "5ED",
+        "POR",
+        "pJGP",
+        "PO2",
+        "ATH",
+        "6ED",
+        "S99",
+        "MED",
+        "ME4",
+        "VMA",
+        "V14",
+        "MPS_AKH"
+      ],
+      "rarity": "Special",
+      "text": "Destroy all lands.",
+      "type": "Sorcery",
+      "types": [
+        "Sorcery"
+      ]
+    },
+    {
+      "artist": "Margaret Organ-Kean",
+      "cmc": 3,
+      "colorIdentity": [
+        "W"
+      ],
+      "colors": [
+        "White"
+      ],
+      "flavor": "\"Do not go there, do not go/ unless you rise on wings, unless you walk on hooves.\"\n—'Song to the Sun,' Femeref song",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "圣洁台地"
+        },
+        {
+          "language": "French",
+          "name": "Mesa sacrée"
+        },
+        {
+          "language": "German",
+          "name": "Heiliger Tafelberg"
+        },
+        {
+          "language": "Italian",
+          "name": "Mesa Inviolabile"
+        },
+        {
+          "language": "Japanese",
+          "name": "聖なるメサ"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Meseta Sagrada"
+        },
+        {
+          "language": "Russian",
+          "name": "Священная Гора"
+        },
+        {
+          "language": "Spanish",
+          "name": "Meseta sagrada"
+        }
+      ],
+      "id": "6e2010e47dedbda40223f699628e328244eef544",
+      "imageName": "sacred mesa",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Time Spiral Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{2}{W}",
+      "mciNumber": "47",
+      "name": "Sacred Mesa",
+      "number": "47",
+      "printings": [
+        "MIR",
+        "ATH",
+        "TSB",
+        "C14"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2004-10-04",
+          "text": "It can be used during upkeep to create a Pegasus token in time for it to be sacrificed."
+        }
+      ],
+      "text": "At the beginning of your upkeep, sacrifice Sacred Mesa unless you sacrifice a Pegasus.\n{1}{W}: Create a 1/1 white Pegasus creature token with flying.",
+      "type": "Enchantment",
+      "types": [
+        "Enchantment"
+      ]
+    },
+    {
+      "artist": "Bryon Wackwitz",
+      "colorIdentity": [
+        "G"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "潘得庇护地"
+        },
+        {
+          "language": "French",
+          "name": "Pendelhavre"
+        },
+        {
+          "language": "German",
+          "name": "Pendelhaven"
+        },
+        {
+          "language": "Italian",
+          "name": "Pendelhaven"
+        },
+        {
+          "language": "Japanese",
+          "name": "ペンデルヘイヴン"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Pendelhaven"
+        },
+        {
+          "language": "Russian",
+          "name": "Пенделхейвен"
+        },
+        {
+          "language": "Spanish",
+          "name": "Pendelhaven"
+        }
+      ],
+      "id": "7bc0d56cc0bafc0f0cbf46f4a41e4bd1373365e9",
+      "imageName": "pendelhaven",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Time Spiral Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "mciNumber": "48",
+      "name": "Pendelhaven",
+      "number": "48",
+      "printings": [
+        "LEG",
+        "ATH",
+        "pFNM",
+        "TSB"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2004-10-04",
+          "text": "The current power/toughness being 1/1 is a targeting requirement so it is checked when announcing and again right before resolving."
+        }
+      ],
+      "supertypes": [
+        "Legendary"
+      ],
+      "text": "{T}: Add {G} to your mana pool.\n{T}: Target 1/1 creature gets +1/+2 until end of turn.",
+      "type": "Legendary Land",
+      "types": [
+        "Land"
+      ]
+    },
+    {
+      "artist": "Tom Wänerstrand",
+      "cmc": 3,
+      "flavor": "This timeworn relic was responsible for many of Urza's victories, though he never fully comprehended its mystical runes.",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "贾伦的钜著"
+        },
+        {
+          "language": "French",
+          "name": "Grimoire de Jalum"
+        },
+        {
+          "language": "German",
+          "name": "Calums Zauberbuch"
+        },
+        {
+          "language": "Italian",
+          "name": "Tomo di Jalum"
+        },
+        {
+          "language": "Japanese",
+          "name": "ジェイラム秘本"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Livro de Jalum"
+        },
+        {
+          "language": "Spanish",
+          "name": "Volumen de Jalum"
+        }
+      ],
+      "id": "8f2b260d11249ec2442ca6c0be5c5784355bb3c2",
+      "imageName": "jalum tome",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{3}",
+      "mciNumber": "49",
+      "name": "Jalum Tome",
+      "number": "49",
+      "originalText": "{2}, {T}: Draw a card, then choose and discard a card.",
+      "printings": [
+        "ATQ",
+        "CHR",
+        "5ED",
+        "ATH",
+        "6ED",
+        "7ED",
+        "C14"
+      ],
+      "rarity": "Special",
+      "text": "{2}, {T}: Draw a card, then discard a card.",
+      "type": "Artifact",
+      "types": [
+        "Artifact"
+      ]
+    },
+    {
+      "artist": "Randy Elliott",
+      "cmc": 3,
+      "colorIdentity": [
+        "W",
+        "G"
+      ],
+      "colors": [
+        "White",
+        "Green"
+      ],
+      "flavor": "\"The path of least resistance will seldom lead you beyond your doorstep.\" -Oracle en-Vec",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Ranger en-Vec"
+        },
+        {
+          "language": "German",
+          "name": "Waldläufer en-Vec"
+        },
+        {
+          "language": "Italian",
+          "name": "Ranger en-Vec"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Patrulheiro en-Vec"
+        },
+        {
+          "language": "Spanish",
+          "name": "Guardabosque en-Vec"
+        }
+      ],
+      "id": "bf6ba2030aea2352002b445f9a24dc3b4b80927c",
+      "imageName": "ranger en-vec",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{1}{G}{W}",
+      "mciNumber": "50",
+      "name": "Ranger en-Vec",
+      "number": "50",
+      "power": "2",
+      "printings": [
+        "TMP",
+        "ATH"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Human",
+        "Soldier",
+        "Archer"
+      ],
+      "text": "First strike\n{G}: Regenerate Ranger en-Vec.",
+      "toughness": "2",
+      "type": "Creature — Human Soldier Archer",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Ken Meyer, Jr.",
+      "cmc": 4,
+      "colorIdentity": [
+        "G"
+      ],
+      "colors": [
+        "Green"
+      ],
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Djinn erhnamite"
+        },
+        {
+          "language": "German",
+          "name": "Erhnam-Dschinn"
+        },
+        {
+          "language": "Italian",
+          "name": "Genio di Erhnam"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Gênio Erhnam"
+        },
+        {
+          "language": "Spanish",
+          "name": "Djinn Érhnam"
+        }
+      ],
+      "id": "4fdd63969d85dee4a2cd84c1ed5399fcebe237af",
+      "imageName": "erhnam djinn",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{3}{G}",
+      "mciNumber": "51",
+      "name": "Erhnam Djinn",
+      "number": "51",
+      "originalText": "During your upkeep, target non-Wall creature an opponent controls gains forestwalk until your next turn. (If defending player controls a forest, that creature is unblockable.)",
+      "power": "4",
+      "printings": [
+        "ARN",
+        "CHR",
+        "ATH",
+        "BTD",
+        "JUD",
+        "VMA"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2004-10-04",
+          "text": "In multiplayer games you can choose a different player's creature each upkeep. You are forced to pick a creature that some opponent controls if there is at least one creature on the battlefield that is a legal target."
+        },
+        {
+          "date": "2004-10-04",
+          "text": "If you have more than one Djinn, you can have all of them target the same creature with their ability."
+        },
+        {
+          "date": "2004-10-04",
+          "text": "If there are no creatures your opponent controls to target at the beginning of your upkeep, ignore this ability."
+        }
+      ],
+      "subtypes": [
+        "Djinn"
+      ],
+      "text": "At the beginning of your upkeep, target non-Wall creature an opponent controls gains forestwalk until your next upkeep. (It can't be blocked as long as defending player controls a Forest.)",
+      "toughness": "5",
+      "type": "Creature — Djinn",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Cornelius Brudi",
+      "cmc": 1,
+      "colorIdentity": [
+        "G"
+      ],
+      "colors": [
+        "Green"
+      ],
+      "flavor": "\"The raging winds..., settling on the sea, the surges, the sweep,/ Raise liquid mountains, and disclose the deep.\"\n—Virgil, Aeneid, Book I, trans. Dryden",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "飓风"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "颶風"
+        },
+        {
+          "language": "French",
+          "name": "Ouragan"
+        },
+        {
+          "language": "German",
+          "name": "Hurrikan"
+        },
+        {
+          "language": "Italian",
+          "name": "Uragano"
+        },
+        {
+          "language": "Japanese",
+          "name": "ハリケーン"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Furacão"
+        },
+        {
+          "language": "Russian",
+          "name": "Ураган"
+        },
+        {
+          "language": "Spanish",
+          "name": "Huracán"
+        }
+      ],
+      "id": "e0c9cfa6a7b1a566b3ee453f502e08ff0232cc55",
+      "imageName": "hurricane",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{X}{G}",
+      "mciNumber": "52",
+      "name": "Hurricane",
+      "number": "52",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "ICE",
+        "5ED",
+        "POR",
+        "PO2",
+        "ATH",
+        "6ED",
+        "BRB",
+        "7ED",
+        "DKM",
+        "10E"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2004-10-04",
+          "text": "Whether or not a creature has flying is only checked on resolution."
+        }
+      ],
+      "text": "Hurricane deals X damage to each creature with flying and each player.",
+      "type": "Sorcery",
+      "types": [
+        "Sorcery"
+      ]
+    },
+    {
+      "artist": "Pat Morrissey",
+      "cmc": 2,
+      "colorIdentity": [
+        "G"
+      ],
+      "colors": [
+        "Green"
+      ],
+      "flavor": "\"I hear there are Bears-or spirits-that guard caravans passing through the forest\"\n—Gulsen, abbey matron",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Ours spectraux"
+        },
+        {
+          "language": "German",
+          "name": "Gespenstische Bären"
+        },
+        {
+          "language": "Italian",
+          "name": "Orsi Spettrali"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Ursos Espectrais"
+        },
+        {
+          "language": "Spanish",
+          "name": "Osos espectrales"
+        }
+      ],
+      "id": "a486bff3a68518362f42e4857c20e69493e8841a",
+      "imageName": "spectral bears",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{1}{G}",
+      "mciNumber": "53",
+      "name": "Spectral Bears",
+      "number": "53",
+      "originalText": "When Spectral Bears attacks, if defending player controls no black cards, Spectral Bears does not untap during your next untap phase.",
+      "power": "3",
+      "printings": [
+        "HML",
+        "ATH",
+        "MED"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2008-08-01",
+          "text": "The checks for black cards is made both at the time you declare attackers and as the ability resolves. If there are any at the time attackers are declared, it won't trigger at all. If there are any at the time it resolves, the ability will do nothing."
+        }
+      ],
+      "subtypes": [
+        "Bear",
+        "Spirit"
+      ],
+      "text": "Whenever Spectral Bears attacks, if defending player controls no black nontoken permanents, it doesn't untap during your next untap step.",
+      "toughness": "3",
+      "type": "Creature — Bear Spirit",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Jeff Miracola",
+      "cmc": 5,
+      "colorIdentity": [
+        "G"
+      ],
+      "colors": [
+        "Green"
+      ],
+      "flavor": "\"You want to know your eemy? Look at your feet while you trample him.\"\n—Tahngarth of the Weatherlight",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "横行"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "橫行"
+        },
+        {
+          "language": "French",
+          "name": "Envahissement"
+        },
+        {
+          "language": "German",
+          "name": "Überrennen"
+        },
+        {
+          "language": "Italian",
+          "name": "Sopraffare"
+        },
+        {
+          "language": "Japanese",
+          "name": "踏み荒らし"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Ultrapassar"
+        },
+        {
+          "language": "Russian",
+          "name": "Набег"
+        },
+        {
+          "language": "Spanish",
+          "name": "Sobrepasar"
+        }
+      ],
+      "id": "e9cd3811b872791637ac118ad5e03bb7e7ae3525",
+      "imageName": "overrun",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{2}{G}{G}{G}",
+      "mciNumber": "54",
+      "name": "Overrun",
+      "number": "54",
+      "printings": [
+        "TMP",
+        "ATH",
+        "ODY",
+        "10E",
+        "M10",
+        "DDD",
+        "DPA",
+        "M12",
+        "PC2",
+        "C14",
+        "DD3_GVL",
+        "TPR",
+        "C15",
+        "CN2",
+        "PCA",
+        "CMA"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2009-10-01",
+          "text": "Overrun affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
+        }
+      ],
+      "text": "Creatures you control get +3/+3 and gain trample until end of turn.",
+      "type": "Sorcery",
+      "types": [
+        "Sorcery"
+      ]
+    },
+    {
+      "artist": "Ruth Thompson",
+      "cmc": 2,
+      "colorIdentity": [
+        "W"
+      ],
+      "colors": [
+        "White"
+      ],
+      "flavor": "A shield of light admits no shadow.",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Ordre du bouclier blanc"
+        },
+        {
+          "language": "German",
+          "name": "Orden des Weißen Schildes"
+        },
+        {
+          "language": "Italian",
+          "name": "Ordine dello Scudo Bianco"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Ordem do Escudo Branco"
+        },
+        {
+          "language": "Spanish",
+          "name": "Orden del Escudo Blanco"
+        }
+      ],
+      "id": "4ffa6535637decf7cb5e819d9de1c8bf33381d12",
+      "imageName": "order of the white shield",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{W}{W}",
+      "mciNumber": "55",
+      "name": "Order of the White Shield",
+      "number": "55",
+      "originalText": "Protection from black\n{W}: Order of the White Shield gains first strike until end of turn.\n{W}{W}: Order of the White Shield gets +1/+0 until end of turn.",
+      "power": "2",
+      "printings": [
+        "ICE",
+        "5ED",
+        "ATH",
+        "ME2"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Human",
+        "Knight"
+      ],
+      "text": "Protection from black\n{W}: Order of the White Shield gains first strike until end of turn.\n{W}{W}: Order of the White Shield gets +1/+0 until end of turn.",
+      "toughness": "1",
+      "type": "Creature — Human Knight",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Val Mayerik",
+      "cmc": 3,
+      "colorIdentity": [
+        "W"
+      ],
+      "colors": [
+        "White"
+      ],
+      "flavor": "\"The clouds came alive and dove to the earth! Hooves flashed among the dark army, who fled before the spectacle of fury.\"\n—Song of All, canto 211",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "冲锋飞马"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": ""
+        },
+        {
+          "language": "French",
+          "name": "Pégase de bataille"
+        },
+        {
+          "language": "German",
+          "name": "Anstürmender Pegasus"
+        },
+        {
+          "language": "Italian",
+          "name": "Pegaso Destriero"
+        },
+        {
+          "language": "Japanese",
+          "name": "突撃ペガサス"
+        },
+        {
+          "language": "Korean",
+          "name": ""
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Pégaso Atacante"
+        },
+        {
+          "language": "Russian",
+          "name": "Боевой пегас"
+        },
+        {
+          "language": "Spanish",
+          "name": "Pegaso de batalla"
+        }
+      ],
+      "id": "b63e0d239581ea09ece76215f1bf6da996e6ea59",
+      "imageName": "pegasus charger",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Urza Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{2}{W}",
+      "mciNumber": "56",
+      "name": "Pegasus Charger",
+      "number": "56",
+      "power": "2",
+      "printings": [
+        "USG",
+        "ATH",
+        "9ED"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Pegasus"
+      ],
+      "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nFirst strike (This creature deals combat damage before creatures without first strike.)",
+      "toughness": "1",
+      "type": "Creature — Pegasus",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Douglas Shuler",
+      "cmc": 5,
+      "colorIdentity": [
+        "W"
+      ],
+      "colors": [
+        "White"
+      ],
+      "flavor": "Born with wings of light and a sword of faith, this heavenly incarnation embodies both fury and purity.",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "撒拉天使"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "撒拉天使"
+        },
+        {
+          "language": "French",
+          "name": "Ange de Serra"
+        },
+        {
+          "language": "German",
+          "name": "Serra-Engel"
+        },
+        {
+          "language": "Italian",
+          "name": "Angelo di Serra"
+        },
+        {
+          "language": "Japanese",
+          "name": "セラの天使"
+        },
+        {
+          "language": "Korean",
+          "name": "세라 천사"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Anjo Serra"
+        },
+        {
+          "language": "Russian",
+          "name": "Ангел Серры"
+        },
+        {
+          "language": "Spanish",
+          "name": "Ángel de Serra"
+        }
+      ],
+      "id": "028cde0cf3b0918fda9be942fe8595ee0a236217",
+      "imageName": "serra angel",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{3}{W}{W}",
+      "mciNumber": "57",
+      "name": "Serra Angel",
+      "number": "57",
+      "power": "4",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "ATH",
+        "pWOS",
+        "7ED",
+        "8ED",
+        "9ED",
+        "10E",
+        "DDC",
+        "M10",
+        "M11",
+        "ME4",
+        "CMD",
+        "M12",
+        "M13",
+        "M14",
+        "M15",
+        "DD3_DVD",
+        "ORI",
+        "V15",
+        "W16",
+        "EMA",
+        "W17",
+        "CMA"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Angel"
+      ],
+      "text": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nVigilance (Attacking doesn't cause this creature to tap.)",
+      "toughness": "4",
+      "type": "Creature — Angel",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
       "artist": "Jeff A. Menges",
       "cmc": 1,
       "colorIdentity": [
@@ -5133,6 +5875,36 @@
       ],
       "colors": [
         "White"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "化剑为犁"
+        },
+        {
+          "language": "French",
+          "name": "Retour au pays"
+        },
+        {
+          "language": "German",
+          "name": "Schwerter zu Pflugscharen"
+        },
+        {
+          "language": "Italian",
+          "name": "Da Spade a Spighe!"
+        },
+        {
+          "language": "Japanese",
+          "name": "剣を鍬に"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Espadas em Arados"
+        },
+        {
+          "language": "Spanish",
+          "name": "Espadas en guadañas"
+        }
       ],
       "id": "24ff6f95e98777c55b5bc45202dc137b3f5815f1",
       "imageName": "swords to plowshares",
@@ -5156,9 +5928,10 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "58",
       "name": "Swords to Plowshares",
+      "number": "58",
       "originalText": "Remove target creature from the game. That creature's controller gains life equal to its power.",
-      "originalType": "Instant",
       "printings": [
         "LEA",
         "LEB",
@@ -5200,319 +5973,6 @@
       ]
     },
     {
-      "artist": "Ron Spencer",
-      "cmc": 2,
-      "colorIdentity": [
-        "B"
-      ],
-      "colors": [
-        "Black"
-      ],
-      "id": "fdb47d0e4b7b67ee3b55bb770501c34b95ff7c5c",
-      "imageName": "terror",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirrodin Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{1}{B}",
-      "name": "Terror",
-      "originalText": "Destroy target nonartifact, nonblack creature. That creature cannot be regenerated this turn.",
-      "originalType": "Instant",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "RQS",
-        "ITP",
-        "5ED",
-        "ATH",
-        "6ED",
-        "BRB",
-        "pFNM",
-        "S00",
-        "BTD",
-        "pMPR",
-        "MRD",
-        "10E",
-        "DPA",
-        "ME4"
-      ],
-      "rarity": "Special",
-      "text": "Destroy target nonartifact, nonblack creature. It can't be regenerated.",
-      "type": "Instant",
-      "types": [
-        "Instant"
-      ]
-    },
-    {
-      "artist": "Douglas Shuler",
-      "cmc": 1,
-      "colorIdentity": [
-        "B"
-      ],
-      "colors": [
-        "Black"
-      ],
-      "id": "8044ac11fcdab08c8689eb035606468a0f45937f",
-      "imageName": "unholy strength",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{B}",
-      "name": "Unholy Strength",
-      "originalText": "Enchanted creature gets +2/+1.",
-      "originalType": "Enchant Creature",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "5ED",
-        "ATH",
-        "7ED",
-        "8ED",
-        "9ED",
-        "10E",
-        "DDC",
-        "M10",
-        "DPA",
-        "M11",
-        "DD3_DVD"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Aura"
-      ],
-      "text": "Enchant creature\nEnchanted creature gets +2/+1.",
-      "type": "Enchantment — Aura",
-      "types": [
-        "Enchantment"
-      ]
-    },
-    {
-      "artist": "Douglas Shuler",
-      "cmc": 3,
-      "colorIdentity": [
-        "R"
-      ],
-      "colors": [
-        "Red"
-      ],
-      "flavor": "\"Oi oi oi, me gotta hurt in 'ere,\nOi oi oi, me smell a ting is near,\nGonna bosh 'n gonna nosh\n'n da hurt'll disappear.\"\n—Troll chant",
-      "id": "6602c8c42e157da105ebd0d1949309d98285f3bf",
-      "imageName": "uthden troll",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Time Spiral Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{2}{R}",
-      "name": "Uthden Troll",
-      "originalText": "{R}: Regenerate Uthden Troll.",
-      "originalType": "Summon — Troll",
-      "power": "2",
-      "printings": [
-        "LEA",
-        "LEB",
-        "2ED",
-        "CED",
-        "CEI",
-        "3ED",
-        "4ED",
-        "ATH",
-        "BRB",
-        "TSB"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Troll"
-      ],
-      "text": "{R}: Regenerate Uthden Troll.",
-      "toughness": "2",
-      "type": "Creature — Troll",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "Janine Johnston",
-      "cmc": 6,
-      "colorIdentity": [
-        "R"
-      ],
-      "colors": [
-        "Red"
-      ],
-      "flavor": "Speed and fire are always a deadly combination.",
-      "id": "e14234e2aaa3c887f9a783ab993fb2468e7e42ab",
-      "imageName": "volcanic dragon",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{4}{R}{R}",
-      "name": "Volcanic Dragon",
-      "originalText": "Flying\nVolcanic Dragon is unaffected by summoning sickness.",
-      "originalType": "Creature — Dragon",
-      "power": "4",
-      "printings": [
-        "MIR",
-        "POR",
-        "ATH",
-        "6ED",
-        "S99",
-        "M12"
-      ],
-      "rarity": "Special",
-      "subtypes": [
-        "Dragon"
-      ],
-      "text": "Flying\nHaste (This creature can attack and {T} as soon as it comes under your control.)",
-      "toughness": "4",
-      "type": "Creature — Dragon",
-      "types": [
-        "Creature"
-      ]
-    },
-    {
-      "artist": "D. Alexander Gregory",
-      "cmc": 3,
-      "colorIdentity": [
-        "W"
-      ],
-      "colors": [
-        "White"
-      ],
-      "flavor": "\"We are to be bound together as the reeds of a basket.\"\n—Asmira, Rashida, and Jabari, unity chant",
-      "id": "794037c9f37b19b1c0ea47f3a570f760d1fcd4fa",
-      "imageName": "warrior's honor",
-      "layout": "normal",
-      "legalities": [
-        {
-          "format": "Commander",
-          "legality": "Legal"
-        },
-        {
-          "format": "Legacy",
-          "legality": "Legal"
-        },
-        {
-          "format": "Mirage Block",
-          "legality": "Legal"
-        },
-        {
-          "format": "Modern",
-          "legality": "Legal"
-        },
-        {
-          "format": "Vintage",
-          "legality": "Legal"
-        }
-      ],
-      "manaCost": "{2}{W}",
-      "name": "Warrior's Honor",
-      "originalText": "All creatures you control get +1/+1 until end of turn.",
-      "originalType": "Instant",
-      "printings": [
-        "VIS",
-        "ATH",
-        "6ED",
-        "9ED",
-        "10E"
-      ],
-      "rarity": "Special",
-      "rulings": [
-        {
-          "date": "2007-07-15",
-          "text": "Warrior's Honor affects creatures you control that are on the battlefield at the time it resolves. If you put a creature onto the battlefield later in the turn, that creature won't get the bonus."
-        }
-      ],
-      "text": "Creatures you control get +1/+1 until end of turn.",
-      "type": "Instant",
-      "types": [
-        "Instant"
-      ]
-    },
-    {
       "artist": "Daniel Gelon",
       "cmc": 2,
       "colorIdentity": [
@@ -5521,7 +5981,45 @@
       "colors": [
         "White"
       ],
-      "flavor": "Out of the blackness and stench of the engulfing swamp emerged a shimmering figure. Only the splattered armor and ichor-stained sword hinted at the unfathomable evil the knight had just laid waste.",
+      "flavor": "Out of the blackness and stench of the engulfing swamp emerged a shimmering figure. Only the splattered armor and ichor-stained sword hinted at the unfathomable evil the Knight had just laid waste.",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "白骑士"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "白騎士"
+        },
+        {
+          "language": "French",
+          "name": "Chevalier blanc"
+        },
+        {
+          "language": "German",
+          "name": "Weißer Ritter"
+        },
+        {
+          "language": "Italian",
+          "name": "Cavaliere Bianco"
+        },
+        {
+          "language": "Japanese",
+          "name": "白騎士"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Cavaleiro Branco"
+        },
+        {
+          "language": "Russian",
+          "name": "Белый Рыцарь"
+        },
+        {
+          "language": "Spanish",
+          "name": "Caballero blanco"
+        }
+      ],
       "id": "19f0a35afddf92b255a3c09e1a0b5da8e9fb02d6",
       "imageName": "white knight",
       "layout": "normal",
@@ -5548,9 +6046,9 @@
         }
       ],
       "manaCost": "{W}{W}",
+      "mciNumber": "59",
       "name": "White Knight",
-      "originalText": "First strike, protection from black",
-      "originalType": "Summon — Knight",
+      "number": "59",
       "power": "2",
       "printings": [
         "LEA",
@@ -5582,6 +6080,1023 @@
       ]
     },
     {
+      "artist": "Mark Zug",
+      "cmc": 2,
+      "colorIdentity": [
+        "W"
+      ],
+      "colors": [
+        "White"
+      ],
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Ruée de pégases"
+        },
+        {
+          "language": "German",
+          "name": "Ansturm der Pegasi"
+        },
+        {
+          "language": "Italian",
+          "name": "Fuga di Pegasi"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Estouro de Pégasos"
+        },
+        {
+          "language": "Spanish",
+          "name": "Estampida de pegasos"
+        }
+      ],
+      "id": "9bfcf1894f261aa4a60f554204e95ae390f4b4d2",
+      "imageName": "pegasus stampede",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{1}{W}",
+      "mciNumber": "60",
+      "name": "Pegasus Stampede",
+      "number": "60",
+      "printings": [
+        "EXO",
+        "ATH",
+        "TPR"
+      ],
+      "rarity": "Special",
+      "text": "Buyback—Sacrifice a land. (You may sacrifice a land in addition to any other costs as you cast this spell. If you do, put this card into your hand as it resolves.)\nCreate a 1/1 white Pegasus creature token with flying.",
+      "type": "Sorcery",
+      "types": [
+        "Sorcery"
+      ]
+    },
+    {
+      "artist": "Bob Eggleton",
+      "colorIdentity": [
+        "W"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "飘移牧草地"
+        },
+        {
+          "language": "French",
+          "name": "Prairie dérivante"
+        },
+        {
+          "language": "German",
+          "name": "Schwebende Wiesen"
+        },
+        {
+          "language": "Italian",
+          "name": "Prateria Sospesa"
+        },
+        {
+          "language": "Japanese",
+          "name": "漂う牧草地"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Campina Flutuante"
+        },
+        {
+          "language": "Spanish",
+          "name": "Pradera a la deriva"
+        }
+      ],
+      "id": "7e3061490fcc2d3ea5435bc183d5d0a7336f4d46",
+      "imageName": "drifting meadow",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Urza Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "mciNumber": "61",
+      "name": "Drifting Meadow",
+      "number": "61",
+      "printings": [
+        "USG",
+        "ATH",
+        "BRB",
+        "C13",
+        "C14",
+        "C15"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2008-10-01",
+          "text": "Cycling is an activated ability. Effects that interact with activated abilities (such as Stifle or Rings of Brighthearth) will interact with cycling. Effects that interact with spells (such as Remove Soul or Faerie Tauntings) will not."
+        }
+      ],
+      "text": "Drifting Meadow enters the battlefield tapped.\n{T}: Add {W} to your mana pool.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+      "type": "Land",
+      "types": [
+        "Land"
+      ]
+    },
+    {
+      "artist": "Stephen Daniele",
+      "colorIdentity": [
+        "G"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "湿滑灰岩地"
+        },
+        {
+          "language": "French",
+          "name": "Karst glissant"
+        },
+        {
+          "language": "German",
+          "name": "Schlüpfriger Karst"
+        },
+        {
+          "language": "Italian",
+          "name": "Carso Scivoloso"
+        },
+        {
+          "language": "Japanese",
+          "name": "滑りやすいカルスト"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Carste Escorregadio"
+        },
+        {
+          "language": "Spanish",
+          "name": "Gruta resbaladiza"
+        }
+      ],
+      "id": "20c2e9b7f685121753a1747baa11df79049f4de4",
+      "imageName": "slippery karst",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Urza Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "mciNumber": "62",
+      "name": "Slippery Karst",
+      "number": "62",
+      "printings": [
+        "USG",
+        "ATH",
+        "BRB",
+        "BTD",
+        "DDD",
+        "C13",
+        "C14",
+        "DD3_GVL",
+        "C15",
+        "CMA"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2008-10-01",
+          "text": "Cycling is an activated ability. Effects that interact with activated abilities (such as Stifle or Rings of Brighthearth) will interact with cycling. Effects that interact with spells (such as Remove Soul or Faerie Tauntings) will not."
+        }
+      ],
+      "text": "Slippery Karst enters the battlefield tapped.\n{T}: Add {G} to your mana pool.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+      "type": "Land",
+      "types": [
+        "Land"
+      ]
+    },
+    {
+      "artist": "David A. Cherry",
+      "cmc": 4,
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "锯刺箭"
+        },
+        {
+          "language": "French",
+          "name": "Flèches barbelées"
+        },
+        {
+          "language": "German",
+          "name": "Gezackte Pfeile"
+        },
+        {
+          "language": "Italian",
+          "name": "Frecce Dentellate"
+        },
+        {
+          "language": "Japanese",
+          "name": "鋸刃の矢"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Flechas Denteadas"
+        },
+        {
+          "language": "Russian",
+          "name": "Зазубренные Стрелы"
+        },
+        {
+          "language": "Spanish",
+          "name": "Flechas dentadas"
+        }
+      ],
+      "id": "0efb952a4af5688abc046aa4d41b13dc8573fea7",
+      "imageName": "serrated arrows",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Time Spiral Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{4}",
+      "mciNumber": "63",
+      "name": "Serrated Arrows",
+      "number": "63",
+      "originalText": "Serrated Arrows comes into play with three arrowhead counters on it.\nWhen there are no arrowhead counters on Serrated Arrows, destroy it.\n{T}, Remove an arrowhead counter from Serrated Arrows: Put a -1/-1 counter on target creature.",
+      "printings": [
+        "HML",
+        "ATH",
+        "pFNM",
+        "TSB",
+        "DDD",
+        "DD3_GVL"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2008-08-01",
+          "text": "The upkeep trigger checks the number of counters at the start of upkeep, and only goes on the stack if there are no arrowhead counters at that time. It will check again on resolution, and will do nothing if you've somehow manage to get a new arrowhead counter on the Arrows."
+        }
+      ],
+      "text": "Serrated Arrows enters the battlefield with three arrowhead counters on it.\nAt the beginning of your upkeep, if there are no arrowhead counters on Serrated Arrows, sacrifice it.\n{T}, Remove an arrowhead counter from Serrated Arrows: Put a -1/-1 counter on target creature.",
+      "type": "Artifact",
+      "types": [
+        "Artifact"
+      ]
+    },
+    {
+      "artist": "Christopher Rush",
+      "cmc": 2,
+      "colorIdentity": [
+        "G"
+      ],
+      "colors": [
+        "Green"
+      ],
+      "flavor": "\"We know our place in the cycle of life-and it is not as flies.\"\n—Eladamri, Lord of Leaves",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "林冠蜘蛛"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "林冠蜘蛛"
+        },
+        {
+          "language": "French",
+          "name": "Araignée de la canopée"
+        },
+        {
+          "language": "German",
+          "name": "Baldachinspinne"
+        },
+        {
+          "language": "Italian",
+          "name": "Ragno delle Fronde"
+        },
+        {
+          "language": "Japanese",
+          "name": "梢の蜘蛛"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Aranha Baldaquina"
+        },
+        {
+          "language": "Russian",
+          "name": "Паук, Обитатель Полога"
+        },
+        {
+          "language": "Spanish",
+          "name": "Araña de la enramada"
+        }
+      ],
+      "id": "60d4bb538360b746c181725b7b436580de271956",
+      "imageName": "canopy spider",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{1}{G}",
+      "mciNumber": "64",
+      "name": "Canopy Spider",
+      "number": "64",
+      "power": "1",
+      "printings": [
+        "TMP",
+        "ATH",
+        "7ED",
+        "8ED",
+        "10E",
+        "TPR"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2008-04-01",
+          "text": "This card now uses the Reach keyword ability to enable the blocking of flying creatures. This works because a creature with flying can only be blocked by creatures with flying or reach."
+        }
+      ],
+      "subtypes": [
+        "Spider"
+      ],
+      "text": "Reach (This creature can block creatures with flying.)",
+      "toughness": "3",
+      "type": "Creature — Spider",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Quinton Hoover",
+      "cmc": 4,
+      "colorIdentity": [
+        "G"
+      ],
+      "colors": [
+        "Green"
+      ],
+      "flavor": "\"It had a mouth like that of a great beast, and gnashed its teeth as it strained to reach us. I am thankful it possessed no means of locomotion.\"\n—Vervamon the Elder",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Plante carnivore"
+        },
+        {
+          "language": "German",
+          "name": "Fleischfressende Pflanze"
+        },
+        {
+          "language": "Italian",
+          "name": "Pianta Carnivora"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Planta Carnivora"
+        },
+        {
+          "language": "Spanish",
+          "name": "Planta carnívora"
+        }
+      ],
+      "id": "22b27a49c31e3c402063651bfcacebac9a1739f2",
+      "imageName": "carnivorous plant",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{3}{G}",
+      "mciNumber": "65",
+      "name": "Carnivorous Plant",
+      "number": "65",
+      "power": "4",
+      "printings": [
+        "DRK",
+        "4ED",
+        "ATH",
+        "MED"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Plant",
+        "Wall"
+      ],
+      "text": "Defender",
+      "toughness": "5",
+      "type": "Creature — Plant Wall",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Sandra Everingham",
+      "cmc": 1,
+      "colorIdentity": [
+        "G"
+      ],
+      "colors": [
+        "Green"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "变巨术"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "變巨術"
+        },
+        {
+          "language": "French",
+          "name": "Croissance gigantesque"
+        },
+        {
+          "language": "German",
+          "name": "Riesenwuchs"
+        },
+        {
+          "language": "Italian",
+          "name": "Crescita Gigante"
+        },
+        {
+          "language": "Japanese",
+          "name": "巨大化"
+        },
+        {
+          "language": "Korean",
+          "name": "거대화"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Crescimento Desenfreado"
+        },
+        {
+          "language": "Russian",
+          "name": "Исполинский Рост"
+        },
+        {
+          "language": "Spanish",
+          "name": "Crecimiento gigante"
+        }
+      ],
+      "id": "cd1f9831cfbc90141548e7acbf2e316294cc9723",
+      "imageName": "giant growth",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Return to Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{G}",
+      "mciNumber": "66",
+      "name": "Giant Growth",
+      "number": "66",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "ICE",
+        "5ED",
+        "ATH",
+        "6ED",
+        "BRB",
+        "pSUS",
+        "pFNM",
+        "S00",
+        "BTD",
+        "7ED",
+        "pMPR",
+        "DKM",
+        "8ED",
+        "9ED",
+        "10E",
+        "EVG",
+        "ME2",
+        "M10",
+        "ME3",
+        "DDD",
+        "DPA",
+        "M11",
+        "ME4",
+        "RTR",
+        "M14",
+        "DD3_EVG",
+        "DD3_GVL"
+      ],
+      "rarity": "Special",
+      "text": "Target creature gets +3/+3 until end of turn.",
+      "type": "Instant",
+      "types": [
+        "Instant"
+      ]
+    },
+    {
+      "artist": "Sandra Everingham",
+      "cmc": 4,
+      "colorIdentity": [
+        "G"
+      ],
+      "colors": [
+        "Green"
+      ],
+      "flavor": "While it possesses potent venom, the Giant Spider often chooses not to paralyze its victims. Perhaps the creature enjoys the gentle rocking motion caused by its captives' struggles to escape its web.",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "巨型蜘蛛"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "巨型蜘蛛"
+        },
+        {
+          "language": "French",
+          "name": "Araignée géante"
+        },
+        {
+          "language": "German",
+          "name": "Riesenspinne"
+        },
+        {
+          "language": "Italian",
+          "name": "Ragno Gigante"
+        },
+        {
+          "language": "Japanese",
+          "name": "大蜘蛛"
+        },
+        {
+          "language": "Korean",
+          "name": "거대한 거미"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Aranha Gigante"
+        },
+        {
+          "language": "Russian",
+          "name": "Гигантский Паук"
+        },
+        {
+          "language": "Spanish",
+          "name": "Araña gigante"
+        }
+      ],
+      "id": "d87d02381b53f9c5ce360d5feaddb227807e725a",
+      "imageName": "giant spider",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{3}{G}",
+      "mciNumber": "67",
+      "name": "Giant Spider",
+      "number": "67",
+      "originalText": "Giant Spider can block creatures with flying.",
+      "power": "2",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "5ED",
+        "POR",
+        "ATH",
+        "6ED",
+        "7ED",
+        "8ED",
+        "9ED",
+        "10E",
+        "M10",
+        "DPA",
+        "M11",
+        "M12",
+        "M14",
+        "AKH"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2008-04-01",
+          "text": "This card now uses the Reach keyword ability to enable the blocking of flying creatures. This works because a creature with flying can only be blocked by creatures with flying or reach."
+        }
+      ],
+      "subtypes": [
+        "Spider"
+      ],
+      "text": "Reach (This creature can block creatures with flying.)",
+      "toughness": "4",
+      "type": "Creature — Spider",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Quinton Hoover",
+      "cmc": 4,
+      "colorIdentity": [
+        "G"
+      ],
+      "colors": [
+        "Green"
+      ],
+      "flavor": "\"Oh, no-not you again?!\"\n—Jaya Ballard, task mage",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Chef de clan gorille"
+        },
+        {
+          "language": "German",
+          "name": "Gorillahäuptling"
+        },
+        {
+          "language": "Italian",
+          "name": "Capotribù dei Gorilla"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Líder dos Gorilas"
+        },
+        {
+          "language": "Spanish",
+          "name": "Cacique gorila"
+        }
+      ],
+      "id": "fa503e2dbdf532961f76faae7423814cb3a4fa4f",
+      "imageName": "gorilla chieftain",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{2}{G}{G}",
+      "mciNumber": "68",
+      "name": "Gorilla Chieftain",
+      "number": "68",
+      "power": "3",
+      "printings": [
+        "ALL",
+        "ATH",
+        "6ED",
+        "7ED"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Ape"
+      ],
+      "text": "{1}{G}: Regenerate Gorilla Chieftain.",
+      "toughness": "3",
+      "type": "Creature — Ape",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Anson Maddocks",
+      "cmc": 1,
+      "colorIdentity": [
+        "G"
+      ],
+      "colors": [
+        "Green"
+      ],
+      "flavor": "One bone broken for every twig snapped underfoot. —Llanowar penalty for trespassing",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "罗堰妖精"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "羅堰妖精"
+        },
+        {
+          "language": "French",
+          "name": "Elfes de Llanowar"
+        },
+        {
+          "language": "German",
+          "name": "Llanowarelfen"
+        },
+        {
+          "language": "Italian",
+          "name": "Elfi di Llanowar"
+        },
+        {
+          "language": "Japanese",
+          "name": "ラノワールのエルフ"
+        },
+        {
+          "language": "Korean",
+          "name": "라노와의 엘프"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Elfos de Llanowar"
+        },
+        {
+          "language": "Russian",
+          "name": "Лановарские Эльфы"
+        },
+        {
+          "language": "Spanish",
+          "name": "Elfos de Llanowar"
+        }
+      ],
+      "id": "3123fa7e63344f84fe2a987ad65732229eff58d6",
+      "imageName": "llanowar elves",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{G}",
+      "mciNumber": "69",
+      "name": "Llanowar Elves",
+      "number": "69",
+      "originalText": "{T}: Add {G} to your mana pool. Play this ability as a mana source.",
+      "power": "1",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "5ED",
+        "ATH",
+        "6ED",
+        "BRB",
+        "pFNM",
+        "S00",
+        "BTD",
+        "7ED",
+        "9ED",
+        "pGTW",
+        "10E",
+        "EVG",
+        "M10",
+        "M11",
+        "M12",
+        "C14",
+        "DD3_EVG",
+        "EMA",
+        "CMA"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Elf",
+        "Druid"
+      ],
+      "text": "{T}: Add {G} to your mana pool.",
+      "toughness": "1",
+      "type": "Creature — Elf Druid",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Dennis Detwiller",
+      "cmc": 1,
+      "colorIdentity": [
+        "G"
+      ],
+      "colors": [
+        "Green"
+      ],
+      "flavor": "String, weapons, wax, or jewels-it makes no difference. Leave nothing unguarded in Scarwood.",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Maraudeurs"
+        },
+        {
+          "language": "German",
+          "name": "Gerümpelsammler"
+        },
+        {
+          "language": "Italian",
+          "name": "Reietti di Scarwood"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Povo Escamotador"
+        },
+        {
+          "language": "Spanish",
+          "name": "Pueblo saqueador"
+        }
+      ],
+      "id": "f526b759713a811bb9de415858f8f9c5c7a5000a",
+      "imageName": "scavenger folk",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{G}",
+      "mciNumber": "70",
+      "name": "Scavenger Folk",
+      "number": "70",
+      "originalText": "{G}, {T}, Sacrifice Scavenger Folk: Destroy target artifact.",
+      "power": "1",
+      "printings": [
+        "DRK",
+        "CHR",
+        "5ED",
+        "ATH",
+        "7ED",
+        "ME4"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Human"
+      ],
+      "text": "{G}, {T}, Sacrifice Scavenger Folk: Destroy target artifact.",
+      "toughness": "1",
+      "type": "Creature — Human",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
       "artist": "Daniel Gelon",
       "cmc": 3,
       "colorIdentity": [
@@ -5590,7 +7105,29 @@
       "colors": [
         "Green"
       ],
-      "flavor": "\"We need not fear the forces of the air; I've yet to see a Spider without an appetite.\"\n—Taaveti of Kelsinko, Elvish Hunter",
+      "flavor": "\"We need not fear the forces of the air; I've yet to see a Spider without an appetite.\"\n—Taaveti of Kelsinko, elvish hunter",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Araignée laineuse"
+        },
+        {
+          "language": "German",
+          "name": "Wollspinne"
+        },
+        {
+          "language": "Italian",
+          "name": "Ragno Lanoso"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Aranha Lanosa"
+        },
+        {
+          "language": "Spanish",
+          "name": "Araña lanuda"
+        }
+      ],
       "id": "27d4a1f9dea190ffaf6af94d0cbee174f9a54a15",
       "imageName": "woolly spider",
       "layout": "normal",
@@ -5613,9 +7150,10 @@
         }
       ],
       "manaCost": "{1}{G}{G}",
+      "mciNumber": "71",
       "name": "Woolly Spider",
+      "number": "71",
       "originalText": "Wooly Spider can block creatures with flying.\nWhen Woolly Spider blocks a creature with flying, Woolly Spider gets +0/+2 until end of turn.",
-      "originalType": "Summon — Spider",
       "power": "2",
       "printings": [
         "ICE",
@@ -5636,6 +7174,986 @@
       ]
     },
     {
+      "artist": "Andrew Robinson",
+      "cmc": 2,
+      "colorIdentity": [
+        "W"
+      ],
+      "colors": [
+        "White"
+      ],
+      "flavor": "Asked how it survived a run-in with a bog imp, the pegasus just shook its mane and burped.",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Pégase cuirassé"
+        },
+        {
+          "language": "German",
+          "name": "Gepanzerter Pegasus"
+        },
+        {
+          "language": "Italian",
+          "name": "Pegaso Corazzato"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Pégaso de Armadura"
+        },
+        {
+          "language": "Spanish",
+          "name": "Pegaso acorazado"
+        }
+      ],
+      "id": "067eae77cb14bef5932842ee6e39fdcb6671fa0e",
+      "imageName": "armored pegasus",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{1}{W}",
+      "mciNumber": "72",
+      "name": "Armored Pegasus",
+      "number": "72",
+      "originalType": "Creature — Pegasus",
+      "power": "1",
+      "printings": [
+        "POR",
+        "pPOD",
+        "TMP",
+        "ATH",
+        "6ED",
+        "BRB",
+        "S00",
+        "TPR"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Pegasus"
+      ],
+      "text": "Flying",
+      "toughness": "2",
+      "type": "Creature — Pegasus",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Zina Saunders",
+      "cmc": 3,
+      "colorIdentity": [
+        "W"
+      ],
+      "colors": [
+        "White"
+      ],
+      "flavor": "\"We called them 'armored lightning.\"'\n—Gerrard of the Weatherlight",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "宾纳里亚骑士"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "賓納里亞騎士"
+        },
+        {
+          "language": "French",
+          "name": "Chevalier bénalian"
+        },
+        {
+          "language": "German",
+          "name": "Benalischer Ritter"
+        },
+        {
+          "language": "Italian",
+          "name": "Cavaliere di Benalia"
+        },
+        {
+          "language": "Japanese",
+          "name": "ベナリアの騎士"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Cavaleiro de Benália"
+        },
+        {
+          "language": "Russian",
+          "name": "Беналийский Рыцарь"
+        },
+        {
+          "language": "Spanish",
+          "name": "Caballero benalita"
+        }
+      ],
+      "id": "5955512dfffdfcf6743389f3b8c6f3d5603ec753",
+      "imageName": "benalish knight",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{2}{W}",
+      "mciNumber": "73",
+      "name": "Benalish Knight",
+      "number": "73",
+      "originalText": "First strike\nYou may play Benalish Knight any time you could play an instant.",
+      "power": "2",
+      "printings": [
+        "WTH",
+        "ATH",
+        "10E"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Human",
+        "Knight"
+      ],
+      "text": "Flash (You may cast this spell any time you could cast an instant.)\nFirst strike (This creature deals combat damage before creatures without first strike.)",
+      "toughness": "2",
+      "type": "Creature — Human Knight",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Liz Danforth",
+      "cmc": 3,
+      "colorIdentity": [
+        "W"
+      ],
+      "colors": [
+        "White"
+      ],
+      "flavor": "\"Without combat medics, Icatia would probably not have withstood the forces of chaos as long as it did.\"\n—Sarpadian Empires, vol. VI",
+      "id": "960d7aa53350c6b00d4e6603b51d4820d9adcae1",
+      "imageName": "combat medic",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{2}{W}",
+      "mciNumber": "74",
+      "name": "Combat Medic",
+      "number": "74",
+      "originalText": "{1}{W}: Prevent 1 damage to a creature or player.",
+      "power": "0",
+      "printings": [
+        "FEM",
+        "ATH",
+        "ME2"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Human",
+        "Cleric",
+        "Soldier"
+      ],
+      "text": "{1}{W}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
+      "toughness": "2",
+      "type": "Creature — Human Cleric Soldier",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Liz Danforth",
+      "cmc": 2,
+      "colorIdentity": [
+        "W"
+      ],
+      "colors": [
+        "White"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "消除魔障"
+        },
+        {
+          "language": "French",
+          "name": "Désenchantement"
+        },
+        {
+          "language": "German",
+          "name": "Entzauberung"
+        },
+        {
+          "language": "Italian",
+          "name": "Disincantare"
+        },
+        {
+          "language": "Japanese",
+          "name": "解呪"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Desencantar"
+        },
+        {
+          "language": "Russian",
+          "name": "Разочаровывать"
+        },
+        {
+          "language": "Spanish",
+          "name": "Desencantar"
+        }
+      ],
+      "id": "d606b8404491a4662a5bd4be08e323be5946bfce",
+      "imageName": "disenchant",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Masques Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Time Spiral Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Urza Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{1}{W}",
+      "mciNumber": "75",
+      "name": "Disenchant",
+      "number": "75",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "ICE",
+        "pARL",
+        "MIR",
+        "5ED",
+        "TMP",
+        "USG",
+        "ATH",
+        "6ED",
+        "MMQ",
+        "BRB",
+        "pFNM",
+        "S00",
+        "7ED",
+        "pMPR",
+        "CST",
+        "TSB",
+        "ME2",
+        "ME3",
+        "TPR",
+        "CN2"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2004-10-04",
+          "text": "This is not modal. If the target changes from an artifact to an enchantment or vice versa, this still destroys it."
+        }
+      ],
+      "text": "Destroy target artifact or enchantment.",
+      "type": "Instant",
+      "types": [
+        "Instant"
+      ]
+    },
+    {
+      "artist": "Una Fricker",
+      "cmc": 2,
+      "colorIdentity": [
+        "W"
+      ],
+      "colors": [
+        "White"
+      ],
+      "flavor": "\"That does it! I'm going back to hunting chickens!\"\n—Rhirhok, goblin archer",
+      "foreignNames": [
+        {
+          "language": "French",
+          "name": "Faucon librevent"
+        },
+        {
+          "language": "German",
+          "name": "Pfeilschneller Falke"
+        },
+        {
+          "language": "Italian",
+          "name": "Falco del Ventolibero"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Falcão do Vento Veloz"
+        },
+        {
+          "language": "Spanish",
+          "name": "Halcón errante"
+        }
+      ],
+      "id": "16585147a3adeb06f4aa5c522e19d0b3b1e6d2f2",
+      "imageName": "freewind falcon",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{1}{W}",
+      "mciNumber": "76",
+      "name": "Freewind Falcon",
+      "number": "76",
+      "power": "1",
+      "printings": [
+        "VIS",
+        "ATH"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Bird"
+      ],
+      "text": "Flying, protection from red",
+      "toughness": "1",
+      "type": "Creature — Bird",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Edward P. Beard, Jr.",
+      "cmc": 1,
+      "colorIdentity": [
+        "W"
+      ],
+      "colors": [
+        "White"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "艾凯逊掷枪手"
+        },
+        {
+          "language": "French",
+          "name": "Javeliniers icatians"
+        },
+        {
+          "language": "German",
+          "name": "Icatianische Speerschleuderer"
+        },
+        {
+          "language": "Italian",
+          "name": "Giavellottieri di Icatia"
+        },
+        {
+          "language": "Japanese",
+          "name": "アイケイシアの投槍兵"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Zagaieiros Icatianos"
+        },
+        {
+          "language": "Russian",
+          "name": "Айкейшунские Метатели Дротиков"
+        },
+        {
+          "language": "Spanish",
+          "name": "Jabalineros icatianos"
+        }
+      ],
+      "id": "7eb28af8954413c319c83eb124def8c94ad9d09f",
+      "imageName": "icatian javelineers",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Time Spiral Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{W}",
+      "mciNumber": "77",
+      "name": "Icatian Javelineers",
+      "number": "77",
+      "originalText": "When Icatian Javelineers comes into play, put a javelin counter on it.\n{T}, Remove a javelin counter from Icatian Javelineers: Icatian Javelineers deals 1 damage to target creature or player.",
+      "power": "1",
+      "printings": [
+        "FEM",
+        "ATH",
+        "pGTW",
+        "TSB",
+        "ME2",
+        "DDO"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Human",
+        "Soldier"
+      ],
+      "text": "Icatian Javelineers enters the battlefield with a javelin counter on it.\n{T}, Remove a javelin counter from Icatian Javelineers: Icatian Javelineers deals 1 damage to target creature or player.",
+      "toughness": "1",
+      "type": "Creature — Human Soldier",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Christopher Rush",
+      "cmc": 1,
+      "colorIdentity": [
+        "W"
+      ],
+      "colors": [
+        "White"
+      ],
+      "flavor": "\"The true dishonor for a soldier is surviving the war.\"\n—Telim'Tor",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "资深步兵"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "資深步兵"
+        },
+        {
+          "language": "French",
+          "name": "Vétéran de l'infanterie"
+        },
+        {
+          "language": "German",
+          "name": "Erfahrener Fußsoldat"
+        },
+        {
+          "language": "Italian",
+          "name": "Fante Veterano"
+        },
+        {
+          "language": "Japanese",
+          "name": "歴戦の歩兵"
+        },
+        {
+          "language": "Korean",
+          "name": ""
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Veterano da Infantaria"
+        },
+        {
+          "language": "Russian",
+          "name": "Ветеран Пехоты"
+        },
+        {
+          "language": "Spanish",
+          "name": "Veterano de infantería"
+        }
+      ],
+      "id": "aca32aa2bd1ae4421868f4ebf48760a47c3390f3",
+      "imageName": "infantry veteran",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{W}",
+      "mciNumber": "78",
+      "name": "Infantry Veteran",
+      "number": "78",
+      "originalType": "Summon — Soldier",
+      "power": "1",
+      "printings": [
+        "VIS",
+        "ATH",
+        "6ED",
+        "BRB",
+        "9ED",
+        "M11",
+        "DDF",
+        "DDN"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2010-08-15",
+          "text": "An \"attacking creature\" is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+        }
+      ],
+      "subtypes": [
+        "Human",
+        "Soldier"
+      ],
+      "text": "{T}: Target attacking creature gets +1/+1 until end of turn.",
+      "toughness": "1",
+      "type": "Creature — Human Soldier",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "Robert Bliss",
+      "cmc": 2,
+      "colorIdentity": [
+        "W"
+      ],
+      "colors": [
+        "White"
+      ],
+      "flavor": "For the first time in his life, Grakk felt a little warm and fuzzy inside.",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "和平主义"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "和平主義"
+        },
+        {
+          "language": "French",
+          "name": "Pacifisme"
+        },
+        {
+          "language": "German",
+          "name": "Pazifismus"
+        },
+        {
+          "language": "Italian",
+          "name": "Pacifismo"
+        },
+        {
+          "language": "Japanese",
+          "name": "平和な心"
+        },
+        {
+          "language": "Korean",
+          "name": "평화주의"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Pacifismo"
+        },
+        {
+          "language": "Russian",
+          "name": "Пацифизм"
+        },
+        {
+          "language": "Spanish",
+          "name": "Pacifismo"
+        }
+      ],
+      "id": "1ad4adc861c5455868af1b62417566b61c153bfe",
+      "imageName": "pacifism",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Khans of Tarkir Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Onslaught Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Urza Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{1}{W}",
+      "mciNumber": "79",
+      "name": "Pacifism",
+      "number": "79",
+      "originalText": "Enchanted creature cannot attack or block.",
+      "printings": [
+        "MIR",
+        "TMP",
+        "USG",
+        "ATH",
+        "6ED",
+        "BRB",
+        "7ED",
+        "ONS",
+        "8ED",
+        "9ED",
+        "10E",
+        "DDC",
+        "M10",
+        "M11",
+        "M12",
+        "M13",
+        "M14",
+        "DD3_DVD",
+        "DTK",
+        "TPR",
+        "EMA"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Aura"
+      ],
+      "text": "Enchant creature\nEnchanted creature can't attack or block.",
+      "type": "Enchantment — Aura",
+      "types": [
+        "Enchantment"
+      ]
+    },
+    {
+      "artist": "Tom Wänerstrand",
+      "cmc": 2,
+      "colorIdentity": [
+        "W"
+      ],
+      "colors": [
+        "White"
+      ],
+      "flavor": "Healers ultimately acquire the divine gifts of spiritual and physical wholeness. The most devout are also granted the ability to pass physical wholeness on to others.",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "撒姆尼人的医疗员"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "撒姆尼人的醫療員"
+        },
+        {
+          "language": "French",
+          "name": "Guérisseur sanctif"
+        },
+        {
+          "language": "German",
+          "name": "Feldscher"
+        },
+        {
+          "language": "Italian",
+          "name": "Guaritore Bianco"
+        },
+        {
+          "language": "Japanese",
+          "name": "サマイトの癒し手"
+        },
+        {
+          "language": "Korean",
+          "name": ""
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Curandeiro Samita"
+        },
+        {
+          "language": "Russian",
+          "name": "Самитский Лекарь"
+        },
+        {
+          "language": "Spanish",
+          "name": "Sanador samita"
+        }
+      ],
+      "id": "dcbb40c009f8fc6889bd93d0cb3162bc9974269b",
+      "imageName": "samite healer",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{1}{W}",
+      "mciNumber": "81",
+      "name": "Samite Healer",
+      "number": "81",
+      "originalText": "{T}: Prevent 1 damage to a creature or player.",
+      "originalType": "Summon — Cleric",
+      "power": "1",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "5ED",
+        "ATH",
+        "6ED",
+        "S00",
+        "7ED",
+        "8ED",
+        "9ED",
+        "10E"
+      ],
+      "rarity": "Special",
+      "subtypes": [
+        "Human",
+        "Cleric"
+      ],
+      "text": "{T}: Prevent the next 1 damage that would be dealt to target creature or player this turn.",
+      "toughness": "1",
+      "type": "Creature — Human Cleric",
+      "types": [
+        "Creature"
+      ]
+    },
+    {
+      "artist": "D. Alexander Gregory",
+      "cmc": 3,
+      "colorIdentity": [
+        "W"
+      ],
+      "colors": [
+        "White"
+      ],
+      "flavor": "\"We are to be bound together as the reeds of a basket.\"\n—Asmira, Rashida, and Jabari, unity chant",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "战士之光"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "戰士之光"
+        },
+        {
+          "language": "French",
+          "name": "Honneur du guerrier"
+        },
+        {
+          "language": "German",
+          "name": "Kriegerehre"
+        },
+        {
+          "language": "Italian",
+          "name": "Onore del Guerriero"
+        },
+        {
+          "language": "Japanese",
+          "name": "戦士の誉れ"
+        },
+        {
+          "language": "Korean",
+          "name": ""
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Honra de Guerreiro"
+        },
+        {
+          "language": "Russian",
+          "name": "Честь Воина"
+        },
+        {
+          "language": "Spanish",
+          "name": "Honor de guerrero"
+        }
+      ],
+      "id": "794037c9f37b19b1c0ea47f3a570f760d1fcd4fa",
+      "imageName": "warrior's honor",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        }
+      ],
+      "manaCost": "{2}{W}",
+      "mciNumber": "82",
+      "name": "Warrior's Honor",
+      "number": "82",
+      "printings": [
+        "VIS",
+        "ATH",
+        "6ED",
+        "9ED",
+        "10E"
+      ],
+      "rarity": "Special",
+      "rulings": [
+        {
+          "date": "2007-07-15",
+          "text": "Warrior's Honor affects creatures you control that are on the battlefield at the time it resolves. If you put a creature onto the battlefield later in the turn, that creature won't get the bonus."
+        }
+      ],
+      "text": "Creatures you control get +1/+1 until end of turn.",
+      "type": "Instant",
+      "types": [
+        "Instant"
+      ]
+    },
+    {
       "artist": "Rebecca Guay",
       "cmc": 2,
       "colorIdentity": [
@@ -5644,7 +8162,45 @@
       "colors": [
         "White"
       ],
-      "flavor": "\"Let no child be without a sword. We will all fight, for if we fail, we will certainly all die.\"\n—Oracle en-Vec",
+      "flavor": "\"Let no child be without a sword. We will all fight, for if we fail, we will certainly all die.\" -Oracle en-Vec",
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "青年骑士"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "青年騎士"
+        },
+        {
+          "language": "French",
+          "name": "Jeune chevalier"
+        },
+        {
+          "language": "German",
+          "name": "Jugendlicher Ritter"
+        },
+        {
+          "language": "Italian",
+          "name": "Cavaliere Giovane"
+        },
+        {
+          "language": "Japanese",
+          "name": "若年の騎士"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Jovem Cavaleiro"
+        },
+        {
+          "language": "Russian",
+          "name": "Юный Рыцарь"
+        },
+        {
+          "language": "Spanish",
+          "name": "Caballero joven"
+        }
+      ],
       "id": "a63875e8814c5390fc25af3323c1cd41fde7b135",
       "imageName": "youthful knight",
       "layout": "normal",
@@ -5671,9 +8227,9 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "83",
       "name": "Youthful Knight",
-      "originalText": "First strike",
-      "originalType": "Summon — Knight",
+      "number": "83",
       "power": "2",
       "printings": [
         "STH",
@@ -5688,11 +8244,1167 @@
         "Human",
         "Knight"
       ],
-      "text": "First strike (This creature deals combat damage before creatures without first strike.)",
+      "text": "First strike",
       "toughness": "1",
       "type": "Creature — Human Knight",
       "types": [
         "Creature"
+      ]
+    },
+    {
+      "artist": "Quinton Hoover",
+      "colorIdentity": [
+        "G"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "树林"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "樹林"
+        },
+        {
+          "language": "French",
+          "name": "Forêt"
+        },
+        {
+          "language": "German",
+          "name": "Wald"
+        },
+        {
+          "language": "Italian",
+          "name": "Foresta"
+        },
+        {
+          "language": "Japanese",
+          "name": "森"
+        },
+        {
+          "language": "Korean",
+          "name": "숲"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta"
+        },
+        {
+          "language": "Russian",
+          "name": "Лес"
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque"
+        }
+      ],
+      "id": "e3b1e2c8ffcd51735577f129439602bf3d427eaf",
+      "imageName": "forest1",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Battle for Zendikar Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Invasion Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kaladesh Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kamigawa Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Khans of Tarkir Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Lorwyn-Shadowmoor Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Masques Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Onslaught Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Return to Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Scars of Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shadows over Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Theros Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Time Spiral Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Un-Sets",
+          "legality": "Legal"
+        },
+        {
+          "format": "Urza Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        },
+        {
+          "format": "Zendikar Block",
+          "legality": "Legal"
+        }
+      ],
+      "mciNumber": "84",
+      "name": "Forest",
+      "number": "84",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "ICE",
+        "RQS",
+        "pARL",
+        "MIR",
+        "ITP",
+        "5ED",
+        "POR",
+        "TMP",
+        "pJGP",
+        "PO2",
+        "UGL",
+        "pALP",
+        "USG",
+        "ATH",
+        "6ED",
+        "PTK",
+        "pGRU",
+        "S99",
+        "MMQ",
+        "BRB",
+        "pELP",
+        "S00",
+        "BTD",
+        "INV",
+        "7ED",
+        "ODY",
+        "DKM",
+        "ONS",
+        "8ED",
+        "MRD",
+        "CHK",
+        "UNH",
+        "9ED",
+        "RAV",
+        "CST",
+        "TSP",
+        "10E",
+        "MED",
+        "LRW",
+        "EVG",
+        "SHM",
+        "ALA",
+        "M10",
+        "HOP",
+        "ME3",
+        "ZEN",
+        "DDD",
+        "H09",
+        "DDE",
+        "ROE",
+        "DPA",
+        "ARC",
+        "M11",
+        "SOM",
+        "MBS",
+        "DDG",
+        "NPH",
+        "CMD",
+        "M12",
+        "DDH",
+        "ISD",
+        "AVR",
+        "PC2",
+        "M13",
+        "DDJ",
+        "RTR",
+        "M14",
+        "DDL",
+        "THS",
+        "C13",
+        "DDM",
+        "M15",
+        "KTK",
+        "C14",
+        "DD3_EVG",
+        "DD3_GVL",
+        "FRF",
+        "DDO",
+        "DTK",
+        "TPR",
+        "ORI",
+        "DDP",
+        "BFZ",
+        "C15",
+        "SOI",
+        "DDR",
+        "KLD",
+        "C16",
+        "PCA",
+        "DDS",
+        "AKH",
+        "CMA",
+        "E01",
+        "HOU"
+      ],
+      "rarity": "Basic Land",
+      "subtypes": [
+        "Forest"
+      ],
+      "supertypes": [
+        "Basic"
+      ],
+      "type": "Basic Land — Forest",
+      "types": [
+        "Land"
+      ]
+    },
+    {
+      "artist": "Tony Roberts",
+      "colorIdentity": [
+        "G"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "树林"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "樹林"
+        },
+        {
+          "language": "French",
+          "name": "Forêt"
+        },
+        {
+          "language": "German",
+          "name": "Wald"
+        },
+        {
+          "language": "Italian",
+          "name": "Foresta"
+        },
+        {
+          "language": "Japanese",
+          "name": "森"
+        },
+        {
+          "language": "Korean",
+          "name": "숲"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Floresta"
+        },
+        {
+          "language": "Russian",
+          "name": "Лес"
+        },
+        {
+          "language": "Spanish",
+          "name": "Bosque"
+        }
+      ],
+      "id": "78bd7f3e760ef65d3fb636728abf9fe2cc123c32",
+      "imageName": "forest2",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Battle for Zendikar Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Invasion Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kaladesh Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kamigawa Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Khans of Tarkir Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Lorwyn-Shadowmoor Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Masques Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Onslaught Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Return to Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Scars of Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shadows over Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Theros Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Time Spiral Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Un-Sets",
+          "legality": "Legal"
+        },
+        {
+          "format": "Urza Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        },
+        {
+          "format": "Zendikar Block",
+          "legality": "Legal"
+        }
+      ],
+      "mciNumber": "85",
+      "name": "Forest",
+      "number": "85",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "ICE",
+        "RQS",
+        "pARL",
+        "MIR",
+        "ITP",
+        "5ED",
+        "POR",
+        "TMP",
+        "pJGP",
+        "PO2",
+        "UGL",
+        "pALP",
+        "USG",
+        "ATH",
+        "6ED",
+        "PTK",
+        "pGRU",
+        "S99",
+        "MMQ",
+        "BRB",
+        "pELP",
+        "S00",
+        "BTD",
+        "INV",
+        "7ED",
+        "ODY",
+        "DKM",
+        "ONS",
+        "8ED",
+        "MRD",
+        "CHK",
+        "UNH",
+        "9ED",
+        "RAV",
+        "CST",
+        "TSP",
+        "10E",
+        "MED",
+        "LRW",
+        "EVG",
+        "SHM",
+        "ALA",
+        "M10",
+        "HOP",
+        "ME3",
+        "ZEN",
+        "DDD",
+        "H09",
+        "DDE",
+        "ROE",
+        "DPA",
+        "ARC",
+        "M11",
+        "SOM",
+        "MBS",
+        "DDG",
+        "NPH",
+        "CMD",
+        "M12",
+        "DDH",
+        "ISD",
+        "AVR",
+        "PC2",
+        "M13",
+        "DDJ",
+        "RTR",
+        "M14",
+        "DDL",
+        "THS",
+        "C13",
+        "DDM",
+        "M15",
+        "KTK",
+        "C14",
+        "DD3_EVG",
+        "DD3_GVL",
+        "FRF",
+        "DDO",
+        "DTK",
+        "TPR",
+        "ORI",
+        "DDP",
+        "BFZ",
+        "C15",
+        "SOI",
+        "DDR",
+        "KLD",
+        "C16",
+        "PCA",
+        "DDS",
+        "AKH",
+        "CMA",
+        "E01",
+        "HOU"
+      ],
+      "rarity": "Basic Land",
+      "subtypes": [
+        "Forest"
+      ],
+      "supertypes": [
+        "Basic"
+      ],
+      "type": "Basic Land — Forest",
+      "types": [
+        "Land"
+      ]
+    },
+    {
+      "artist": "Tom Wänerstrand",
+      "colorIdentity": [
+        "W"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "平原"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "平原"
+        },
+        {
+          "language": "French",
+          "name": "Plaine"
+        },
+        {
+          "language": "German",
+          "name": "Ebene"
+        },
+        {
+          "language": "Italian",
+          "name": "Pianura"
+        },
+        {
+          "language": "Japanese",
+          "name": "平地"
+        },
+        {
+          "language": "Korean",
+          "name": "들"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Planície"
+        },
+        {
+          "language": "Russian",
+          "name": "Равнина"
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura"
+        }
+      ],
+      "id": "33ead63bca6d2b297ea52916114f928d279e2e51",
+      "imageName": "plains1",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Battle for Zendikar Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Invasion Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kaladesh Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kamigawa Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Khans of Tarkir Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Lorwyn-Shadowmoor Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Masques Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Onslaught Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Return to Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Scars of Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shadows over Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Theros Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Time Spiral Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Un-Sets",
+          "legality": "Legal"
+        },
+        {
+          "format": "Urza Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        },
+        {
+          "format": "Zendikar Block",
+          "legality": "Legal"
+        }
+      ],
+      "mciNumber": "86",
+      "name": "Plains",
+      "number": "86",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "ICE",
+        "RQS",
+        "pARL",
+        "MIR",
+        "ITP",
+        "5ED",
+        "POR",
+        "pPRE",
+        "TMP",
+        "pJGP",
+        "PO2",
+        "UGL",
+        "pALP",
+        "USG",
+        "ATH",
+        "6ED",
+        "PTK",
+        "pGRU",
+        "S99",
+        "MMQ",
+        "BRB",
+        "pELP",
+        "S00",
+        "INV",
+        "7ED",
+        "ODY",
+        "ONS",
+        "8ED",
+        "MRD",
+        "CHK",
+        "UNH",
+        "9ED",
+        "RAV",
+        "CST",
+        "TSP",
+        "10E",
+        "MED",
+        "LRW",
+        "SHM",
+        "ALA",
+        "DDC",
+        "M10",
+        "HOP",
+        "ME3",
+        "ZEN",
+        "H09",
+        "DDE",
+        "ROE",
+        "ARC",
+        "M11",
+        "DDF",
+        "SOM",
+        "MBS",
+        "DDG",
+        "NPH",
+        "CMD",
+        "M12",
+        "DDH",
+        "ISD",
+        "DDI",
+        "AVR",
+        "PC2",
+        "M13",
+        "RTR",
+        "DDK",
+        "M14",
+        "DDL",
+        "THS",
+        "C13",
+        "MD1",
+        "M15",
+        "DDN",
+        "KTK",
+        "C14",
+        "DD3_DVD",
+        "FRF",
+        "DDO",
+        "DTK",
+        "TPR",
+        "ORI",
+        "DDP",
+        "BFZ",
+        "C15",
+        "DDQ",
+        "SOI",
+        "KLD",
+        "C16",
+        "PCA",
+        "AKH",
+        "CMA",
+        "E01",
+        "HOU"
+      ],
+      "rarity": "Basic Land",
+      "subtypes": [
+        "Plains"
+      ],
+      "supertypes": [
+        "Basic"
+      ],
+      "type": "Basic Land — Plains",
+      "types": [
+        "Land"
+      ]
+    },
+    {
+      "artist": "Douglas Shuler",
+      "colorIdentity": [
+        "W"
+      ],
+      "foreignNames": [
+        {
+          "language": "Chinese Simplified",
+          "name": "平原"
+        },
+        {
+          "language": "Chinese Traditional",
+          "name": "平原"
+        },
+        {
+          "language": "French",
+          "name": "Plaine"
+        },
+        {
+          "language": "German",
+          "name": "Ebene"
+        },
+        {
+          "language": "Italian",
+          "name": "Pianura"
+        },
+        {
+          "language": "Japanese",
+          "name": "平地"
+        },
+        {
+          "language": "Korean",
+          "name": "들"
+        },
+        {
+          "language": "Portuguese (Brazil)",
+          "name": "Planície"
+        },
+        {
+          "language": "Russian",
+          "name": "Равнина"
+        },
+        {
+          "language": "Spanish",
+          "name": "Llanura"
+        }
+      ],
+      "id": "602e372354d9a0c1845ab9278f4f1d519d49fd4a",
+      "imageName": "plains2",
+      "layout": "normal",
+      "legalities": [
+        {
+          "format": "Amonkhet Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Battle for Zendikar Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Commander",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ice Age Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Invasion Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kaladesh Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Kamigawa Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Khans of Tarkir Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Legacy",
+          "legality": "Legal"
+        },
+        {
+          "format": "Lorwyn-Shadowmoor Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Masques Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirage Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Modern",
+          "legality": "Legal"
+        },
+        {
+          "format": "Odyssey Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Onslaught Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Return to Ravnica Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Scars of Mirrodin Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shadows over Innistrad Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Shards of Alara Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Standard",
+          "legality": "Legal"
+        },
+        {
+          "format": "Tempest Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Theros Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Time Spiral Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Un-Sets",
+          "legality": "Legal"
+        },
+        {
+          "format": "Urza Block",
+          "legality": "Legal"
+        },
+        {
+          "format": "Vintage",
+          "legality": "Legal"
+        },
+        {
+          "format": "Zendikar Block",
+          "legality": "Legal"
+        }
+      ],
+      "mciNumber": "87",
+      "name": "Plains",
+      "number": "87",
+      "printings": [
+        "LEA",
+        "LEB",
+        "2ED",
+        "CED",
+        "CEI",
+        "3ED",
+        "4ED",
+        "ICE",
+        "RQS",
+        "pARL",
+        "MIR",
+        "ITP",
+        "5ED",
+        "POR",
+        "pPRE",
+        "TMP",
+        "pJGP",
+        "PO2",
+        "UGL",
+        "pALP",
+        "USG",
+        "ATH",
+        "6ED",
+        "PTK",
+        "pGRU",
+        "S99",
+        "MMQ",
+        "BRB",
+        "pELP",
+        "S00",
+        "INV",
+        "7ED",
+        "ODY",
+        "ONS",
+        "8ED",
+        "MRD",
+        "CHK",
+        "UNH",
+        "9ED",
+        "RAV",
+        "CST",
+        "TSP",
+        "10E",
+        "MED",
+        "LRW",
+        "SHM",
+        "ALA",
+        "DDC",
+        "M10",
+        "HOP",
+        "ME3",
+        "ZEN",
+        "H09",
+        "DDE",
+        "ROE",
+        "ARC",
+        "M11",
+        "DDF",
+        "SOM",
+        "MBS",
+        "DDG",
+        "NPH",
+        "CMD",
+        "M12",
+        "DDH",
+        "ISD",
+        "DDI",
+        "AVR",
+        "PC2",
+        "M13",
+        "RTR",
+        "DDK",
+        "M14",
+        "DDL",
+        "THS",
+        "C13",
+        "MD1",
+        "M15",
+        "DDN",
+        "KTK",
+        "C14",
+        "DD3_DVD",
+        "FRF",
+        "DDO",
+        "DTK",
+        "TPR",
+        "ORI",
+        "DDP",
+        "BFZ",
+        "C15",
+        "DDQ",
+        "SOI",
+        "KLD",
+        "C16",
+        "PCA",
+        "AKH",
+        "CMA",
+        "E01",
+        "HOU"
+      ],
+      "rarity": "Basic Land",
+      "subtypes": [
+        "Plains"
+      ],
+      "supertypes": [
+        "Basic"
+      ],
+      "type": "Basic Land — Plains",
+      "types": [
+        "Land"
       ]
     }
   ]

--- a/json/C16.json
+++ b/json/C16.json
@@ -1,6 +1,7 @@
 {
   "name": "Commander 2016",
   "code": "C16",
+  "magicCardsInfoCode": "c16",
   "releaseDate": "2016-11-11",
   "border": "black",
   "type": "commander",
@@ -78,6 +79,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "1",
       "multiverseid": 420618,
       "name": "Duelist's Heritage",
       "number": "1",
@@ -164,6 +166,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "2",
       "multiverseid": 420619,
       "name": "Entrapment Maneuver",
       "number": "2",
@@ -262,6 +265,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "3",
       "multiverseid": 420620,
       "name": "Orzhov Advokist",
       "number": "3",
@@ -365,6 +369,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "4",
       "multiverseid": 420621,
       "name": "Selfless Squire",
       "number": "4",
@@ -465,6 +470,7 @@
         }
       ],
       "manaCost": "{6}{W}",
+      "mciNumber": "5",
       "multiverseid": 420622,
       "name": "Sublime Exhalation",
       "number": "5",
@@ -555,6 +561,7 @@
         }
       ],
       "manaCost": "{6}{U}",
+      "mciNumber": "6",
       "multiverseid": 420623,
       "name": "Coastal Breach",
       "number": "6",
@@ -645,6 +652,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "7",
       "multiverseid": 420624,
       "name": "Deepglow Skate",
       "number": "7",
@@ -743,6 +751,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "8",
       "multiverseid": 420625,
       "name": "Faerie Artisans",
       "number": "8",
@@ -859,6 +868,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "9",
       "multiverseid": 420626,
       "name": "Grip of Phyresis",
       "number": "9",
@@ -948,6 +958,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "10",
       "multiverseid": 420627,
       "name": "Manifold Insights",
       "number": "10",
@@ -1041,6 +1052,7 @@
         }
       ],
       "manaCost": "{6}{B}",
+      "mciNumber": "11",
       "multiverseid": 420628,
       "name": "Cruel Entertainment",
       "number": "11",
@@ -1178,6 +1190,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "12",
       "multiverseid": 420629,
       "name": "Curse of Vengeance",
       "number": "12",
@@ -1272,6 +1285,7 @@
         }
       ],
       "manaCost": "{5}{B}",
+      "mciNumber": "13",
       "multiverseid": 420630,
       "name": "Curtains' Call",
       "number": "13",
@@ -1366,6 +1380,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "14",
       "multiverseid": 420631,
       "name": "Magus of the Will",
       "number": "14",
@@ -1478,6 +1493,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "15",
       "multiverseid": 420632,
       "name": "Parting Thoughts",
       "number": "15",
@@ -1571,6 +1587,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "16",
       "multiverseid": 420633,
       "name": "Charging Cinderhorn",
       "number": "16",
@@ -1674,6 +1691,7 @@
         }
       ],
       "manaCost": "{6}{R}",
+      "mciNumber": "17",
       "multiverseid": 420634,
       "name": "Divergent Transformations",
       "number": "17",
@@ -1788,6 +1806,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "18",
       "multiverseid": 420635,
       "name": "Frenzied Fugue",
       "number": "18",
@@ -1881,6 +1900,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "19",
       "multiverseid": 420636,
       "name": "Goblin Spymaster",
       "number": "19",
@@ -1973,6 +1993,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "20",
       "multiverseid": 420637,
       "name": "Runehorn Hellkite",
       "number": "20",
@@ -2067,6 +2088,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "21",
       "multiverseid": 420638,
       "name": "Benefactor's Draught",
       "number": "21",
@@ -2161,6 +2183,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "22",
       "multiverseid": 420639,
       "name": "Evolutionary Escalation",
       "number": "22",
@@ -2255,6 +2278,7 @@
         }
       ],
       "manaCost": "{10}{G}",
+      "mciNumber": "23",
       "multiverseid": 420640,
       "name": "Primeval Protector",
       "number": "23",
@@ -2349,6 +2373,7 @@
         }
       ],
       "manaCost": "{6}{G}",
+      "mciNumber": "24",
       "multiverseid": 420641,
       "name": "Seeds of Renewal",
       "number": "24",
@@ -2447,6 +2472,7 @@
         }
       ],
       "manaCost": "{7}{G}",
+      "mciNumber": "25",
       "multiverseid": 420642,
       "name": "Stonehoof Chieftain",
       "number": "25",
@@ -2535,6 +2561,7 @@
         }
       ],
       "manaCost": "{R}{W}",
+      "mciNumber": "26",
       "multiverseid": 420643,
       "name": "Akiri, Line-Slinger",
       "number": "26",
@@ -2648,6 +2675,7 @@
         }
       ],
       "manaCost": "{2}{U}{B}",
+      "mciNumber": "27",
       "multiverseid": 420644,
       "name": "Ancient Excavation",
       "number": "27",
@@ -2743,6 +2771,7 @@
         }
       ],
       "manaCost": "{G}{W}{U}{B}",
+      "mciNumber": "28",
       "multiverseid": 420645,
       "name": "Atraxa, Praetors' Voice",
       "number": "28",
@@ -2863,6 +2892,7 @@
         }
       ],
       "manaCost": "{W}{U}{B}{R}",
+      "mciNumber": "29",
       "multiverseid": 420646,
       "name": "Breya, Etherium Shaper",
       "number": "29",
@@ -2963,6 +2993,7 @@
         }
       ],
       "manaCost": "{2}{R}{W}",
+      "mciNumber": "30",
       "multiverseid": 420647,
       "name": "Bruse Tarl, Boorish Herder",
       "number": "30",
@@ -3079,6 +3110,7 @@
         }
       ],
       "manaCost": "{4}{B}{R}",
+      "mciNumber": "31",
       "multiverseid": 420648,
       "name": "Grave Upheaval",
       "number": "31",
@@ -3161,6 +3193,7 @@
         }
       ],
       "manaCost": "{3}{B}{G}",
+      "mciNumber": "32",
       "multiverseid": 420649,
       "name": "Ikra Shidiqi, the Usurper",
       "number": "32",
@@ -3278,6 +3311,7 @@
         }
       ],
       "manaCost": "{2}{W}{U}",
+      "mciNumber": "33",
       "multiverseid": 420650,
       "name": "Ishai, Ojutai Dragonspeaker",
       "number": "33",
@@ -3395,6 +3429,7 @@
         }
       ],
       "manaCost": "{3}{U}{R}",
+      "mciNumber": "34",
       "multiverseid": 420651,
       "name": "Kraum, Ludevic's Opus",
       "number": "34",
@@ -3524,6 +3559,7 @@
         }
       ],
       "manaCost": "{2}{G}{U}",
+      "mciNumber": "35",
       "multiverseid": 420652,
       "name": "Kydele, Chosen of Kruphix",
       "number": "35",
@@ -3653,6 +3689,7 @@
         }
       ],
       "manaCost": "{R}{G}{W}{U}",
+      "mciNumber": "36",
       "multiverseid": 420653,
       "name": "Kynaios and Tiro of Meletis",
       "number": "36",
@@ -3754,6 +3791,7 @@
         }
       ],
       "manaCost": "{1}{U}{R}",
+      "mciNumber": "37",
       "multiverseid": 420654,
       "name": "Ludevic, Necro-Alchemist",
       "number": "37",
@@ -3894,6 +3932,7 @@
         }
       ],
       "manaCost": "{3}{W}{U}",
+      "mciNumber": "38",
       "multiverseid": 420655,
       "name": "Migratory Route",
       "number": "38",
@@ -3975,6 +4014,7 @@
         }
       ],
       "manaCost": "{3}{W}{B}",
+      "mciNumber": "39",
       "multiverseid": 420656,
       "name": "Ravos, Soultender",
       "number": "39",
@@ -4087,6 +4127,7 @@
         }
       ],
       "manaCost": "{1}{B}{G}",
+      "mciNumber": "40",
       "multiverseid": 420657,
       "name": "Reyhan, Last of the Abzan",
       "number": "40",
@@ -4207,6 +4248,7 @@
         }
       ],
       "manaCost": "{B}{R}{G}{W}",
+      "mciNumber": "41",
       "multiverseid": 420658,
       "name": "Saskia the Unyielding",
       "number": "41",
@@ -4315,6 +4357,7 @@
         }
       ],
       "manaCost": "{2}{G}{W}",
+      "mciNumber": "42",
       "multiverseid": 420659,
       "name": "Sidar Kondo of Jamuraa",
       "number": "42",
@@ -4415,6 +4458,7 @@
         }
       ],
       "manaCost": "{1}{U}{B}",
+      "mciNumber": "43",
       "multiverseid": 420660,
       "name": "Silas Renn, Seeker Adept",
       "number": "43",
@@ -4551,6 +4595,7 @@
         }
       ],
       "manaCost": "{3}{G}{W}",
+      "mciNumber": "44",
       "multiverseid": 420661,
       "name": "Sylvan Reclamation",
       "number": "44",
@@ -4632,6 +4677,7 @@
         }
       ],
       "manaCost": "{2}{R}{G}",
+      "mciNumber": "45",
       "multiverseid": 420662,
       "name": "Tana, the Bloodsower",
       "number": "45",
@@ -4745,6 +4791,7 @@
         }
       ],
       "manaCost": "{G}{U}",
+      "mciNumber": "46",
       "multiverseid": 420663,
       "name": "Thrasios, Triton Hero",
       "number": "46",
@@ -4861,6 +4908,7 @@
         }
       ],
       "manaCost": "{6}{R}{G}",
+      "mciNumber": "47",
       "multiverseid": 420664,
       "name": "Treacherous Terrain",
       "number": "47",
@@ -4942,6 +4990,7 @@
         }
       ],
       "manaCost": "{1}{W}{B}",
+      "mciNumber": "48",
       "multiverseid": 420665,
       "name": "Tymna the Weaver",
       "number": "48",
@@ -5066,6 +5115,7 @@
         }
       ],
       "manaCost": "{1}{B}{R}",
+      "mciNumber": "49",
       "multiverseid": 420666,
       "name": "Vial Smasher the Fierce",
       "number": "49",
@@ -5202,6 +5252,7 @@
         }
       ],
       "manaCost": "{U}{B}{R}{G}",
+      "mciNumber": "50",
       "multiverseid": 420667,
       "name": "Yidris, Maelstrom Wielder",
       "number": "50",
@@ -5315,6 +5366,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "51",
       "multiverseid": 420668,
       "name": "Armory Automaton",
       "number": "51",
@@ -5421,6 +5473,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "52",
       "multiverseid": 420669,
       "name": "Boompile",
       "number": "52",
@@ -5504,6 +5557,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "53",
       "multiverseid": 420670,
       "name": "Conqueror's Flail",
       "number": "53",
@@ -5594,6 +5648,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "54",
       "multiverseid": 420671,
       "name": "Crystalline Crawler",
       "number": "54",
@@ -5691,6 +5746,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "55",
       "multiverseid": 420672,
       "name": "Prismatic Geoscope",
       "number": "55",
@@ -5792,6 +5848,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "56",
       "multiverseid": 420673,
       "name": "Ash Barrens",
       "number": "56",
@@ -5880,6 +5937,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "57",
       "multiverseid": 420674,
       "name": "Abzan Falconer",
       "number": "57",
@@ -5985,6 +6043,7 @@
         }
       ],
       "manaCost": "{6}{W}{W}{W}",
+      "mciNumber": "58",
       "multiverseid": 420675,
       "name": "Blazing Archon",
       "number": "58",
@@ -6086,6 +6145,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "59",
       "multiverseid": 420676,
       "name": "Blind Obedience",
       "number": "59",
@@ -6189,6 +6249,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "60",
       "multiverseid": 420677,
       "name": "Brave the Sands",
       "number": "60",
@@ -6284,6 +6345,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "61",
       "multiverseid": 420678,
       "name": "Cathars' Crusade",
       "number": "61",
@@ -6379,6 +6441,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "62",
       "multiverseid": 420679,
       "name": "Citadel Siege",
       "number": "62",
@@ -6473,6 +6536,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "63",
       "multiverseid": 420680,
       "name": "Custodi Soulbinders",
       "number": "63",
@@ -6568,6 +6632,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "64",
       "multiverseid": 420681,
       "name": "Dispeller's Capsule",
       "number": "64",
@@ -6663,6 +6728,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "65",
       "multiverseid": 420682,
       "name": "Elite Scaleguard",
       "number": "65",
@@ -6768,6 +6834,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "66",
       "multiverseid": 420683,
       "name": "Ghostly Prison",
       "number": "66",
@@ -6871,6 +6938,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "67",
       "multiverseid": 420684,
       "name": "Hoofprints of the Stag",
       "number": "67",
@@ -6966,6 +7034,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "68",
       "multiverseid": 420685,
       "name": "Hushwing Gryff",
       "number": "68",
@@ -7090,6 +7159,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "69",
       "multiverseid": 420686,
       "name": "Mentor of the Meek",
       "number": "69",
@@ -7201,6 +7271,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "70",
       "multiverseid": 420687,
       "name": "Mirror Entity",
       "number": "70",
@@ -7312,6 +7383,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "71",
       "multiverseid": 420688,
       "name": "Oblation",
       "number": "71",
@@ -7399,6 +7471,7 @@
         }
       ],
       "manaCost": "{4}{W}{W}",
+      "mciNumber": "72",
       "multiverseid": 420689,
       "name": "Open the Vaults",
       "number": "72",
@@ -7507,6 +7580,7 @@
         }
       ],
       "manaCost": "{4}{W}{W}",
+      "mciNumber": "73",
       "multiverseid": 420690,
       "name": "Phyrexian Rebirth",
       "number": "73",
@@ -7605,6 +7679,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "74",
       "multiverseid": 420691,
       "name": "Reveillark",
       "number": "74",
@@ -7730,6 +7805,7 @@
         }
       ],
       "manaCost": "{6}{W}{W}",
+      "mciNumber": "75",
       "multiverseid": 420692,
       "name": "Reverse the Sands",
       "number": "75",
@@ -7829,6 +7905,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "76",
       "multiverseid": 420693,
       "name": "Sanctum Gargoyle",
       "number": "76",
@@ -7932,6 +8009,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "77",
       "multiverseid": 420694,
       "name": "Sphere of Safety",
       "number": "77",
@@ -8027,6 +8105,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "78",
       "multiverseid": 420695,
       "name": "Swords to Plowshares",
       "number": "78",
@@ -8141,6 +8220,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "79",
       "multiverseid": 420696,
       "name": "Wave of Reckoning",
       "number": "79",
@@ -8230,6 +8310,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "80",
       "multiverseid": 420697,
       "name": "Windborn Muse",
       "number": "80",
@@ -8331,6 +8412,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "81",
       "multiverseid": 420698,
       "name": "Academy Elite",
       "number": "81",
@@ -8426,6 +8508,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "82",
       "multiverseid": 420699,
       "name": "Aeon Chronicler",
       "number": "82",
@@ -8566,6 +8649,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "83",
       "multiverseid": 420700,
       "name": "Arcane Denial",
       "number": "83",
@@ -8659,6 +8743,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "84",
       "multiverseid": 420701,
       "name": "Chain of Vapor",
       "number": "84",
@@ -8743,6 +8828,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "85",
       "multiverseid": 420702,
       "name": "Chasm Skulker",
       "number": "85",
@@ -8844,6 +8930,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "86",
       "multiverseid": 420703,
       "name": "Chief Engineer",
       "number": "86",
@@ -8974,6 +9061,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "87",
       "multiverseid": 420704,
       "name": "Devastation Tide",
       "number": "87",
@@ -9063,6 +9151,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "88",
       "multiverseid": 420705,
       "name": "Disdainful Stroke",
       "number": "88",
@@ -9159,6 +9248,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "89",
       "multiverseid": 420706,
       "name": "Etherium Sculptor",
       "number": "89",
@@ -9272,6 +9362,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "90",
       "multiverseid": 420707,
       "name": "Ethersworn Adjudicator",
       "number": "90",
@@ -9368,6 +9459,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "91",
       "multiverseid": 420708,
       "name": "Evacuation",
       "number": "91",
@@ -9462,6 +9554,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "92",
       "multiverseid": 420709,
       "name": "Master of Etherium",
       "number": "92",
@@ -9565,6 +9658,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "93",
       "multiverseid": 420710,
       "name": "Minds Aglow",
       "number": "93",
@@ -9656,6 +9750,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "94",
       "multiverseid": 420711,
       "name": "Propaganda",
       "number": "94",
@@ -9769,6 +9864,7 @@
         }
       ],
       "manaCost": "{X}{U}",
+      "mciNumber": "95",
       "multiverseid": 420712,
       "name": "Read the Runes",
       "number": "95",
@@ -9863,6 +9959,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "96",
       "multiverseid": 420713,
       "name": "Reins of Power",
       "number": "96",
@@ -9959,6 +10056,7 @@
         }
       ],
       "manaCost": "{5}{U}",
+      "mciNumber": "97",
       "multiverseid": 420714,
       "name": "Spelltwine",
       "number": "97",
@@ -10079,6 +10177,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "98",
       "multiverseid": 420715,
       "name": "Swan Song",
       "number": "98",
@@ -10173,6 +10272,7 @@
         }
       ],
       "manaCost": "{3}{U/P}",
+      "mciNumber": "99",
       "multiverseid": 420716,
       "name": "Tezzeret's Gambit",
       "number": "99",
@@ -10284,6 +10384,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "100",
       "multiverseid": 420717,
       "name": "Thrummingbird",
       "number": "100",
@@ -10402,6 +10503,7 @@
         }
       ],
       "manaCost": "{7}{U}",
+      "mciNumber": "101",
       "multiverseid": 420718,
       "name": "Treasure Cruise",
       "number": "101",
@@ -10516,6 +10618,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "102",
       "multiverseid": 420719,
       "name": "Trinket Mage",
       "number": "102",
@@ -10619,6 +10722,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "103",
       "multiverseid": 420720,
       "name": "Vedalken Engineer",
       "number": "103",
@@ -10710,6 +10814,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "104",
       "multiverseid": 420721,
       "name": "Windfall",
       "number": "104",
@@ -10802,6 +10907,7 @@
         }
       ],
       "manaCost": "{5}{B}{B}{B}",
+      "mciNumber": "105",
       "multiverseid": 420722,
       "name": "Army of the Damned",
       "number": "105",
@@ -10887,6 +10993,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "106",
       "multiverseid": 420723,
       "name": "Bane of the Living",
       "number": "106",
@@ -10991,6 +11098,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "107",
       "multiverseid": 420724,
       "name": "Beacon of Unrest",
       "number": "107",
@@ -11090,6 +11198,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "108",
       "multiverseid": 420725,
       "name": "Brutal Hordechief",
       "number": "108",
@@ -11208,6 +11317,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "109",
       "multiverseid": 420726,
       "name": "Executioner's Capsule",
       "number": "109",
@@ -11304,6 +11414,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "110",
       "multiverseid": 420727,
       "name": "Festercreep",
       "number": "110",
@@ -11397,6 +11508,7 @@
         }
       ],
       "manaCost": "{5}{B}{B}",
+      "mciNumber": "111",
       "multiverseid": 420728,
       "name": "Ghastly Conscription",
       "number": "111",
@@ -11543,6 +11655,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "112",
       "multiverseid": 420729,
       "name": "Guiltfeeder",
       "number": "112",
@@ -11639,6 +11752,7 @@
         }
       ],
       "manaCost": "{7}{B}{B}",
+      "mciNumber": "113",
       "multiverseid": 420730,
       "name": "In Garruk's Wake",
       "number": "113",
@@ -11725,6 +11839,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "114",
       "multiverseid": 420731,
       "name": "Languish",
       "number": "114",
@@ -11815,6 +11930,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "115",
       "multiverseid": 420732,
       "name": "Necroplasm",
       "number": "115",
@@ -11922,6 +12038,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "116",
       "multiverseid": 420733,
       "name": "Sangromancer",
       "number": "116",
@@ -12019,6 +12136,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "117",
       "multiverseid": 420734,
       "name": "Waste Not",
       "number": "117",
@@ -12108,6 +12226,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "118",
       "multiverseid": 420735,
       "name": "Wight of Precinct Six",
       "number": "118",
@@ -12212,6 +12331,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "119",
       "multiverseid": 420736,
       "name": "Alesha, Who Smiles at Death",
       "number": "119",
@@ -12321,6 +12441,7 @@
         }
       ],
       "manaCost": "{8}{R}",
+      "mciNumber": "120",
       "multiverseid": 420737,
       "name": "Blasphemous Act",
       "number": "120",
@@ -12424,6 +12545,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "121",
       "multiverseid": 420738,
       "name": "Breath of Fury",
       "number": "121",
@@ -12513,6 +12635,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "122",
       "multiverseid": 420739,
       "name": "Chaos Warp",
       "number": "122",
@@ -12619,6 +12742,7 @@
       ],
       "loyalty": 3,
       "manaCost": "{3}{R}",
+      "mciNumber": "123",
       "multiverseid": 420740,
       "name": "Daretti, Scrap Savant",
       "number": "123",
@@ -12721,6 +12845,7 @@
         }
       ],
       "manaCost": "{5}{R}{R}",
+      "mciNumber": "124",
       "multiverseid": 420741,
       "name": "Dragon Mage",
       "number": "124",
@@ -12822,6 +12947,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "125",
       "multiverseid": 420742,
       "name": "Godo, Bandit Warlord",
       "number": "125",
@@ -12925,6 +13051,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "126",
       "multiverseid": 420743,
       "name": "Grab the Reins",
       "number": "126",
@@ -13028,6 +13155,7 @@
         }
       ],
       "manaCost": "{5}{R}{R}",
+      "mciNumber": "127",
       "multiverseid": 420744,
       "name": "Hellkite Igniter",
       "number": "127",
@@ -13127,6 +13255,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "128",
       "multiverseid": 420745,
       "name": "Hellkite Tyrant",
       "number": "128",
@@ -13227,6 +13356,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "129",
       "multiverseid": 420746,
       "name": "Humble Defector",
       "number": "129",
@@ -13336,6 +13466,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "130",
       "multiverseid": 420747,
       "name": "Kazuul, Tyrant of the Cliffs",
       "number": "130",
@@ -13459,6 +13590,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "131",
       "multiverseid": 420748,
       "name": "Past in Flames",
       "number": "131",
@@ -13571,6 +13703,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "132",
       "multiverseid": 420749,
       "name": "Reforge the Soul",
       "number": "132",
@@ -13660,6 +13793,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "133",
       "multiverseid": 420750,
       "name": "Slobad, Goblin Tinkerer",
       "number": "133",
@@ -13764,6 +13898,7 @@
         }
       ],
       "manaCost": "{5}{R}{R}",
+      "mciNumber": "134",
       "multiverseid": 420751,
       "name": "Stalking Vengeance",
       "number": "134",
@@ -13859,6 +13994,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "135",
       "multiverseid": 420752,
       "name": "Taurean Mauler",
       "number": "135",
@@ -13956,6 +14092,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "136",
       "multiverseid": 420753,
       "name": "Trash for Treasure",
       "number": "136",
@@ -14044,6 +14181,7 @@
         }
       ],
       "manaCost": "{5}{R}{R}",
+      "mciNumber": "137",
       "multiverseid": 420754,
       "name": "Volcanic Vision",
       "number": "137",
@@ -14142,6 +14280,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "138",
       "multiverseid": 420755,
       "name": "Wheel of Fate",
       "number": "138",
@@ -14280,6 +14419,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "139",
       "multiverseid": 420756,
       "name": "Whims of the Fates",
       "number": "139",
@@ -14383,6 +14523,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "140",
       "multiverseid": 420757,
       "name": "Whipflare",
       "number": "140",
@@ -14473,6 +14614,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "141",
       "multiverseid": 420758,
       "name": "Beast Within",
       "number": "141",
@@ -14575,6 +14717,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "142",
       "multiverseid": 420759,
       "name": "Beastmaster Ascension",
       "number": "142",
@@ -14669,6 +14812,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "143",
       "multiverseid": 420760,
       "name": "Burgeoning",
       "number": "143",
@@ -14764,6 +14908,7 @@
         }
       ],
       "manaCost": "{1}{G}{G}",
+      "mciNumber": "144",
       "multiverseid": 420761,
       "name": "Champion of Lambholt",
       "number": "144",
@@ -14864,6 +15009,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "145",
       "multiverseid": 420762,
       "name": "Collective Voyage",
       "number": "145",
@@ -14955,6 +15101,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "146",
       "multiverseid": 420763,
       "name": "Cultivate",
       "number": "146",
@@ -15055,6 +15202,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "147",
       "multiverseid": 420764,
       "name": "Den Protector",
       "number": "147",
@@ -15164,6 +15312,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "148",
       "multiverseid": 420765,
       "name": "Far Wanderings",
       "number": "148",
@@ -15253,6 +15402,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "149",
       "multiverseid": 420766,
       "name": "Farseek",
       "number": "149",
@@ -15346,6 +15496,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "150",
       "multiverseid": 420767,
       "name": "Forgotten Ancient",
       "number": "150",
@@ -15458,6 +15609,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "151",
       "multiverseid": 420768,
       "name": "Gamekeeper",
       "number": "151",
@@ -15563,6 +15715,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "152",
       "multiverseid": 420769,
       "name": "Hardened Scales",
       "number": "152",
@@ -15662,6 +15815,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "153",
       "multiverseid": 420770,
       "name": "Inspiring Call",
       "number": "153",
@@ -15757,6 +15911,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "154",
       "multiverseid": 420771,
       "name": "Kalonian Hydra",
       "number": "154",
@@ -15857,6 +16012,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "155",
       "multiverseid": 420772,
       "name": "Kodama's Reach",
       "number": "155",
@@ -15954,6 +16110,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "156",
       "multiverseid": 420773,
       "name": "Lurking Predators",
       "number": "156",
@@ -16052,6 +16209,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "157",
       "multiverseid": 420774,
       "name": "Managorger Hydra",
       "number": "157",
@@ -16152,6 +16310,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "158",
       "multiverseid": 420775,
       "name": "Mycoloth",
       "number": "158",
@@ -16267,6 +16426,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "159",
       "multiverseid": 420776,
       "name": "Oath of Druids",
       "number": "159",
@@ -16365,6 +16525,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "160",
       "multiverseid": 420777,
       "name": "Quirion Explorer",
       "number": "160",
@@ -16471,6 +16632,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "161",
       "multiverseid": 420778,
       "name": "Rampant Growth",
       "number": "161",
@@ -16577,6 +16739,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "162",
       "multiverseid": 420779,
       "name": "Realm Seekers",
       "number": "162",
@@ -16683,6 +16846,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "163",
       "multiverseid": 420780,
       "name": "Rites of Flourishing",
       "number": "163",
@@ -16779,6 +16943,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "164",
       "multiverseid": 420781,
       "name": "Sakura-Tribe Elder",
       "number": "164",
@@ -16882,6 +17047,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "165",
       "multiverseid": 420782,
       "name": "Satyr Wayfinder",
       "number": "165",
@@ -16975,6 +17141,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "166",
       "multiverseid": 420783,
       "name": "Scavenging Ooze",
       "number": "166",
@@ -17078,6 +17245,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "167",
       "multiverseid": 420784,
       "name": "Shamanic Revelation",
       "number": "167",
@@ -17174,6 +17342,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "168",
       "multiverseid": 420785,
       "name": "Solidarity of Heroes",
       "number": "168",
@@ -17289,6 +17458,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "169",
       "multiverseid": 420786,
       "name": "Sylvok Explorer",
       "number": "169",
@@ -17375,6 +17545,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "170",
       "multiverseid": 420787,
       "name": "Tempt with Discovery",
       "number": "170",
@@ -17473,6 +17644,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "171",
       "multiverseid": 420788,
       "name": "Thelonite Hermit",
       "number": "171",
@@ -17562,6 +17734,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "172",
       "multiverseid": 420789,
       "name": "Thunderfoot Baloth",
       "number": "172",
@@ -17679,6 +17852,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "173",
       "multiverseid": 420790,
       "name": "Tuskguard Captain",
       "number": "173",
@@ -17779,6 +17953,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "174",
       "multiverseid": 420791,
       "name": "Veteran Explorer",
       "number": "174",
@@ -17878,6 +18053,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "175",
       "multiverseid": 420792,
       "name": "Wall of Blossoms",
       "number": "175",
@@ -17980,6 +18156,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "176",
       "multiverseid": 420793,
       "name": "Wild Beastmaster",
       "number": "176",
@@ -18088,6 +18265,7 @@
         }
       ],
       "manaCost": "{W}{B}{G}",
+      "mciNumber": "177",
       "multiverseid": 420794,
       "name": "Abzan Charm",
       "number": "177",
@@ -18187,6 +18365,7 @@
         }
       ],
       "manaCost": "{2}{R}{W}{B}",
+      "mciNumber": "178",
       "multiverseid": 420795,
       "name": "Ankle Shanker",
       "number": "178",
@@ -18282,6 +18461,7 @@
         }
       ],
       "manaCost": "{R}{G}",
+      "mciNumber": "179",
       "multiverseid": 420796,
       "name": "Artifact Mutation",
       "number": "179",
@@ -18375,6 +18555,7 @@
         }
       ],
       "manaCost": "{G}{W}",
+      "mciNumber": "180",
       "multiverseid": 420797,
       "name": "Aura Mutation",
       "number": "180",
@@ -18464,6 +18645,7 @@
         }
       ],
       "manaCost": "{U}{B}",
+      "mciNumber": "181",
       "multiverseid": 420798,
       "name": "Baleful Strix",
       "number": "181",
@@ -18565,6 +18747,7 @@
         }
       ],
       "manaCost": "{3}{B}{R}",
+      "mciNumber": "182",
       "multiverseid": 420799,
       "name": "Bituminous Blast",
       "number": "182",
@@ -18691,6 +18874,7 @@
         }
       ],
       "manaCost": "{4}{U}{B}{R}",
+      "mciNumber": "183",
       "multiverseid": 420800,
       "name": "Blood Tyrant",
       "number": "183",
@@ -18801,6 +18985,7 @@
         }
       ],
       "manaCost": "{2}{R}{G}",
+      "mciNumber": "184",
       "multiverseid": 420801,
       "name": "Bloodbraid Elf",
       "number": "184",
@@ -18931,6 +19116,7 @@
         }
       ],
       "manaCost": "{R}{W}",
+      "mciNumber": "185",
       "multiverseid": 420802,
       "name": "Boros Charm",
       "number": "185",
@@ -19033,6 +19219,7 @@
         }
       ],
       "manaCost": "{1}{G}{U}",
+      "mciNumber": "186",
       "multiverseid": 420803,
       "name": "Bred for the Hunt",
       "number": "186",
@@ -19129,6 +19316,7 @@
         }
       ],
       "manaCost": "{X}{R}{G}",
+      "mciNumber": "187",
       "multiverseid": 420804,
       "name": "Clan Defiance",
       "number": "187",
@@ -19230,6 +19418,7 @@
         }
       ],
       "manaCost": "{G}{U}",
+      "mciNumber": "188",
       "multiverseid": 420805,
       "name": "Coiling Oracle",
       "number": "188",
@@ -19332,6 +19521,7 @@
         }
       ],
       "manaCost": "{3}{U}{B}",
+      "mciNumber": "189",
       "multiverseid": 420806,
       "name": "Consuming Aberration",
       "number": "189",
@@ -19439,6 +19629,7 @@
         }
       ],
       "manaCost": "{2}{B}{G}",
+      "mciNumber": "190",
       "multiverseid": 420807,
       "name": "Corpsejack Menace",
       "number": "190",
@@ -19548,6 +19739,7 @@
         }
       ],
       "manaCost": "{R}{W}{B}",
+      "mciNumber": "191",
       "multiverseid": 420808,
       "name": "Crackling Doom",
       "number": "191",
@@ -19658,6 +19850,7 @@
         }
       ],
       "manaCost": "{1}{G}{W}",
+      "mciNumber": "192",
       "multiverseid": 420809,
       "name": "Dauntless Escort",
       "number": "192",
@@ -19765,6 +19958,7 @@
         }
       ],
       "manaCost": "{2}{R}{G}",
+      "mciNumber": "193",
       "multiverseid": 420810,
       "name": "Decimate",
       "number": "193",
@@ -19865,6 +20059,7 @@
         }
       ],
       "manaCost": "{4}{W}{B}{G}",
+      "mciNumber": "194",
       "multiverseid": 420811,
       "name": "Duneblast",
       "number": "194",
@@ -19955,6 +20150,7 @@
         }
       ],
       "manaCost": "{1}{G}{U}",
+      "mciNumber": "195",
       "multiverseid": 420812,
       "name": "Edric, Spymaster of Trest",
       "number": "195",
@@ -20068,6 +20264,7 @@
         }
       ],
       "manaCost": "{4}{G}{W}",
+      "mciNumber": "196",
       "multiverseid": 420813,
       "name": "Enduring Scalelord",
       "number": "196",
@@ -20169,6 +20366,7 @@
         }
       ],
       "manaCost": "{4}{U}{R}",
+      "mciNumber": "197",
       "multiverseid": 420814,
       "name": "Etherium-Horn Sorcerer",
       "number": "197",
@@ -20274,6 +20472,7 @@
         }
       ],
       "manaCost": "{2}{G}{U}",
+      "mciNumber": "198",
       "multiverseid": 420815,
       "name": "Fathom Mage",
       "number": "198",
@@ -20410,6 +20609,7 @@
         }
       ],
       "manaCost": "{5}{W}{W}{U}",
+      "mciNumber": "199",
       "multiverseid": 420816,
       "name": "Filigree Angel",
       "number": "199",
@@ -20507,6 +20707,7 @@
         }
       ],
       "manaCost": "{2}{B}{G}{W}",
+      "mciNumber": "200",
       "multiverseid": 420817,
       "name": "Ghave, Guru of Spores",
       "number": "200",
@@ -20611,6 +20812,7 @@
         }
       ],
       "manaCost": "{U}{B}{R}{G}",
+      "mciNumber": "201",
       "multiverseid": 420818,
       "name": "Glint-Eye Nephilim",
       "number": "201",
@@ -20707,6 +20909,7 @@
         }
       ],
       "manaCost": "{1}{W}{U}",
+      "mciNumber": "202",
       "multiverseid": 420819,
       "name": "Gwafa Hazid, Profiteer",
       "number": "202",
@@ -20813,6 +21016,7 @@
         }
       ],
       "manaCost": "{1}{W}{U}",
+      "mciNumber": "203",
       "multiverseid": 420820,
       "name": "Hanna, Ship's Navigator",
       "number": "203",
@@ -20914,6 +21118,7 @@
         }
       ],
       "manaCost": "{2}{G}{U}",
+      "mciNumber": "204",
       "multiverseid": 420821,
       "name": "Horizon Chimera",
       "number": "204",
@@ -21015,6 +21220,7 @@
         }
       ],
       "manaCost": "{2}{R}{W}",
+      "mciNumber": "205",
       "multiverseid": 420822,
       "name": "Iroas, God of Victory",
       "number": "205",
@@ -21161,6 +21367,7 @@
         }
       ],
       "manaCost": "{3}{R}{W}",
+      "mciNumber": "206",
       "multiverseid": 420823,
       "name": "Jor Kadeen, the Prevailer",
       "number": "206",
@@ -21261,6 +21468,7 @@
         }
       ],
       "manaCost": "{3}{G}{W}",
+      "mciNumber": "207",
       "multiverseid": 420824,
       "name": "Juniper Order Ranger",
       "number": "207",
@@ -21365,6 +21573,7 @@
         }
       ],
       "manaCost": "{B}{G}",
+      "mciNumber": "208",
       "multiverseid": 420825,
       "name": "Korozda Guildmage",
       "number": "208",
@@ -21473,6 +21682,7 @@
         }
       ],
       "manaCost": "{X}{B}{R}{G}",
+      "mciNumber": "209",
       "multiverseid": 420826,
       "name": "Lavalanche",
       "number": "209",
@@ -21574,6 +21784,7 @@
         }
       ],
       "manaCost": "{2}{G}{U}",
+      "mciNumber": "210",
       "multiverseid": 420827,
       "name": "Master Biomancer",
       "number": "210",
@@ -21676,6 +21887,7 @@
         }
       ],
       "manaCost": "{4}{W}{B}",
+      "mciNumber": "211",
       "multiverseid": 420828,
       "name": "Merciless Eviction",
       "number": "211",
@@ -21773,6 +21985,7 @@
         }
       ],
       "manaCost": "{1}{W}{B}",
+      "mciNumber": "212",
       "multiverseid": 420829,
       "name": "Mortify",
       "number": "212",
@@ -21875,6 +22088,7 @@
         }
       ],
       "manaCost": "{3}{B}{G}",
+      "mciNumber": "213",
       "multiverseid": 420830,
       "name": "Nath of the Gilt-Leaf",
       "number": "213",
@@ -21976,6 +22190,7 @@
         }
       ],
       "manaCost": "{R}{G}{W}",
+      "mciNumber": "214",
       "multiverseid": 420831,
       "name": "Naya Charm",
       "number": "214",
@@ -22083,6 +22298,7 @@
         }
       ],
       "manaCost": "{B}{G}",
+      "mciNumber": "215",
       "multiverseid": 420832,
       "name": "Necrogenesis",
       "number": "215",
@@ -22181,6 +22397,7 @@
         }
       ],
       "manaCost": "{4}{G}{U}",
+      "mciNumber": "216",
       "multiverseid": 420833,
       "name": "Progenitor Mimic",
       "number": "216",
@@ -22315,6 +22532,7 @@
         }
       ],
       "manaCost": "{1}{B}{G}",
+      "mciNumber": "217",
       "multiverseid": 420834,
       "name": "Putrefy",
       "number": "217",
@@ -22417,6 +22635,7 @@
         }
       ],
       "manaCost": "{B}{R}",
+      "mciNumber": "218",
       "multiverseid": 420835,
       "name": "Rakdos Charm",
       "number": "218",
@@ -22513,6 +22732,7 @@
         }
       ],
       "manaCost": "{4}{R}{G}",
+      "mciNumber": "219",
       "multiverseid": 420836,
       "name": "Rubblehulk",
       "number": "219",
@@ -22612,6 +22832,7 @@
         }
       ],
       "manaCost": "{1}{G}{W}",
+      "mciNumber": "220",
       "multiverseid": 420837,
       "name": "Selvala, Explorer Returned",
       "number": "220",
@@ -22729,6 +22950,7 @@
         }
       ],
       "manaCost": "{3}{W}{U}{B}",
+      "mciNumber": "221",
       "multiverseid": 420838,
       "name": "Sharuum the Hegemon",
       "number": "221",
@@ -22831,6 +23053,7 @@
         }
       ],
       "manaCost": "{1}{U}{R}",
+      "mciNumber": "222",
       "multiverseid": 420839,
       "name": "Spellheart Chimera",
       "number": "222",
@@ -22933,6 +23156,7 @@
         }
       ],
       "manaCost": "{3}{U}{B}",
+      "mciNumber": "223",
       "multiverseid": 420840,
       "name": "Sphinx Summoner",
       "number": "223",
@@ -23029,6 +23253,7 @@
         }
       ],
       "manaCost": "{W}{U}{B}",
+      "mciNumber": "224",
       "multiverseid": 420841,
       "name": "Sydri, Galvanic Genius",
       "number": "224",
@@ -23151,6 +23376,7 @@
         }
       ],
       "manaCost": "{B}{R}",
+      "mciNumber": "225",
       "multiverseid": 420842,
       "name": "Terminate",
       "number": "225",
@@ -23250,6 +23476,7 @@
         }
       ],
       "manaCost": "{2}{W}{B}",
+      "mciNumber": "226",
       "multiverseid": 420843,
       "name": "Utter End",
       "number": "226",
@@ -23343,6 +23570,7 @@
         }
       ],
       "manaCost": "{1}{G}{U}",
+      "mciNumber": "227",
       "multiverseid": 420844,
       "name": "Vorel of the Hull Clade",
       "number": "227",
@@ -23449,6 +23677,7 @@
         }
       ],
       "manaCost": "{3}{B}{G}",
+      "mciNumber": "228",
       "multiverseid": 420845,
       "name": "Vulturous Zombie",
       "number": "228",
@@ -23558,6 +23787,7 @@
         }
       ],
       "manaCost": "{2}{U}{B}",
+      "mciNumber": "229",
       "multiverseid": 420846,
       "name": "Whispering Madness",
       "number": "229",
@@ -23703,6 +23933,7 @@
         }
       ],
       "manaCost": "{1}{R}{G}",
+      "mciNumber": "230",
       "multiverseid": 420847,
       "name": "Wilderness Elemental",
       "number": "230",
@@ -23792,6 +24023,7 @@
         }
       ],
       "manaCost": "{1}{R}{W}{U}",
+      "mciNumber": "231",
       "multiverseid": 420848,
       "name": "Zedruu the Greathearted",
       "number": "231",
@@ -23906,6 +24138,7 @@
         }
       ],
       "manaCost": "{R}{G}",
+      "mciNumber": "232",
       "multiverseid": 420849,
       "name": "Zhur-Taa Druid",
       "number": "232",
@@ -24018,6 +24251,7 @@
         }
       ],
       "manaCost": "{2}{B/R}",
+      "mciNumber": "233",
       "multiverseid": 420850,
       "name": "Everlasting Torment",
       "number": "233",
@@ -24143,6 +24377,7 @@
         }
       ],
       "manaCost": "{2}{W/U}{W/U}",
+      "mciNumber": "234",
       "multiverseid": 420851,
       "name": "Mirrorweave",
       "number": "234",
@@ -24259,6 +24494,7 @@
         }
       ],
       "manaCost": "{G/W}{G/W}",
+      "mciNumber": "235",
       "multiverseid": 420852,
       "name": "Selesnya Guildmage",
       "number": "235",
@@ -24361,6 +24597,7 @@
         }
       ],
       "manaCost": "{4}{G/U}{G/U}",
+      "mciNumber": "236",
       "multiverseid": 420853,
       "name": "Spitting Image",
       "number": "236",
@@ -24476,6 +24713,7 @@
         }
       ],
       "manaCost": "{W/B}{U}",
+      "mciNumber": "237",
       "multiverseid": 420854,
       "name": "Thopter Foundry",
       "number": "237",
@@ -24573,6 +24811,7 @@
         }
       ],
       "manaCost": "{2}{B/G}{B/G}{B/G}",
+      "mciNumber": "238",
       "multiverseid": 420855,
       "name": "Worm Harvest",
       "number": "238",
@@ -25048,6 +25287,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "241",
       "multiverseid": 420858,
       "name": "Akroan Horse",
       "number": "241",
@@ -25138,6 +25378,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "242",
       "multiverseid": 420859,
       "name": "Assault Suit",
       "number": "242",
@@ -25234,6 +25475,7 @@
         }
       ],
       "manaCost": "{X}{X}{X}",
+      "mciNumber": "243",
       "multiverseid": 420860,
       "name": "Astral Cornucopia",
       "number": "243",
@@ -25327,6 +25569,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "244",
       "multiverseid": 420861,
       "name": "Blinkmoth Urn",
       "number": "244",
@@ -25419,6 +25662,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "245",
       "multiverseid": 420862,
       "name": "Bonehoard",
       "number": "245",
@@ -25525,6 +25769,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "246",
       "multiverseid": 420863,
       "name": "Cauldron of Souls",
       "number": "246",
@@ -25642,6 +25887,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "247",
       "multiverseid": 420864,
       "name": "Chromatic Lantern",
       "number": "247",
@@ -25724,6 +25970,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "248",
       "multiverseid": 420865,
       "name": "Commander's Sphere",
       "number": "248",
@@ -25824,6 +26071,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "249",
       "multiverseid": 420866,
       "name": "Cranial Plating",
       "number": "249",
@@ -25912,6 +26160,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "250",
       "multiverseid": 420867,
       "name": "Darksteel Ingot",
       "number": "250",
@@ -26001,6 +26250,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "251",
       "multiverseid": 420868,
       "name": "Empyrial Plate",
       "number": "251",
@@ -26086,6 +26336,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "252",
       "multiverseid": 420869,
       "name": "Etched Oracle",
       "number": "252",
@@ -26177,6 +26428,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "253",
       "multiverseid": 420870,
       "name": "Everflowing Chalice",
       "number": "253",
@@ -26267,6 +26519,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "254",
       "multiverseid": 420871,
       "name": "Fellwar Stone",
       "number": "254",
@@ -26390,6 +26643,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "255",
       "multiverseid": 420872,
       "name": "Golgari Signet",
       "number": "255",
@@ -26482,6 +26736,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "256",
       "multiverseid": 420873,
       "name": "Gruul Signet",
       "number": "256",
@@ -26564,6 +26819,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "257",
       "multiverseid": 420874,
       "name": "Howling Mine",
       "number": "257",
@@ -26679,6 +26935,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "258",
       "multiverseid": 420875,
       "name": "Ichor Wellspring",
       "number": "258",
@@ -26769,6 +27026,7 @@
         }
       ],
       "manaCost": "{6}",
+      "mciNumber": "259",
       "multiverseid": 420876,
       "name": "Keening Stone",
       "number": "259",
@@ -26858,6 +27116,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "260",
       "multiverseid": 420877,
       "name": "Lightning Greaves",
       "number": "260",
@@ -26957,6 +27216,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "261",
       "multiverseid": 420878,
       "name": "Loxodon Warhammer",
       "number": "261",
@@ -27050,6 +27310,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "262",
       "multiverseid": 420879,
       "name": "Mycosynth Wellspring",
       "number": "262",
@@ -27139,6 +27400,7 @@
         }
       ],
       "manaCost": "{7}",
+      "mciNumber": "263",
       "multiverseid": 420880,
       "name": "Myr Battlesphere",
       "number": "263",
@@ -27249,6 +27511,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "264",
       "multiverseid": 420881,
       "name": "Myr Retriever",
       "number": "264",
@@ -27331,6 +27594,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "265",
       "multiverseid": 420882,
       "name": "Nevinyrral's Disk",
       "number": "265",
@@ -27438,6 +27702,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "266",
       "multiverseid": 420883,
       "name": "Orzhov Signet",
       "number": "266",
@@ -27525,6 +27790,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "267",
       "multiverseid": 420884,
       "name": "Psychosis Crawler",
       "number": "267",
@@ -27626,6 +27892,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "268",
       "multiverseid": 420885,
       "name": "Rakdos Signet",
       "number": "268",
@@ -27713,6 +27980,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "269",
       "multiverseid": 420886,
       "name": "Shimmer Myr",
       "number": "269",
@@ -27812,6 +28080,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "270",
       "multiverseid": 420887,
       "name": "Simic Signet",
       "number": "270",
@@ -27900,6 +28169,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "271",
       "multiverseid": 420888,
       "name": "Skullclamp",
       "number": "271",
@@ -27984,6 +28254,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "272",
       "multiverseid": 420889,
       "name": "Sol Ring",
       "number": "272",
@@ -28081,6 +28352,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "273",
       "multiverseid": 420890,
       "name": "Solemn Simulacrum",
       "number": "273",
@@ -28170,6 +28442,7 @@
         }
       ],
       "manaCost": "{6}",
+      "mciNumber": "274",
       "multiverseid": 420891,
       "name": "Soul of New Phyrexia",
       "number": "274",
@@ -28272,6 +28545,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "275",
       "multiverseid": 420892,
       "name": "Sunforger",
       "number": "275",
@@ -28369,6 +28643,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "276",
       "multiverseid": 420893,
       "name": "Swiftfoot Boots",
       "number": "276",
@@ -28461,6 +28736,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "277",
       "multiverseid": 420894,
       "name": "Temple Bell",
       "number": "277",
@@ -28540,6 +28816,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "278",
       "multiverseid": 420895,
       "name": "Trading Post",
       "number": "278",
@@ -28625,6 +28902,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "279",
       "multiverseid": 420896,
       "name": "Venser's Journal",
       "number": "279",
@@ -28714,6 +28992,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "280",
       "multiverseid": 420897,
       "name": "Whispersilk Cloak",
       "number": "280",
@@ -28809,6 +29088,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "281",
       "multiverseid": 420898,
       "name": "Arcane Sanctum",
       "number": "281",
@@ -28895,6 +29175,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "282",
       "multiverseid": 420899,
       "name": "Azorius Chancery",
       "number": "282",
@@ -28990,6 +29271,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "283",
       "multiverseid": 420900,
       "name": "Boros Garrison",
       "number": "283",
@@ -29079,6 +29361,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "284",
       "multiverseid": 420901,
       "name": "Buried Ruin",
       "number": "284",
@@ -29164,6 +29447,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "285",
       "multiverseid": 420902,
       "name": "Caves of Koilos",
       "number": "285",
@@ -29252,6 +29536,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "286",
       "multiverseid": 420903,
       "name": "Command Tower",
       "number": "286",
@@ -29357,6 +29642,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "287",
       "multiverseid": 420904,
       "name": "Crumbling Necropolis",
       "number": "287",
@@ -29442,6 +29728,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "288",
       "multiverseid": 420905,
       "name": "Darksteel Citadel",
       "number": "288",
@@ -29534,6 +29821,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "289",
       "multiverseid": 420906,
       "name": "Darkwater Catacombs",
       "number": "289",
@@ -29618,6 +29906,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "290",
       "multiverseid": 420907,
       "name": "Dimir Aqueduct",
       "number": "290",
@@ -29712,6 +30001,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "291",
       "multiverseid": 420908,
       "name": "Dismal Backwater",
       "number": "291",
@@ -29795,6 +30085,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "292",
       "multiverseid": 420909,
       "name": "Dragonskull Summit",
       "number": "292",
@@ -29893,6 +30184,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "293",
       "multiverseid": 420910,
       "name": "Dreadship Reef",
       "number": "293",
@@ -29995,6 +30287,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "294",
       "multiverseid": 420911,
       "name": "Evolving Wilds",
       "number": "294",
@@ -30097,6 +30390,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "295",
       "multiverseid": 420912,
       "name": "Exotic Orchard",
       "number": "295",
@@ -30202,6 +30496,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "296",
       "multiverseid": 420913,
       "name": "Forbidden Orchard",
       "number": "296",
@@ -30290,6 +30585,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "297",
       "multiverseid": 420914,
       "name": "Frontier Bivouac",
       "number": "297",
@@ -30374,6 +30670,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "298",
       "multiverseid": 420915,
       "name": "Golgari Rot Farm",
       "number": "298",
@@ -30462,6 +30759,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "299",
       "multiverseid": 420916,
       "name": "Grand Coliseum",
       "number": "299",
@@ -30547,6 +30845,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "300",
       "multiverseid": 420917,
       "name": "Gruul Turf",
       "number": "300",
@@ -30631,6 +30930,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "301",
       "multiverseid": 420918,
       "name": "Homeward Path",
       "number": "301",
@@ -30726,6 +31026,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "302",
       "multiverseid": 420919,
       "name": "Izzet Boilerworks",
       "number": "302",
@@ -30821,6 +31122,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "303",
       "multiverseid": 420920,
       "name": "Jungle Hollow",
       "number": "303",
@@ -30911,6 +31213,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "304",
       "multiverseid": 420921,
       "name": "Jungle Shrine",
       "number": "304",
@@ -30998,6 +31301,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "305",
       "multiverseid": 420922,
       "name": "Karplusan Forest",
       "number": "305",
@@ -31080,6 +31384,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "306",
       "multiverseid": 420923,
       "name": "Krosan Verge",
       "number": "306",
@@ -31166,6 +31471,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "307",
       "multiverseid": 420924,
       "name": "Mosswort Bridge",
       "number": "307",
@@ -31255,6 +31561,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "308",
       "multiverseid": 420925,
       "name": "Murmuring Bosk",
       "number": "308",
@@ -31337,6 +31644,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "309",
       "multiverseid": 420926,
       "name": "Myriad Landscape",
       "number": "309",
@@ -31430,6 +31738,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "310",
       "multiverseid": 420927,
       "name": "Mystic Monastery",
       "number": "310",
@@ -31517,6 +31826,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "311",
       "multiverseid": 420928,
       "name": "Nomad Outpost",
       "number": "311",
@@ -31590,6 +31900,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "312",
       "multiverseid": 420929,
       "name": "Opal Palace",
       "number": "312",
@@ -31695,6 +32006,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "313",
       "multiverseid": 420930,
       "name": "Opulent Palace",
       "number": "313",
@@ -31779,6 +32091,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "314",
       "multiverseid": 420931,
       "name": "Orzhov Basilica",
       "number": "314",
@@ -31874,6 +32187,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "315",
       "multiverseid": 420932,
       "name": "Rakdos Carnarium",
       "number": "315",
@@ -31967,6 +32281,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "316",
       "multiverseid": 420933,
       "name": "Reliquary Tower",
       "number": "316",
@@ -32057,6 +32372,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "317",
       "multiverseid": 420934,
       "name": "Rootbound Crag",
       "number": "317",
@@ -32155,6 +32471,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "318",
       "multiverseid": 420935,
       "name": "Rugged Highlands",
       "number": "318",
@@ -32238,6 +32555,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "319",
       "multiverseid": 420936,
       "name": "Rupture Spire",
       "number": "319",
@@ -32331,6 +32649,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "320",
       "multiverseid": 420937,
       "name": "Sandsteppe Citadel",
       "number": "320",
@@ -32418,6 +32737,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "321",
       "multiverseid": 420938,
       "name": "Savage Lands",
       "number": "321",
@@ -32507,6 +32827,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "322",
       "multiverseid": 420939,
       "name": "Seaside Citadel",
       "number": "322",
@@ -32594,6 +32915,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "323",
       "multiverseid": 420940,
       "name": "Seat of the Synod",
       "number": "323",
@@ -32681,6 +33003,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "324",
       "multiverseid": 420941,
       "name": "Selesnya Sanctuary",
       "number": "324",
@@ -32775,6 +33098,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "325",
       "multiverseid": 420942,
       "name": "Shadowblood Ridge",
       "number": "325",
@@ -32859,6 +33183,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "326",
       "multiverseid": 420943,
       "name": "Simic Growth Chamber",
       "number": "326",
@@ -32951,6 +33276,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "327",
       "multiverseid": 420944,
       "name": "Spinerock Knoll",
       "number": "327",
@@ -33047,6 +33373,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "328",
       "multiverseid": 420945,
       "name": "Sungrass Prairie",
       "number": "328",
@@ -33127,6 +33454,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "329",
       "multiverseid": 420946,
       "name": "Sunpetal Grove",
       "number": "329",
@@ -33224,6 +33552,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "330",
       "multiverseid": 420947,
       "name": "Swiftwater Cliffs",
       "number": "330",
@@ -33305,6 +33634,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "331",
       "multiverseid": 420948,
       "name": "Temple of the False God",
       "number": "331",
@@ -33392,6 +33722,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "332",
       "multiverseid": 420949,
       "name": "Terramorphic Expanse",
       "number": "332",
@@ -33493,6 +33824,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "333",
       "multiverseid": 420950,
       "name": "Thornwood Falls",
       "number": "333",
@@ -33576,6 +33908,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "334",
       "multiverseid": 420951,
       "name": "Transguild Promenade",
       "number": "334",
@@ -33662,6 +33995,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "335",
       "multiverseid": 420952,
       "name": "Underground River",
       "number": "335",
@@ -33751,6 +34085,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "336",
       "multiverseid": 420953,
       "name": "Windbrisk Heights",
       "number": "336",

--- a/json/CN2.json
+++ b/json/CN2.json
@@ -1,6 +1,7 @@
 {
   "name": "Conspiracy: Take the Crown",
   "code": "CN2",
+  "magicCardsInfoCode": "cn2",
   "releaseDate": "2016-08-26",
   "border": "black",
   "type": "conspiracy",
@@ -64,6 +65,7 @@
           "legality": "Banned"
         }
       ],
+      "mciNumber": "1",
       "multiverseid": 416758,
       "name": "Adriana's Valor",
       "number": "1",
@@ -179,6 +181,7 @@
           "legality": "Banned"
         }
       ],
+      "mciNumber": "2",
       "multiverseid": 416759,
       "name": "Assemble the Rank and Vile",
       "number": "2",
@@ -287,6 +290,7 @@
           "legality": "Banned"
         }
       ],
+      "mciNumber": "3",
       "multiverseid": 416760,
       "name": "Echoing Boon",
       "number": "3",
@@ -423,6 +427,7 @@
           "legality": "Banned"
         }
       ],
+      "mciNumber": "4",
       "multiverseid": 416761,
       "name": "Emissary's Ploy",
       "number": "4",
@@ -502,6 +507,7 @@
           "legality": "Banned"
         }
       ],
+      "mciNumber": "5",
       "multiverseid": 416762,
       "name": "Hired Heist",
       "number": "5",
@@ -610,6 +616,7 @@
           "legality": "Banned"
         }
       ],
+      "mciNumber": "6",
       "multiverseid": 416763,
       "name": "Hold the Perimeter",
       "number": "6",
@@ -691,6 +698,7 @@
           "legality": "Banned"
         }
       ],
+      "mciNumber": "7",
       "multiverseid": 416764,
       "name": "Hymn of the Wilds",
       "number": "7",
@@ -798,6 +806,7 @@
           "legality": "Banned"
         }
       ],
+      "mciNumber": "8",
       "multiverseid": 416765,
       "name": "Incendiary Dissent",
       "number": "8",
@@ -909,6 +918,7 @@
           "legality": "Banned"
         }
       ],
+      "mciNumber": "9",
       "multiverseid": 416766,
       "name": "Natural Unity",
       "number": "9",
@@ -1017,6 +1027,7 @@
           "legality": "Banned"
         }
       ],
+      "mciNumber": "10",
       "multiverseid": 416767,
       "name": "Sovereign's Realm",
       "number": "10",
@@ -1117,6 +1128,7 @@
           "legality": "Banned"
         }
       ],
+      "mciNumber": "11",
       "multiverseid": 416768,
       "name": "Summoner's Bond",
       "number": "11",
@@ -1234,6 +1246,7 @@
           "legality": "Banned"
         }
       ],
+      "mciNumber": "12",
       "multiverseid": 416769,
       "name": "Weight Advantage",
       "number": "12",
@@ -1327,6 +1340,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "13",
       "multiverseid": 416770,
       "name": "Ballot Broker",
       "number": "13",
@@ -1405,6 +1419,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "14",
       "multiverseid": 416771,
       "name": "Custodi Peacekeeper",
       "number": "14",
@@ -1475,6 +1490,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "15",
       "multiverseid": 416772,
       "name": "Custodi Soulcaller",
       "number": "15",
@@ -1561,6 +1577,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "16",
       "multiverseid": 416773,
       "name": "Lieutenants of the Guard",
       "number": "16",
@@ -1651,6 +1668,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "17",
       "multiverseid": 416774,
       "name": "Noble Banneret",
       "number": "17",
@@ -1721,6 +1739,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "18",
       "multiverseid": 416775,
       "name": "Palace Jailer",
       "number": "18",
@@ -1828,6 +1847,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "19",
       "multiverseid": 416776,
       "name": "Palace Sentinels",
       "number": "19",
@@ -1902,6 +1922,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "20",
       "multiverseid": 416777,
       "name": "Paliano Vanguard",
       "number": "20",
@@ -1963,6 +1984,7 @@
         }
       ],
       "manaCost": "{5}{W}",
+      "mciNumber": "21",
       "multiverseid": 416778,
       "name": "Protector of the Crown",
       "number": "21",
@@ -2054,6 +2076,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "22",
       "multiverseid": 416779,
       "name": "Recruiter of the Guard",
       "number": "22",
@@ -2115,6 +2138,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "23",
       "multiverseid": 416780,
       "name": "Sanctum Prelate",
       "number": "23",
@@ -2185,6 +2209,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "24",
       "multiverseid": 416781,
       "name": "Spectral Grasp",
       "number": "24",
@@ -2243,6 +2268,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "25",
       "multiverseid": 416782,
       "name": "Throne Warden",
       "number": "25",
@@ -2322,6 +2348,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "26",
       "multiverseid": 416783,
       "name": "Wings of the Guard",
       "number": "26",
@@ -2403,6 +2430,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "27",
       "multiverseid": 416784,
       "name": "Arcane Savant",
       "number": "27",
@@ -2486,6 +2514,7 @@
         }
       ],
       "manaCost": "{5}{U}",
+      "mciNumber": "28",
       "multiverseid": 416785,
       "name": "Canal Courier",
       "number": "28",
@@ -2564,6 +2593,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "29",
       "multiverseid": 416786,
       "name": "Coveted Peacock",
       "number": "29",
@@ -2646,6 +2676,7 @@
         }
       ],
       "manaCost": "{7}{U}{U}",
+      "mciNumber": "30",
       "multiverseid": 416787,
       "name": "Expropriate",
       "number": "30",
@@ -2739,6 +2770,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "31",
       "multiverseid": 416788,
       "name": "Illusion of Choice",
       "number": "31",
@@ -2803,6 +2835,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "32",
       "multiverseid": 416789,
       "name": "Illusionary Informant",
       "number": "32",
@@ -2870,6 +2903,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "33",
       "multiverseid": 416790,
       "name": "Jeering Homunculus",
       "number": "33",
@@ -2952,6 +2986,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "34",
       "multiverseid": 416791,
       "name": "Keeper of Keys",
       "number": "34",
@@ -3035,6 +3070,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "35",
       "multiverseid": 416792,
       "name": "Messenger Jays",
       "number": "35",
@@ -3124,6 +3160,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "36",
       "multiverseid": 416793,
       "name": "Skittering Crustacean",
       "number": "36",
@@ -3183,6 +3220,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "37",
       "multiverseid": 416794,
       "name": "Spire Phantasm",
       "number": "37",
@@ -3254,6 +3292,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "38",
       "multiverseid": 416795,
       "name": "Stunt Double",
       "number": "38",
@@ -3343,6 +3382,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "39",
       "multiverseid": 416796,
       "name": "Archdemon of Paliano",
       "number": "39",
@@ -3417,6 +3457,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "40",
       "multiverseid": 416797,
       "name": "Capital Punishment",
       "number": "40",
@@ -3510,6 +3551,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "41",
       "multiverseid": 416798,
       "name": "Custodi Lich",
       "number": "41",
@@ -3584,6 +3626,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "42",
       "multiverseid": 416799,
       "name": "Deadly Designs",
       "number": "42",
@@ -3649,6 +3692,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "43",
       "multiverseid": 416800,
       "name": "Garrulous Sycophant",
       "number": "43",
@@ -3728,6 +3772,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "44",
       "multiverseid": 416801,
       "name": "Marchesa's Decree",
       "number": "44",
@@ -3797,6 +3842,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "45",
       "multiverseid": 416802,
       "name": "Regicide",
       "number": "45",
@@ -3877,6 +3923,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "46",
       "multiverseid": 416803,
       "name": "Sinuous Vermin",
       "number": "46",
@@ -3943,6 +3990,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "47",
       "multiverseid": 416804,
       "name": "Smuggler Captain",
       "number": "47",
@@ -4010,6 +4058,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "48",
       "multiverseid": 416805,
       "name": "Thorn of the Black Rose",
       "number": "48",
@@ -4085,6 +4134,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "49",
       "multiverseid": 416806,
       "name": "Besmirch",
       "number": "49",
@@ -4174,6 +4224,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "50",
       "multiverseid": 416807,
       "name": "Crown-Hunter Hireling",
       "number": "50",
@@ -4253,6 +4304,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "51",
       "multiverseid": 416808,
       "name": "Deputized Protester",
       "number": "51",
@@ -4335,6 +4387,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "52",
       "multiverseid": 416809,
       "name": "Garbage Fire",
       "number": "52",
@@ -4400,6 +4453,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "53",
       "multiverseid": 416810,
       "name": "Goblin Racketeer",
       "number": "53",
@@ -4483,6 +4537,7 @@
         }
       ],
       "manaCost": "{R}{R}",
+      "mciNumber": "54",
       "multiverseid": 416811,
       "name": "Grenzo, Havoc Raiser",
       "number": "54",
@@ -4584,6 +4639,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "55",
       "multiverseid": 416812,
       "name": "Grenzo's Ruffians",
       "number": "55",
@@ -4665,6 +4721,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "56",
       "multiverseid": 416813,
       "name": "Pyretic Hunter",
       "number": "56",
@@ -4735,6 +4792,7 @@
         }
       ],
       "manaCost": "{5}{R}{R}",
+      "mciNumber": "57",
       "multiverseid": 416814,
       "name": "Skyline Despot",
       "number": "57",
@@ -4813,6 +4871,7 @@
         }
       ],
       "manaCost": "{X}{R}",
+      "mciNumber": "58",
       "multiverseid": 416815,
       "name": "Subterranean Tremors",
       "number": "58",
@@ -4867,6 +4926,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "59",
       "multiverseid": 416816,
       "name": "Volatile Chimera",
       "number": "59",
@@ -4945,6 +5005,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "60",
       "multiverseid": 416817,
       "name": "Animus of Predation",
       "number": "60",
@@ -5022,6 +5083,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "61",
       "multiverseid": 416818,
       "name": "Borderland Explorer",
       "number": "61",
@@ -5088,6 +5150,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "62",
       "multiverseid": 416819,
       "name": "Caller of the Untamed",
       "number": "62",
@@ -5159,6 +5222,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "63",
       "multiverseid": 416820,
       "name": "Domesticated Hydra",
       "number": "63",
@@ -5219,6 +5283,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "64",
       "multiverseid": 416821,
       "name": "Entourage of Trest",
       "number": "64",
@@ -5297,6 +5362,7 @@
         }
       ],
       "manaCost": "{5}{G}",
+      "mciNumber": "65",
       "multiverseid": 416822,
       "name": "Fang of the Pack",
       "number": "65",
@@ -5378,6 +5444,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "66",
       "multiverseid": 416823,
       "name": "Leovold's Operative",
       "number": "66",
@@ -5445,6 +5512,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "67",
       "multiverseid": 416824,
       "name": "Menagerie Liberator",
       "number": "67",
@@ -5528,6 +5596,7 @@
         }
       ],
       "manaCost": "{5}{G}",
+      "mciNumber": "68",
       "multiverseid": 416825,
       "name": "Orchard Elemental",
       "number": "68",
@@ -5617,6 +5686,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "69",
       "multiverseid": 416826,
       "name": "Regal Behemoth",
       "number": "69",
@@ -5694,6 +5764,7 @@
         }
       ],
       "manaCost": "{1}{G}{G}",
+      "mciNumber": "70",
       "multiverseid": 416827,
       "name": "Selvala, Heart of the Wilds",
       "number": "70",
@@ -5771,6 +5842,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "71",
       "multiverseid": 416828,
       "name": "Selvala's Stampede",
       "number": "71",
@@ -5863,6 +5935,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "72",
       "multiverseid": 416829,
       "name": "Splitting Slime",
       "number": "72",
@@ -5931,6 +6004,7 @@
         }
       ],
       "manaCost": "{3}{R}{W}",
+      "mciNumber": "73",
       "multiverseid": 416830,
       "name": "Adriana, Captain of the Guard",
       "number": "73",
@@ -6019,6 +6093,7 @@
       ],
       "loyalty": 3,
       "manaCost": "{1}{B}{R}",
+      "mciNumber": "74",
       "multiverseid": 416831,
       "name": "Daretti, Ingenious Iconoclast",
       "number": "74",
@@ -6176,6 +6251,7 @@
         }
       ],
       "manaCost": "{3}{W}{B}",
+      "mciNumber": "76",
       "multiverseid": 416833,
       "name": "Knights of the Black Rose",
       "number": "76",
@@ -6259,6 +6335,7 @@
         }
       ],
       "manaCost": "{B}{G}{U}",
+      "mciNumber": "77",
       "multiverseid": 416834,
       "name": "Leovold, Emissary of Trest",
       "number": "77",
@@ -6348,6 +6425,7 @@
         }
       ],
       "manaCost": "{1}{R}{W}{B}",
+      "mciNumber": "78",
       "multiverseid": 416835,
       "name": "Queen Marchesa",
       "number": "78",
@@ -6424,6 +6502,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "79",
       "multiverseid": 416836,
       "name": "Spy Kit",
       "number": "79",
@@ -6488,6 +6567,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "80",
       "multiverseid": 416837,
       "name": "Throne of the High City",
       "number": "80",
@@ -6565,6 +6645,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "81",
       "multiverseid": 416838,
       "name": "Affa Guard Hound",
       "number": "81",
@@ -6655,6 +6736,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "82",
       "multiverseid": 416839,
       "name": "Disenchant",
       "number": "82",
@@ -6750,6 +6832,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "83",
       "multiverseid": 416840,
       "name": "Doomed Traveler",
       "number": "83",
@@ -6820,6 +6903,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "84",
       "multiverseid": 416841,
       "name": "Faith's Reward",
       "number": "84",
@@ -6901,6 +6985,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "85",
       "multiverseid": 416842,
       "name": "Ghostly Possession",
       "number": "85",
@@ -6968,6 +7053,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "86",
       "multiverseid": 416843,
       "name": "Ghostly Prison",
       "number": "86",
@@ -7046,6 +7132,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "87",
       "multiverseid": 416844,
       "name": "Gleam of Resistance",
       "number": "87",
@@ -7129,6 +7216,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "88",
       "multiverseid": 416845,
       "name": "Gods Willing",
       "number": "88",
@@ -7214,6 +7302,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "89",
       "multiverseid": 416846,
       "name": "Guardian of the Gateless",
       "number": "89",
@@ -7289,6 +7378,7 @@
         }
       ],
       "manaCost": "{X}{W}",
+      "mciNumber": "90",
       "multiverseid": 416847,
       "name": "Hail of Arrows",
       "number": "90",
@@ -7360,6 +7450,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "91",
       "multiverseid": 416848,
       "name": "Hallowed Burial",
       "number": "91",
@@ -7434,6 +7525,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "92",
       "multiverseid": 416849,
       "name": "Hollowhenge Spirit",
       "number": "92",
@@ -7516,6 +7608,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "93",
       "multiverseid": 416850,
       "name": "Hundred-Handed One",
       "number": "93",
@@ -7599,6 +7692,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "94",
       "multiverseid": 416851,
       "name": "Kill Shot",
       "number": "94",
@@ -7663,6 +7757,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "95",
       "multiverseid": 416852,
       "name": "Pariah",
       "number": "95",
@@ -7742,6 +7837,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "96",
       "multiverseid": 416853,
       "name": "Raise the Alarm",
       "number": "96",
@@ -7812,6 +7908,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "97",
       "multiverseid": 416854,
       "name": "Reviving Dose",
       "number": "97",
@@ -7877,6 +7974,7 @@
         }
       ],
       "manaCost": "{4}{W}{W}",
+      "mciNumber": "98",
       "multiverseid": 416855,
       "name": "Spirit of the Hearth",
       "number": "98",
@@ -7943,6 +8041,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "99",
       "multiverseid": 416856,
       "name": "Wild Griffin",
       "number": "99",
@@ -8017,6 +8116,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "100",
       "multiverseid": 416857,
       "name": "Windborne Charge",
       "number": "100",
@@ -8087,6 +8187,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "101",
       "multiverseid": 416858,
       "name": "Zealous Strike",
       "number": "101",
@@ -8151,6 +8252,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "102",
       "multiverseid": 416859,
       "name": "Bonds of Quicksilver",
       "number": "102",
@@ -8224,6 +8326,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "103",
       "multiverseid": 416860,
       "name": "Caller of Gales",
       "number": "103",
@@ -8294,6 +8397,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "104",
       "multiverseid": 416861,
       "name": "Cloaked Siren",
       "number": "104",
@@ -8363,6 +8467,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "105",
       "multiverseid": 416862,
       "name": "Covenant of Minds",
       "number": "105",
@@ -8432,6 +8537,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "106",
       "multiverseid": 416863,
       "name": "Deceiver Exarch",
       "number": "106",
@@ -8499,6 +8605,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "107",
       "multiverseid": 416864,
       "name": "Desertion",
       "number": "107",
@@ -8575,6 +8682,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "108",
       "multiverseid": 416865,
       "name": "Dismiss",
       "number": "108",
@@ -8647,6 +8755,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "109",
       "multiverseid": 416866,
       "name": "Divination",
       "number": "109",
@@ -8721,6 +8830,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "110",
       "multiverseid": 416867,
       "name": "Fleeting Distraction",
       "number": "110",
@@ -8797,6 +8907,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "111",
       "multiverseid": 416868,
       "name": "Followed Footsteps",
       "number": "111",
@@ -8878,6 +8989,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "112",
       "multiverseid": 416869,
       "name": "Into the Void",
       "number": "112",
@@ -8944,6 +9056,7 @@
         }
       ],
       "manaCost": "{U}{U}",
+      "mciNumber": "113",
       "multiverseid": 416870,
       "name": "Kami of the Crescent Moon",
       "number": "113",
@@ -9022,6 +9135,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "114",
       "multiverseid": 416871,
       "name": "Merfolk Looter",
       "number": "114",
@@ -9098,6 +9212,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "115",
       "multiverseid": 416872,
       "name": "Merfolk Skyscout",
       "number": "115",
@@ -9182,6 +9297,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "116",
       "multiverseid": 416873,
       "name": "Mnemonic Wall",
       "number": "116",
@@ -9269,6 +9385,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "117",
       "multiverseid": 416874,
       "name": "Negate",
       "number": "117",
@@ -9351,6 +9468,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "118",
       "multiverseid": 416875,
       "name": "Omenspeaker",
       "number": "118",
@@ -9436,6 +9554,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "119",
       "multiverseid": 416876,
       "name": "Repulse",
       "number": "119",
@@ -9502,6 +9621,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "120",
       "multiverseid": 416877,
       "name": "Serum Visions",
       "number": "120",
@@ -9565,6 +9685,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "121",
       "multiverseid": 416878,
       "name": "Show and Tell",
       "number": "121",
@@ -9648,6 +9769,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}{U}",
+      "mciNumber": "122",
       "multiverseid": 416879,
       "name": "Sphinx of Magosi",
       "number": "122",
@@ -9719,6 +9841,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "123",
       "multiverseid": 416880,
       "name": "Traumatic Visions",
       "number": "123",
@@ -9803,6 +9926,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "124",
       "multiverseid": 416881,
       "name": "Vaporkin",
       "number": "124",
@@ -9871,6 +9995,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "125",
       "multiverseid": 416882,
       "name": "Vertigo Spawn",
       "number": "125",
@@ -9949,6 +10074,7 @@
         }
       ],
       "manaCost": "{6}{B}",
+      "mciNumber": "126",
       "multiverseid": 416883,
       "name": "Absorb Vis",
       "number": "126",
@@ -10041,6 +10167,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "127",
       "multiverseid": 416884,
       "name": "Altar's Reap",
       "number": "127",
@@ -10124,6 +10251,7 @@
         }
       ],
       "manaCost": "{6}{B}{B}",
+      "mciNumber": "128",
       "multiverseid": 416885,
       "name": "Avatar of Woe",
       "number": "128",
@@ -10205,6 +10333,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "129",
       "multiverseid": 416886,
       "name": "Blood-Toll Harpy",
       "number": "129",
@@ -10270,6 +10399,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "130",
       "multiverseid": 416887,
       "name": "Child of Night",
       "number": "130",
@@ -10348,6 +10478,7 @@
         }
       ],
       "manaCost": "{X}{B}",
+      "mciNumber": "131",
       "multiverseid": 416888,
       "name": "Death Wind",
       "number": "131",
@@ -10421,6 +10552,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "132",
       "multiverseid": 416889,
       "name": "Diabolic Tutor",
       "number": "132",
@@ -10495,6 +10627,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "133",
       "multiverseid": 416890,
       "name": "Driver of the Dead",
       "number": "133",
@@ -10571,6 +10704,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "134",
       "multiverseid": 416891,
       "name": "Farbog Boneflinger",
       "number": "134",
@@ -10642,6 +10776,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "135",
       "multiverseid": 416892,
       "name": "Festergloom",
       "number": "135",
@@ -10706,6 +10841,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "136",
       "multiverseid": 416893,
       "name": "Fleshbag Marauder",
       "number": "136",
@@ -10790,6 +10926,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "137",
       "multiverseid": 416894,
       "name": "Guul Draz Specter",
       "number": "137",
@@ -10859,6 +10996,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "138",
       "multiverseid": 416895,
       "name": "Harvester of Souls",
       "number": "138",
@@ -10934,6 +11072,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "139",
       "multiverseid": 416896,
       "name": "Infest",
       "number": "139",
@@ -11002,6 +11141,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "140",
       "multiverseid": 416897,
       "name": "Inquisition of Kozilek",
       "number": "140",
@@ -11073,6 +11213,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "141",
       "multiverseid": 416898,
       "name": "Keepsake Gorgon",
       "number": "141",
@@ -11156,6 +11297,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "142",
       "multiverseid": 416899,
       "name": "Mausoleum Turnkey",
       "number": "142",
@@ -11229,6 +11371,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "143",
       "multiverseid": 416900,
       "name": "Murder",
       "number": "143",
@@ -11294,6 +11437,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "144",
       "multiverseid": 416901,
       "name": "Phyrexian Arena",
       "number": "144",
@@ -11359,6 +11503,7 @@
         }
       ],
       "manaCost": "{5}{B}",
+      "mciNumber": "145",
       "multiverseid": 416902,
       "name": "Public Execution",
       "number": "145",
@@ -11433,6 +11578,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "146",
       "multiverseid": 416903,
       "name": "Raise Dead",
       "number": "146",
@@ -11527,6 +11673,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "147",
       "multiverseid": 416904,
       "name": "Sangromancer",
       "number": "147",
@@ -11604,6 +11751,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "148",
       "multiverseid": 416905,
       "name": "Shambling Goblin",
       "number": "148",
@@ -11674,6 +11822,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "149",
       "multiverseid": 416906,
       "name": "Stromkirk Patrol",
       "number": "149",
@@ -11740,6 +11889,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "150",
       "multiverseid": 416907,
       "name": "Unnerve",
       "number": "150",
@@ -11812,6 +11962,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "151",
       "multiverseid": 416908,
       "name": "Burn Away",
       "number": "151",
@@ -11878,6 +12029,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "152",
       "multiverseid": 416909,
       "name": "Burning Wish",
       "number": "152",
@@ -11969,6 +12121,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "153",
       "multiverseid": 416910,
       "name": "Charmbreaker Devils",
       "number": "153",
@@ -12050,6 +12203,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "154",
       "multiverseid": 416911,
       "name": "Coordinated Assault",
       "number": "154",
@@ -12119,6 +12273,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "155",
       "multiverseid": 416912,
       "name": "Ember Beast",
       "number": "155",
@@ -12202,6 +12357,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "156",
       "multiverseid": 416913,
       "name": "Fiery Fall",
       "number": "156",
@@ -12291,6 +12447,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "157",
       "multiverseid": 416914,
       "name": "Flame Slash",
       "number": "157",
@@ -12356,6 +12513,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "158",
       "multiverseid": 416915,
       "name": "Gang of Devils",
       "number": "158",
@@ -12428,6 +12586,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "159",
       "multiverseid": 416916,
       "name": "Goblin Balloon Brigade",
       "number": "159",
@@ -12517,6 +12676,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "160",
       "multiverseid": 416917,
       "name": "Goblin Tunneler",
       "number": "160",
@@ -12595,6 +12755,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}{R}",
+      "mciNumber": "161",
       "multiverseid": 416918,
       "name": "Gratuitous Violence",
       "number": "161",
@@ -12659,6 +12820,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "162",
       "multiverseid": 416919,
       "name": "Guttersnipe",
       "number": "162",
@@ -12737,6 +12899,7 @@
         }
       ],
       "manaCost": "{6}{R}",
+      "mciNumber": "163",
       "multiverseid": 416920,
       "name": "Hamletback Goliath",
       "number": "163",
@@ -12815,6 +12978,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "164",
       "multiverseid": 416921,
       "name": "Havengul Vampire",
       "number": "164",
@@ -12883,6 +13047,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "165",
       "multiverseid": 416922,
       "name": "Hurly-Burly",
       "number": "165",
@@ -12947,6 +13112,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "166",
       "multiverseid": 416923,
       "name": "Ill-Tempered Cyclops",
       "number": "166",
@@ -13030,6 +13196,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "167",
       "multiverseid": 416924,
       "name": "Kiln Fiend",
       "number": "167",
@@ -13107,6 +13274,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "168",
       "multiverseid": 416925,
       "name": "Ogre Sentry",
       "number": "168",
@@ -13176,6 +13344,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "169",
       "multiverseid": 416926,
       "name": "Stoneshock Giant",
       "number": "169",
@@ -13268,6 +13437,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "170",
       "multiverseid": 416927,
       "name": "Sulfurous Blast",
       "number": "170",
@@ -13346,6 +13516,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "171",
       "multiverseid": 416928,
       "name": "Tormenting Voice",
       "number": "171",
@@ -13423,6 +13594,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "172",
       "multiverseid": 416929,
       "name": "Trumpet Blast",
       "number": "172",
@@ -13505,6 +13677,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "173",
       "multiverseid": 416930,
       "name": "Twin Bolt",
       "number": "173",
@@ -13579,6 +13752,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "174",
       "multiverseid": 416931,
       "name": "Beast Within",
       "number": "174",
@@ -13648,6 +13822,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "175",
       "multiverseid": 416932,
       "name": "Berserk",
       "number": "175",
@@ -13725,6 +13900,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "176",
       "multiverseid": 416933,
       "name": "Birds of Paradise",
       "number": "176",
@@ -13810,6 +13986,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "177",
       "multiverseid": 416934,
       "name": "Brushstrider",
       "number": "177",
@@ -13875,6 +14052,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "178",
       "multiverseid": 416935,
       "name": "Burgeoning",
       "number": "178",
@@ -13946,6 +14124,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "179",
       "multiverseid": 416936,
       "name": "Copperhorn Scout",
       "number": "179",
@@ -14031,6 +14210,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "180",
       "multiverseid": 416937,
       "name": "Explosive Vegetation",
       "number": "180",
@@ -14099,6 +14279,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "181",
       "multiverseid": 416938,
       "name": "Fade into Antiquity",
       "number": "181",
@@ -14159,6 +14340,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "182",
       "multiverseid": 416939,
       "name": "Forgotten Ancient",
       "number": "182",
@@ -14251,6 +14433,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "183",
       "multiverseid": 416940,
       "name": "Irresistible Prey",
       "number": "183",
@@ -14337,6 +14520,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "184",
       "multiverseid": 416941,
       "name": "Lace with Moonglove",
       "number": "184",
@@ -14407,6 +14591,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "185",
       "multiverseid": 416942,
       "name": "Lay of the Land",
       "number": "185",
@@ -14478,6 +14663,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "186",
       "multiverseid": 416943,
       "name": "Manaplasm",
       "number": "186",
@@ -14557,6 +14743,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "187",
       "multiverseid": 416944,
       "name": "Nessian Asp",
       "number": "187",
@@ -14645,6 +14832,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "188",
       "multiverseid": 416945,
       "name": "Netcaster Spider",
       "number": "188",
@@ -14720,6 +14908,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}{G}",
+      "mciNumber": "189",
       "multiverseid": 416946,
       "name": "Overrun",
       "number": "189",
@@ -14808,6 +14997,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "190",
       "multiverseid": 416947,
       "name": "Plummet",
       "number": "190",
@@ -14893,6 +15083,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "191",
       "multiverseid": 416948,
       "name": "Prey Upon",
       "number": "191",
@@ -14967,6 +15158,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "192",
       "multiverseid": 416949,
       "name": "Ravenous Leucrocota",
       "number": "192",
@@ -15050,6 +15242,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "193",
       "multiverseid": 416950,
       "name": "Strength in Numbers",
       "number": "193",
@@ -15120,6 +15313,7 @@
         }
       ],
       "manaCost": "{5}{G}",
+      "mciNumber": "194",
       "multiverseid": 416951,
       "name": "Sylvan Bounty",
       "number": "194",
@@ -15206,6 +15400,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "195",
       "multiverseid": 416952,
       "name": "Voyaging Satyr",
       "number": "195",
@@ -15275,6 +15470,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "196",
       "multiverseid": 416953,
       "name": "Wild Pair",
       "number": "196",
@@ -15360,6 +15556,7 @@
         }
       ],
       "manaCost": "{R}{W}",
+      "mciNumber": "197",
       "multiverseid": 416954,
       "name": "Akroan Hoplite",
       "number": "197",
@@ -15442,6 +15639,7 @@
         }
       ],
       "manaCost": "{2}{W}{U}",
+      "mciNumber": "198",
       "multiverseid": 416955,
       "name": "Ascended Lawmage",
       "number": "198",
@@ -15514,6 +15712,7 @@
         }
       ],
       "manaCost": "{2}{B}{R}",
+      "mciNumber": "199",
       "multiverseid": 416956,
       "name": "Carnage Gladiator",
       "number": "199",
@@ -15597,6 +15796,7 @@
         }
       ],
       "manaCost": "{G}{U}",
+      "mciNumber": "200",
       "multiverseid": 416957,
       "name": "Coiling Oracle",
       "number": "200",
@@ -15667,6 +15867,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}{G}{G}",
+      "mciNumber": "201",
       "multiverseid": 416958,
       "name": "Dragonlair Spider",
       "number": "201",
@@ -15749,6 +15950,7 @@
         }
       ],
       "manaCost": "{2}{U}{B}",
+      "mciNumber": "202",
       "multiverseid": 416959,
       "name": "Duskmantle Seer",
       "number": "202",
@@ -15831,6 +16033,7 @@
         }
       ],
       "manaCost": "{2}{R}{G}",
+      "mciNumber": "203",
       "multiverseid": 416960,
       "name": "Gruul War Chant",
       "number": "203",
@@ -15898,6 +16101,7 @@
         }
       ],
       "manaCost": "{3}{G}{W}",
+      "mciNumber": "204",
       "multiverseid": 416961,
       "name": "Juniper Order Ranger",
       "number": "204",
@@ -15978,6 +16182,7 @@
         }
       ],
       "manaCost": "{3}{B}{G}",
+      "mciNumber": "205",
       "multiverseid": 416962,
       "name": "Pharika's Mender",
       "number": "205",
@@ -16048,6 +16253,7 @@
         }
       ],
       "manaCost": "{U}{B}",
+      "mciNumber": "206",
       "multiverseid": 416963,
       "name": "Shipwreck Singer",
       "number": "206",
@@ -16132,6 +16338,7 @@
         }
       ],
       "manaCost": "{2}{U}{R}",
+      "mciNumber": "207",
       "multiverseid": 416964,
       "name": "Stormchaser Chimera",
       "number": "207",
@@ -16195,6 +16402,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "208",
       "multiverseid": 416965,
       "name": "Bronze Sable",
       "number": "208",
@@ -16258,6 +16466,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "209",
       "multiverseid": 416966,
       "name": "Hedron Matrix",
       "number": "209",
@@ -16319,6 +16528,7 @@
         }
       ],
       "manaCost": "{7}",
+      "mciNumber": "210",
       "multiverseid": 416967,
       "name": "Hexplate Golem",
       "number": "210",
@@ -16377,6 +16587,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "211",
       "multiverseid": 416968,
       "name": "Horn of Greed",
       "number": "211",
@@ -16441,6 +16652,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "212",
       "multiverseid": 416969,
       "name": "Kitesail",
       "number": "212",
@@ -16504,6 +16716,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "213",
       "multiverseid": 416970,
       "name": "Opaline Unicorn",
       "number": "213",
@@ -16568,6 +16781,7 @@
         }
       ],
       "manaCost": "{7}",
+      "mciNumber": "214",
       "multiverseid": 416971,
       "name": "Platinum Angel",
       "number": "214",
@@ -16659,6 +16873,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "215",
       "multiverseid": 416972,
       "name": "Psychosis Crawler",
       "number": "215",
@@ -16731,6 +16946,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "216",
       "multiverseid": 416973,
       "name": "Runed Servitor",
       "number": "216",
@@ -16798,6 +17014,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "217",
       "multiverseid": 416974,
       "name": "Dread Statuary",
       "number": "217",
@@ -16885,6 +17102,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "218",
       "multiverseid": 416975,
       "name": "Evolving Wilds",
       "number": "218",
@@ -16962,6 +17180,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "219",
       "multiverseid": 416976,
       "name": "Exotic Orchard",
       "number": "219",
@@ -17043,6 +17262,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "220",
       "multiverseid": 416977,
       "name": "Rogue's Passage",
       "number": "220",
@@ -17112,6 +17332,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "221",
       "multiverseid": 416978,
       "name": "Shimmering Grotto",
       "number": "221",

--- a/json/DDQ.json
+++ b/json/DDQ.json
@@ -1,6 +1,7 @@
 {
   "name": "Duel Decks: Blessed vs. Cursed",
   "code": "DDQ",
+  "magicCardsInfoCode": "ddq",
   "releaseDate": "2016-02-26",
   "border": "black",
   "type": "duel deck",
@@ -52,6 +53,7 @@
         }
       ],
       "manaCost": "{1}{W}{U}",
+      "mciNumber": "1",
       "multiverseid": 409577,
       "name": "Geist of Saint Traft",
       "number": "1",
@@ -131,6 +133,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "2",
       "multiverseid": 409578,
       "name": "Bonds of Faith",
       "number": "2",
@@ -200,6 +203,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "3",
       "multiverseid": 409579,
       "name": "Cathedral Sanctifier",
       "number": "3",
@@ -265,6 +269,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "4",
       "multiverseid": 409580,
       "name": "Champion of the Parish",
       "number": "4",
@@ -330,6 +335,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "5",
       "multiverseid": 409581,
       "name": "Chapel Geist",
       "number": "5",
@@ -394,6 +400,7 @@
         }
       ],
       "manaCost": "{4}{W}{W}",
+      "mciNumber": "6",
       "multiverseid": 409582,
       "name": "Dearly Departed",
       "number": "6",
@@ -472,6 +479,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "7",
       "multiverseid": 409583,
       "name": "Doomed Traveler",
       "number": "7",
@@ -545,6 +553,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "8",
       "multiverseid": 409584,
       "name": "Eerie Interlude",
       "number": "8",
@@ -618,6 +627,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "9",
       "multiverseid": 409585,
       "name": "Elder Cathar",
       "number": "9",
@@ -683,6 +693,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "10",
       "multiverseid": 409586,
       "name": "Emancipation Angel",
       "number": "10",
@@ -756,6 +767,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "11",
       "multiverseid": 409587,
       "name": "Fiend Hunter",
       "number": "11",
@@ -830,6 +842,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "12",
       "multiverseid": 409588,
       "name": "Gather the Townsfolk",
       "number": "12",
@@ -890,6 +903,7 @@
         }
       ],
       "manaCost": "{4}{W}{W}",
+      "mciNumber": "13",
       "multiverseid": 409589,
       "name": "Goldnight Redeemer",
       "number": "13",
@@ -959,6 +973,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "14",
       "multiverseid": 409590,
       "name": "Increasing Devotion",
       "number": "14",
@@ -1018,6 +1033,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "15",
       "multiverseid": 409591,
       "name": "Momentary Blink",
       "number": "15",
@@ -1092,6 +1108,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "16",
       "multiverseid": 409592,
       "name": "Moorland Inquisitor",
       "number": "16",
@@ -1157,6 +1174,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "17",
       "multiverseid": 409593,
       "name": "Rebuke",
       "number": "17",
@@ -1216,6 +1234,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "18",
       "multiverseid": 409594,
       "name": "Slayer of the Wicked",
       "number": "18",
@@ -1286,6 +1305,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "19",
       "multiverseid": 409595,
       "name": "Spectral Gateguards",
       "number": "19",
@@ -1351,6 +1371,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "20",
       "multiverseid": 409596,
       "name": "Thraben Heretic",
       "number": "20",
@@ -1419,6 +1440,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "21",
       "multiverseid": 409597,
       "name": "Topplegeist",
       "number": "21",
@@ -1505,6 +1527,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "22",
       "multiverseid": 409598,
       "name": "Village Bell-Ringer",
       "number": "22",
@@ -1576,6 +1599,7 @@
         }
       ],
       "manaCost": "{4}{W}{W}",
+      "mciNumber": "23",
       "multiverseid": 409599,
       "name": "Voice of the Provinces",
       "number": "23",
@@ -1640,6 +1664,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "24",
       "multiverseid": 409600,
       "name": "Captain of the Mists",
       "number": "24",
@@ -1705,6 +1730,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "25",
       "multiverseid": 409601,
       "name": "Gryff Vanguard",
       "number": "25",
@@ -1770,6 +1796,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "26",
       "multiverseid": 409602,
       "name": "Mist Raven",
       "number": "26",
@@ -1841,6 +1868,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "27",
       "multiverseid": 409603,
       "name": "Nephalia Smuggler",
       "number": "27",
@@ -1910,6 +1938,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "28",
       "multiverseid": 409604,
       "name": "Pore Over the Pages",
       "number": "28",
@@ -1974,6 +2003,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "29",
       "multiverseid": 409605,
       "name": "Tandem Lookout",
       "number": "29",
@@ -2046,6 +2076,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "30",
       "multiverseid": 409606,
       "name": "Tower Geist",
       "number": "30",
@@ -2111,6 +2142,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "31",
       "multiverseid": 409607,
       "name": "Butcher's Cleaver",
       "number": "31",
@@ -2167,6 +2199,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "32",
       "multiverseid": 409608,
       "name": "Sharpened Pitchfork",
       "number": "32",
@@ -2220,6 +2253,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "33",
       "multiverseid": 409609,
       "name": "Seraph Sanctuary",
       "number": "33",
@@ -2274,6 +2308,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "34",
       "multiverseid": 409610,
       "name": "Tranquil Cove",
       "number": "34",
@@ -4006,6 +4041,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "41",
       "multiverseid": 409617,
       "name": "Mindwrack Demon",
       "number": "41",
@@ -4096,6 +4132,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "42",
       "multiverseid": 409618,
       "name": "Compelling Deterrence",
       "number": "42",
@@ -4169,6 +4206,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "43",
       "multiverseid": 409619,
       "name": "Forbidden Alchemy",
       "number": "43",
@@ -4236,6 +4274,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "44",
       "multiverseid": 409620,
       "name": "Havengul Runebinder",
       "number": "44",
@@ -4311,6 +4350,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "45",
       "multiverseid": 409621,
       "name": "Makeshift Mauler",
       "number": "45",
@@ -4385,6 +4425,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "46",
       "multiverseid": 409622,
       "name": "Relentless Skaabs",
       "number": "46",
@@ -4463,6 +4504,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "47",
       "multiverseid": 409623,
       "name": "Scrapskin Drake",
       "number": "47",
@@ -4529,6 +4571,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "48",
       "multiverseid": 409624,
       "name": "Screeching Skaab",
       "number": "48",
@@ -4595,6 +4638,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "49",
       "multiverseid": 409625,
       "name": "Stitched Drake",
       "number": "49",
@@ -4670,6 +4714,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "50",
       "multiverseid": 409626,
       "name": "Abattoir Ghoul",
       "number": "50",
@@ -4740,6 +4785,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "51",
       "multiverseid": 409627,
       "name": "Appetite for Brains",
       "number": "51",
@@ -4809,6 +4855,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "52",
       "multiverseid": 409628,
       "name": "Barter in Blood",
       "number": "52",
@@ -4887,6 +4934,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "53",
       "multiverseid": 409629,
       "name": "Butcher Ghoul",
       "number": "53",
@@ -4951,6 +4999,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "54",
       "multiverseid": 409630,
       "name": "Diregraf Ghoul",
       "number": "54",
@@ -5016,6 +5065,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "55",
       "multiverseid": 409631,
       "name": "Dread Return",
       "number": "55",
@@ -5077,6 +5127,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "56",
       "multiverseid": 409632,
       "name": "Driver of the Dead",
       "number": "56",
@@ -5148,6 +5199,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "57",
       "multiverseid": 409633,
       "name": "Falkenrath Noble",
       "number": "57",
@@ -5219,6 +5271,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "58",
       "multiverseid": 409634,
       "name": "Ghoulraiser",
       "number": "58",
@@ -5283,6 +5336,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "59",
       "multiverseid": 409635,
       "name": "Gravecrawler",
       "number": "59",
@@ -5358,6 +5412,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "60",
       "multiverseid": 409636,
       "name": "Harvester of Souls",
       "number": "60",
@@ -5424,6 +5479,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "61",
       "multiverseid": 409637,
       "name": "Human Frailty",
       "number": "61",
@@ -5483,6 +5539,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "62",
       "multiverseid": 409638,
       "name": "Moan of the Unhallowed",
       "number": "62",
@@ -5541,6 +5598,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "63",
       "multiverseid": 409639,
       "name": "Sever the Bloodline",
       "number": "63",
@@ -5624,6 +5682,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "64",
       "multiverseid": 409640,
       "name": "Tooth Collector",
       "number": "64",
@@ -5711,6 +5770,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "65",
       "multiverseid": 409641,
       "name": "Tribute to Hunger",
       "number": "65",
@@ -5775,6 +5835,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "66",
       "multiverseid": 409642,
       "name": "Unbreathing Horde",
       "number": "66",
@@ -5853,6 +5914,7 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "67",
       "multiverseid": 409643,
       "name": "Victim of Night",
       "number": "67",
@@ -5914,6 +5976,7 @@
         }
       ],
       "manaCost": "{1}{U}{B}",
+      "mciNumber": "68",
       "multiverseid": 409644,
       "name": "Diregraf Captain",
       "number": "68",
@@ -5973,6 +6036,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "69",
       "multiverseid": 409645,
       "name": "Cobbled Wings",
       "number": "69",
@@ -6030,6 +6094,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "70",
       "multiverseid": 409646,
       "name": "Dismal Backwater",
       "number": "70",

--- a/json/DDR.json
+++ b/json/DDR.json
@@ -1,6 +1,7 @@
 {
   "name": "Duel Decks: Nissa vs. Ob Nixilis",
   "code": "DDR",
+  "magicCardsInfoCode": "ddr",
   "releaseDate": "2016-09-02",
   "type": "duel deck",
   "border": "black",
@@ -52,6 +53,7 @@
       ],
       "loyalty": 3,
       "manaCost": "{1}{G}{G}",
+      "mciNumber": "1",
       "multiverseid": 417424,
       "name": "Nissa, Voice of Zendikar",
       "number": "1",
@@ -113,6 +115,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "2",
       "multiverseid": 417425,
       "name": "Abundance",
       "number": "2",
@@ -190,6 +193,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "3",
       "multiverseid": 417426,
       "name": "Briarhorn",
       "number": "3",
@@ -262,6 +266,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "4",
       "multiverseid": 417427,
       "name": "Citanul Woodreaders",
       "number": "4",
@@ -328,6 +333,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "5",
       "multiverseid": 417428,
       "name": "Civic Wayfinder",
       "number": "5",
@@ -396,6 +402,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}{G}{G}",
+      "mciNumber": "6",
       "multiverseid": 417429,
       "name": "Cloudthresher",
       "number": "6",
@@ -464,6 +471,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "7",
       "multiverseid": 417430,
       "name": "Crop Rotation",
       "number": "7",
@@ -523,6 +531,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "8",
       "multiverseid": 417431,
       "name": "Elvish Visionary",
       "number": "8",
@@ -595,6 +604,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "9",
       "multiverseid": 417432,
       "name": "Fertilid",
       "number": "9",
@@ -672,6 +682,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "10",
       "multiverseid": 417433,
       "name": "Gaea's Blessing",
       "number": "10",
@@ -744,6 +755,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "11",
       "multiverseid": 417434,
       "name": "Gilt-Leaf Seer",
       "number": "11",
@@ -809,6 +821,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "12",
       "multiverseid": 417435,
       "name": "Jaddi Lifestrider",
       "number": "12",
@@ -883,6 +896,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "13",
       "multiverseid": 417436,
       "name": "Natural Connection",
       "number": "13",
@@ -942,6 +956,7 @@
         }
       ],
       "manaCost": "{G}{G}",
+      "mciNumber": "14",
       "multiverseid": 417437,
       "name": "Nissa's Chosen",
       "number": "14",
@@ -1008,6 +1023,7 @@
         }
       ],
       "manaCost": "{5}{G}{G}",
+      "mciNumber": "15",
       "multiverseid": 417438,
       "name": "Oakgnarl Warrior",
       "number": "15",
@@ -1076,6 +1092,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "16",
       "multiverseid": 417439,
       "name": "Oran-Rief Hydra",
       "number": "16",
@@ -1161,6 +1178,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "17",
       "multiverseid": 417440,
       "name": "Oran-Rief Invoker",
       "number": "17",
@@ -1230,6 +1248,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "18",
       "multiverseid": 417441,
       "name": "Saddleback Lagac",
       "number": "18",
@@ -1312,6 +1331,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "19",
       "multiverseid": 417442,
       "name": "Scythe Leopard",
       "number": "19",
@@ -1399,6 +1419,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "20",
       "multiverseid": 417443,
       "name": "Seek the Horizon",
       "number": "20",
@@ -1455,6 +1476,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "21",
       "multiverseid": 417444,
       "name": "Thicket Elemental",
       "number": "21",
@@ -1525,6 +1547,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "22",
       "multiverseid": 417445,
       "name": "Thornweald Archer",
       "number": "22",
@@ -1597,6 +1620,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "23",
       "multiverseid": 417446,
       "name": "Vines of the Recluse",
       "number": "23",
@@ -1662,6 +1686,7 @@
         }
       ],
       "manaCost": "{6}{G}{G}",
+      "mciNumber": "24",
       "multiverseid": 417447,
       "name": "Walker of the Grove",
       "number": "24",
@@ -1754,6 +1779,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "25",
       "multiverseid": 417448,
       "name": "Wood Elves",
       "number": "25",
@@ -1832,6 +1858,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "26",
       "multiverseid": 417449,
       "name": "Woodborn Behemoth",
       "number": "26",
@@ -1895,6 +1922,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "27",
       "multiverseid": 417450,
       "name": "Fertile Thicket",
       "number": "27",
@@ -1954,6 +1982,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "28",
       "multiverseid": 417451,
       "name": "Khalni Garden",
       "number": "28",
@@ -2011,6 +2040,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "29",
       "multiverseid": 417452,
       "name": "Mosswort Bridge",
       "number": "29",
@@ -2068,6 +2098,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "30",
       "multiverseid": 417453,
       "name": "Treetop Village",
       "number": "30",
@@ -3567,6 +3598,7 @@
       ],
       "loyalty": 5,
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "36",
       "multiverseid": 417459,
       "name": "Ob Nixilis Reignited",
       "number": "36",
@@ -3644,6 +3676,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "37",
       "multiverseid": 417460,
       "name": "Altar's Reap",
       "number": "37",
@@ -3715,6 +3748,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "38",
       "multiverseid": 417461,
       "name": "Ambition's Cost",
       "number": "38",
@@ -3777,6 +3811,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "39",
       "multiverseid": 417462,
       "name": "Bala Ged Scorpion",
       "number": "39",
@@ -3847,6 +3882,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "40",
       "multiverseid": 417463,
       "name": "Blistergrub",
       "number": "40",
@@ -3911,6 +3947,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "41",
       "multiverseid": 417464,
       "name": "Cadaver Imp",
       "number": "41",
@@ -3982,6 +4019,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "42",
       "multiverseid": 417465,
       "name": "Carrier Thrall",
       "number": "42",
@@ -4068,6 +4106,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "43",
       "multiverseid": 417466,
       "name": "Demon's Grasp",
       "number": "43",
@@ -4126,6 +4165,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "44",
       "multiverseid": 417467,
       "name": "Desecration Demon",
       "number": "44",
@@ -4197,6 +4237,7 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "45",
       "multiverseid": 417468,
       "name": "Despoiler of Souls",
       "number": "45",
@@ -4262,6 +4303,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "46",
       "multiverseid": 417469,
       "name": "Disfigure",
       "number": "46",
@@ -4317,6 +4359,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "47",
       "multiverseid": 417470,
       "name": "Doom Blade",
       "number": "47",
@@ -4377,6 +4420,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "48",
       "multiverseid": 417471,
       "name": "Fetid Imp",
       "number": "48",
@@ -4441,6 +4485,7 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "49",
       "multiverseid": 417472,
       "name": "Foul Imp",
       "number": "49",
@@ -4515,6 +4560,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "50",
       "multiverseid": 417473,
       "name": "Giant Scorpion",
       "number": "50",
@@ -4580,6 +4626,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "51",
       "multiverseid": 417474,
       "name": "Grim Discovery",
       "number": "51",
@@ -4639,6 +4686,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "52",
       "multiverseid": 417475,
       "name": "Hideous End",
       "number": "52",
@@ -4704,6 +4752,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "53",
       "multiverseid": 417476,
       "name": "Indulgent Tormentor",
       "number": "53",
@@ -4775,6 +4824,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "54",
       "multiverseid": 417477,
       "name": "Innocent Blood",
       "number": "54",
@@ -4842,6 +4892,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "55",
       "multiverseid": 417478,
       "name": "Mire's Toll",
       "number": "55",
@@ -4907,6 +4958,7 @@
         }
       ],
       "manaCost": "{5}{B}{B}{B}",
+      "mciNumber": "56",
       "multiverseid": 417479,
       "name": "Pestilence Demon",
       "number": "56",
@@ -4974,6 +5026,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "57",
       "multiverseid": 417480,
       "name": "Priest of the Blood Rite",
       "number": "57",
@@ -5039,6 +5092,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "58",
       "multiverseid": 417481,
       "name": "Quest for the Gravelord",
       "number": "58",
@@ -5104,6 +5158,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "59",
       "multiverseid": 417482,
       "name": "Renegade Demon",
       "number": "59",
@@ -5161,6 +5216,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "60",
       "multiverseid": 417483,
       "name": "Shadows of the Past",
       "number": "60",
@@ -5226,6 +5282,7 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "61",
       "multiverseid": 417484,
       "name": "Smallpox",
       "number": "61",
@@ -5293,6 +5350,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "62",
       "multiverseid": 417485,
       "name": "Squelching Leeches",
       "number": "62",
@@ -5368,6 +5426,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "63",
       "multiverseid": 417486,
       "name": "Tendrils of Corruption",
       "number": "63",
@@ -5442,6 +5501,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "64",
       "multiverseid": 417487,
       "name": "Unhallowed Pact",
       "number": "64",
@@ -5509,6 +5569,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "65",
       "multiverseid": 417488,
       "name": "Leechridden Swamp",
       "number": "65",

--- a/json/DDS.json
+++ b/json/DDS.json
@@ -1,6 +1,7 @@
 {
   "name": "Duel Decks: Mind vs. Might",
   "code": "DDS",
+  "magicCardsInfoCode": "dds",
   "releaseDate": "2017-03-31",
   "type": "duel deck",
   "border": "black",
@@ -49,6 +50,7 @@
         }
       ],
       "manaCost": "{1}{U}{R}",
+      "mciNumber": "1",
       "multiverseid": 426573,
       "name": "Jhoira of the Ghitu",
       "number": "1",
@@ -152,6 +154,7 @@
         }
       ],
       "manaCost": "{6}{U}{U}",
+      "mciNumber": "2",
       "multiverseid": 426574,
       "name": "Beacon of Tomorrows",
       "number": "2",
@@ -216,6 +219,7 @@
         }
       ],
       "manaCost": "{7}{U}{U}{U}",
+      "mciNumber": "3",
       "multiverseid": 426575,
       "name": "Deep-Sea Kraken",
       "number": "3",
@@ -318,6 +322,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "4",
       "multiverseid": 426576,
       "name": "Mind's Desire",
       "number": "4",
@@ -405,6 +410,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "5",
       "multiverseid": 426577,
       "name": "Peer Through Depths",
       "number": "5",
@@ -474,6 +480,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "6",
       "multiverseid": 426578,
       "name": "Quicken",
       "number": "6",
@@ -552,6 +559,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "7",
       "multiverseid": 426579,
       "name": "Reach Through Mists",
       "number": "7",
@@ -614,6 +622,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "8",
       "multiverseid": 426580,
       "name": "Sage-Eye Avengers",
       "number": "8",
@@ -698,6 +707,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "9",
       "multiverseid": 426581,
       "name": "Sift Through Sands",
       "number": "9",
@@ -756,6 +766,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "10",
       "multiverseid": 426582,
       "name": "Snap",
       "number": "10",
@@ -821,6 +832,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "11",
       "multiverseid": 426583,
       "name": "Talrand, Sky Summoner",
       "number": "11",
@@ -895,6 +907,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "12",
       "multiverseid": 426584,
       "name": "Temporal Fissure",
       "number": "12",
@@ -977,6 +990,7 @@
         }
       ],
       "manaCost": "{6}{U}{U}{U}",
+      "mciNumber": "13",
       "multiverseid": 426585,
       "name": "The Unspeakable",
       "number": "13",
@@ -1043,6 +1057,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "14",
       "multiverseid": 426586,
       "name": "Desperate Ritual",
       "number": "14",
@@ -1128,6 +1143,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "15",
       "multiverseid": 426587,
       "name": "Empty the Warrens",
       "number": "15",
@@ -1206,6 +1222,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "16",
       "multiverseid": 426588,
       "name": "Grapeshot",
       "number": "16",
@@ -1287,6 +1304,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "17",
       "multiverseid": 426589,
       "name": "Rift Bolt",
       "number": "17",
@@ -1389,6 +1407,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "18",
       "multiverseid": 426590,
       "name": "Shivan Meteor",
       "number": "18",
@@ -1489,6 +1508,7 @@
         }
       ],
       "manaCost": "{5}{R}{R}",
+      "mciNumber": "19",
       "multiverseid": 426591,
       "name": "Volcanic Vision",
       "number": "19",
@@ -1556,6 +1576,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "20",
       "multiverseid": 426592,
       "name": "Young Pyromancer",
       "number": "20",
@@ -1629,6 +1650,7 @@
         }
       ],
       "manaCost": "{5}{U}{R}",
+      "mciNumber": "21",
       "multiverseid": 426593,
       "name": "Firemind's Foresight",
       "number": "21",
@@ -1701,6 +1723,7 @@
         }
       ],
       "manaCost": "{U}{R}",
+      "mciNumber": "22",
       "multiverseid": 426594,
       "name": "Goblin Electromancer",
       "number": "22",
@@ -1793,6 +1816,7 @@
         }
       ],
       "manaCost": "{1}{U}{R}",
+      "mciNumber": "23",
       "multiverseid": 426595,
       "name": "Jori En, Ruin Diver",
       "number": "23",
@@ -1873,6 +1897,7 @@
         }
       ],
       "manaCost": "{1}{U}{R}",
+      "mciNumber": "24",
       "multiverseid": 426596,
       "name": "Nivix Cyclops",
       "number": "24",
@@ -1945,6 +1970,7 @@
         }
       ],
       "manaCost": "{1}{U}{R}",
+      "mciNumber": "25",
       "multiverseid": 426597,
       "name": "Spellheart Chimera",
       "number": "25",
@@ -2018,6 +2044,7 @@
         }
       ],
       "manaCost": "{4}{U/R}{U/R}",
+      "mciNumber": "26",
       "multiverseid": 426598,
       "name": "Nucklavee",
       "number": "26",
@@ -2078,6 +2105,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "27",
       "multiverseid": 426599,
       "name": "Swiftwater Cliffs",
       "number": "27",
@@ -3821,6 +3849,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "34",
       "multiverseid": 426606,
       "name": "Lovisa Coldeyes",
       "number": "34",
@@ -3894,6 +3923,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "35",
       "multiverseid": 426607,
       "name": "Beacon of Destruction",
       "number": "35",
@@ -3964,6 +3994,7 @@
         }
       ],
       "manaCost": "{5}{R}{R}",
+      "mciNumber": "36",
       "multiverseid": 426608,
       "name": "Boldwyr Intimidator",
       "number": "36",
@@ -4041,6 +4072,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "37",
       "multiverseid": 426609,
       "name": "Firebolt",
       "number": "37",
@@ -4100,6 +4132,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "38",
       "multiverseid": 426610,
       "name": "Gorehorn Minotaurs",
       "number": "38",
@@ -4168,6 +4201,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "39",
       "multiverseid": 426611,
       "name": "Kamahl, Pit Fighter",
       "number": "39",
@@ -4246,6 +4280,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "40",
       "multiverseid": 426612,
       "name": "Kruin Striker",
       "number": "40",
@@ -4311,6 +4346,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "41",
       "multiverseid": 426613,
       "name": "Zo-Zu the Punisher",
       "number": "41",
@@ -4379,6 +4415,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "42",
       "multiverseid": 426614,
       "name": "Ambassador Oak",
       "number": "42",
@@ -4439,6 +4476,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}{G}",
+      "mciNumber": "43",
       "multiverseid": 426615,
       "name": "Beast Attack",
       "number": "43",
@@ -4503,6 +4541,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "44",
       "multiverseid": 426616,
       "name": "Call of the Herd",
       "number": "44",
@@ -4565,6 +4604,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "45",
       "multiverseid": 426617,
       "name": "Cloudcrown Oak",
       "number": "45",
@@ -4630,6 +4670,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "46",
       "multiverseid": 426618,
       "name": "Harmonize",
       "number": "46",
@@ -4704,6 +4745,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "47",
       "multiverseid": 426619,
       "name": "Increasing Savagery",
       "number": "47",
@@ -4767,6 +4809,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "48",
       "multiverseid": 426620,
       "name": "Rampant Growth",
       "number": "48",
@@ -4847,6 +4890,7 @@
         }
       ],
       "manaCost": "{6}{G}",
+      "mciNumber": "49",
       "multiverseid": 426621,
       "name": "Roar of the Wurm",
       "number": "49",
@@ -4908,6 +4952,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "50",
       "multiverseid": 426622,
       "name": "Skarrgan Pit-Skulk",
       "number": "50",
@@ -4974,6 +5019,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "51",
       "multiverseid": 426623,
       "name": "Sylvan Might",
       "number": "51",
@@ -5034,6 +5080,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "52",
       "multiverseid": 426624,
       "name": "Talara's Battalion",
       "number": "52",
@@ -5102,6 +5149,7 @@
         }
       ],
       "manaCost": "{R}{G}",
+      "mciNumber": "53",
       "multiverseid": 426625,
       "name": "Radha, Heir to Keld",
       "number": "53",
@@ -5182,6 +5230,7 @@
         }
       ],
       "manaCost": "{1}{R}{G}",
+      "mciNumber": "54",
       "multiverseid": 426626,
       "name": "Relentless Hunter",
       "number": "54",
@@ -5249,6 +5298,7 @@
         }
       ],
       "manaCost": "{R/G}{R/G}",
+      "mciNumber": "55",
       "multiverseid": 426627,
       "name": "Burning-Tree Emissary",
       "number": "55",
@@ -5323,6 +5373,7 @@
         }
       ],
       "manaCost": "{R/G}",
+      "mciNumber": "56",
       "multiverseid": 426628,
       "name": "Guttural Response",
       "number": "56",
@@ -5384,6 +5435,7 @@
         }
       ],
       "manaCost": "{1}{R/G}{R/G}{R/G}",
+      "mciNumber": "57",
       "multiverseid": 426629,
       "name": "Rubblebelt Raiders",
       "number": "57",
@@ -5449,6 +5501,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "58",
       "multiverseid": 426630,
       "name": "Coat of Arms",
       "number": "58",
@@ -5525,6 +5578,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "59",
       "multiverseid": 426631,
       "name": "Rugged Highlands",
       "number": "59",

--- a/json/EMA.json
+++ b/json/EMA.json
@@ -1,6 +1,7 @@
 {
   "name": "Eternal Masters",
   "code": "EMA",
+  "magicCardsInfoCode": "ema",
   "releaseDate": "2016-06-10",
   "border": "black",
   "type": "reprint",
@@ -81,6 +82,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "1",
       "multiverseid": 413543,
       "name": "Aven Riftwatcher",
       "number": "1",
@@ -143,6 +145,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "2",
       "multiverseid": 413544,
       "name": "Balance",
       "number": "2",
@@ -231,6 +234,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "3",
       "multiverseid": 413545,
       "name": "Ballynock Cohort",
       "number": "3",
@@ -297,6 +301,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "4",
       "multiverseid": 413546,
       "name": "Benevolent Bodyguard",
       "number": "4",
@@ -367,6 +372,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "5",
       "multiverseid": 413547,
       "name": "Calciderm",
       "number": "5",
@@ -439,6 +445,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "6",
       "multiverseid": 413548,
       "name": "Coalition Honor Guard",
       "number": "6",
@@ -523,6 +530,7 @@
         }
       ],
       "manaCost": "{W}{W}",
+      "mciNumber": "7",
       "multiverseid": 413549,
       "name": "Eight-and-a-Half-Tails",
       "number": "7",
@@ -598,6 +606,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "8",
       "multiverseid": 413550,
       "name": "Elite Vanguard",
       "number": "8",
@@ -665,6 +674,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "9",
       "multiverseid": 413551,
       "name": "Enlightened Tutor",
       "number": "9",
@@ -736,6 +746,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "10",
       "multiverseid": 413552,
       "name": "Faith's Fetters",
       "number": "10",
@@ -811,6 +822,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "11",
       "multiverseid": 413553,
       "name": "Field of Souls",
       "number": "11",
@@ -882,6 +894,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "12",
       "multiverseid": 413554,
       "name": "Glimmerpoint Stag",
       "number": "12",
@@ -970,6 +983,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "13",
       "multiverseid": 413555,
       "name": "Honden of Cleansing Fire",
       "number": "13",
@@ -1036,6 +1050,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "14",
       "multiverseid": 413556,
       "name": "Humble",
       "number": "14",
@@ -1118,6 +1133,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "15",
       "multiverseid": 413557,
       "name": "Intangible Virtue",
       "number": "15",
@@ -1181,6 +1197,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}{W}",
+      "mciNumber": "16",
       "multiverseid": 413558,
       "name": "Jareth, Leonine Titan",
       "number": "16",
@@ -1251,6 +1268,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "17",
       "multiverseid": 413559,
       "name": "Karmic Guide",
       "number": "17",
@@ -1325,6 +1343,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "18",
       "multiverseid": 413560,
       "name": "Kor Hookmaster",
       "number": "18",
@@ -1404,6 +1423,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "19",
       "multiverseid": 413561,
       "name": "Mesa Enchantress",
       "number": "19",
@@ -1491,6 +1511,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "20",
       "multiverseid": 413562,
       "name": "Mistral Charger",
       "number": "20",
@@ -1556,6 +1577,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "21",
       "multiverseid": 413563,
       "name": "Monk Idealist",
       "number": "21",
@@ -1624,6 +1646,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "22",
       "multiverseid": 413564,
       "name": "Mother of Runes",
       "number": "22",
@@ -1714,6 +1737,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "23",
       "multiverseid": 413565,
       "name": "Pacifism",
       "number": "23",
@@ -1800,6 +1824,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "24",
       "multiverseid": 413566,
       "name": "Raise the Alarm",
       "number": "24",
@@ -1871,6 +1896,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "25",
       "multiverseid": 413567,
       "name": "Rally the Peasants",
       "number": "25",
@@ -1937,6 +1963,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "26",
       "multiverseid": 413568,
       "name": "Seal of Cleansing",
       "number": "26",
@@ -2006,6 +2033,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "27",
       "multiverseid": 413569,
       "name": "Second Thoughts",
       "number": "27",
@@ -2076,6 +2104,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "28",
       "multiverseid": 413570,
       "name": "Serra Angel",
       "number": "28",
@@ -2168,6 +2197,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "29",
       "multiverseid": 413571,
       "name": "Shelter",
       "number": "29",
@@ -2235,6 +2265,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "30",
       "multiverseid": 413572,
       "name": "Soulcatcher",
       "number": "30",
@@ -2307,6 +2338,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "31",
       "multiverseid": 413573,
       "name": "Squadron Hawk",
       "number": "31",
@@ -2373,6 +2405,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "32",
       "multiverseid": 413574,
       "name": "Swords to Plowshares",
       "number": "32",
@@ -2458,6 +2491,7 @@
         }
       ],
       "manaCost": "{X}{W}{W}",
+      "mciNumber": "33",
       "multiverseid": 413575,
       "name": "Unexpectedly Absent",
       "number": "33",
@@ -2533,6 +2567,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "34",
       "multiverseid": 413576,
       "name": "Wall of Omens",
       "number": "34",
@@ -2601,6 +2636,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "35",
       "multiverseid": 413577,
       "name": "War Priest of Thune",
       "number": "35",
@@ -2672,6 +2708,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "36",
       "multiverseid": 413578,
       "name": "Welkin Guide",
       "number": "36",
@@ -2742,6 +2779,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "37",
       "multiverseid": 413579,
       "name": "Whitemane Lion",
       "number": "37",
@@ -2818,6 +2856,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "38",
       "multiverseid": 413580,
       "name": "Wrath of God",
       "number": "38",
@@ -2900,6 +2939,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}{U}",
+      "mciNumber": "39",
       "multiverseid": 413581,
       "name": "Arcanis the Omnipotent",
       "number": "39",
@@ -2980,6 +3020,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "40",
       "multiverseid": 413582,
       "name": "Brainstorm",
       "number": "40",
@@ -3056,6 +3097,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "41",
       "multiverseid": 413583,
       "name": "Cephalid Sage",
       "number": "41",
@@ -3127,6 +3169,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "42",
       "multiverseid": 413584,
       "name": "Control Magic",
       "number": "42",
@@ -3215,6 +3258,7 @@
         }
       ],
       "manaCost": "{U}{U}",
+      "mciNumber": "43",
       "multiverseid": 413585,
       "name": "Counterspell",
       "number": "43",
@@ -3300,6 +3344,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "44",
       "multiverseid": 413586,
       "name": "Daze",
       "number": "44",
@@ -3369,6 +3414,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "45",
       "multiverseid": 413587,
       "name": "Deep Analysis",
       "number": "45",
@@ -3432,6 +3478,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "46",
       "multiverseid": 413588,
       "name": "Diminishing Returns",
       "number": "46",
@@ -3511,6 +3558,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "47",
       "multiverseid": 413589,
       "name": "Dream Twist",
       "number": "47",
@@ -3570,6 +3618,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "48",
       "multiverseid": 413590,
       "name": "Fact or Fiction",
       "number": "48",
@@ -3648,6 +3697,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "49",
       "multiverseid": 413591,
       "name": "Force of Will",
       "number": "49",
@@ -3718,6 +3768,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}{U}",
+      "mciNumber": "50",
       "multiverseid": 413592,
       "name": "Future Sight",
       "number": "50",
@@ -3802,6 +3853,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "51",
       "multiverseid": 413593,
       "name": "Gaseous Form",
       "number": "51",
@@ -3873,6 +3925,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "52",
       "multiverseid": 413594,
       "name": "Giant Tortoise",
       "number": "52",
@@ -3941,6 +3994,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "53",
       "multiverseid": 413595,
       "name": "Glacial Wall",
       "number": "53",
@@ -4013,6 +4067,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "54",
       "multiverseid": 413596,
       "name": "Honden of Seeing Winds",
       "number": "54",
@@ -4079,6 +4134,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "55",
       "multiverseid": 413597,
       "name": "Hydroblast",
       "number": "55",
@@ -4155,6 +4211,7 @@
         }
       ],
       "manaCost": "{7}{U}{U}",
+      "mciNumber": "56",
       "multiverseid": 413598,
       "name": "Inkwell Leviathan",
       "number": "56",
@@ -4227,6 +4284,7 @@
       ],
       "loyalty": 3,
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "57",
       "multiverseid": 413599,
       "name": "Jace, the Mind Sculptor",
       "number": "57",
@@ -4306,6 +4364,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "58",
       "multiverseid": 413600,
       "name": "Jetting Glasskite",
       "number": "58",
@@ -4372,6 +4431,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "59",
       "multiverseid": 413601,
       "name": "Man-o'-War",
       "number": "59",
@@ -4451,6 +4511,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "60",
       "multiverseid": 413602,
       "name": "Memory Lapse",
       "number": "60",
@@ -4527,6 +4588,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "61",
       "multiverseid": 413603,
       "name": "Merfolk Looter",
       "number": "61",
@@ -4599,6 +4661,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "62",
       "multiverseid": 413604,
       "name": "Mystical Tutor",
       "number": "62",
@@ -4671,6 +4734,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "63",
       "multiverseid": 413605,
       "name": "Oona's Grace",
       "number": "63",
@@ -4749,6 +4813,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "64",
       "multiverseid": 413606,
       "name": "Peregrine Drake",
       "number": "64",
@@ -4818,6 +4883,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "65",
       "multiverseid": 413607,
       "name": "Phantom Monster",
       "number": "65",
@@ -4895,6 +4961,7 @@
         }
       ],
       "manaCost": "{6}{U}",
+      "mciNumber": "66",
       "multiverseid": 413608,
       "name": "Phyrexian Ingester",
       "number": "66",
@@ -4979,6 +5046,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "67",
       "multiverseid": 413609,
       "name": "Prodigal Sorcerer",
       "number": "67",
@@ -5059,6 +5127,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "68",
       "multiverseid": 413610,
       "name": "Quiet Speculation",
       "number": "68",
@@ -5123,6 +5192,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "69",
       "multiverseid": 413611,
       "name": "Screeching Skaab",
       "number": "69",
@@ -5186,6 +5256,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "70",
       "multiverseid": 413612,
       "name": "Serendib Efreet",
       "number": "70",
@@ -5254,6 +5325,7 @@
         }
       ],
       "manaCost": "{5}{U}",
+      "mciNumber": "71",
       "multiverseid": 413613,
       "name": "Shoreline Ranger",
       "number": "71",
@@ -5325,6 +5397,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "72",
       "multiverseid": 413614,
       "name": "Silent Departure",
       "number": "72",
@@ -5389,6 +5462,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "73",
       "multiverseid": 413615,
       "name": "Sprite Noble",
       "number": "73",
@@ -5454,6 +5528,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "74",
       "multiverseid": 413616,
       "name": "Stupefying Touch",
       "number": "74",
@@ -5527,6 +5602,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "75",
       "multiverseid": 413617,
       "name": "Tidal Wave",
       "number": "75",
@@ -5587,6 +5663,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "76",
       "multiverseid": 413618,
       "name": "Warden of Evos Isle",
       "number": "76",
@@ -5663,6 +5740,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "77",
       "multiverseid": 413619,
       "name": "Wonder",
       "number": "77",
@@ -5727,6 +5805,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "78",
       "multiverseid": 413620,
       "name": "Animate Dead",
       "number": "78",
@@ -5822,6 +5901,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "79",
       "multiverseid": 413621,
       "name": "Annihilate",
       "number": "79",
@@ -5895,6 +5975,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "80",
       "multiverseid": 413622,
       "name": "Blightsoil Druid",
       "number": "80",
@@ -5965,6 +6046,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "81",
       "multiverseid": 413623,
       "name": "Blood Artist",
       "number": "81",
@@ -6036,6 +6118,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "82",
       "multiverseid": 413624,
       "name": "Braids, Cabal Minion",
       "number": "82",
@@ -6110,6 +6193,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "83",
       "multiverseid": 413625,
       "name": "Cabal Therapy",
       "number": "83",
@@ -6178,6 +6262,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "84",
       "multiverseid": 413626,
       "name": "Carrion Feeder",
       "number": "84",
@@ -6251,6 +6336,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "85",
       "multiverseid": 413627,
       "name": "Deadbridge Shaman",
       "number": "85",
@@ -6325,6 +6411,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "86",
       "multiverseid": 413628,
       "name": "Duress",
       "number": "86",
@@ -6398,6 +6485,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "87",
       "multiverseid": 413629,
       "name": "Entomb",
       "number": "87",
@@ -6465,6 +6553,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "88",
       "multiverseid": 413630,
       "name": "Eyeblight's Ending",
       "number": "88",
@@ -6546,6 +6635,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "89",
       "multiverseid": 413631,
       "name": "Gravedigger",
       "number": "89",
@@ -6635,6 +6725,7 @@
         }
       ],
       "manaCost": "{5}{B}{B}",
+      "mciNumber": "90",
       "multiverseid": 413632,
       "name": "Havoc Demon",
       "number": "90",
@@ -6710,6 +6801,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "91",
       "multiverseid": 413633,
       "name": "Honden of Night's Reach",
       "number": "91",
@@ -6772,6 +6864,7 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "92",
       "multiverseid": 413634,
       "name": "Hymn to Tourach",
       "number": "92",
@@ -6835,6 +6928,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "93",
       "multiverseid": 413635,
       "name": "Ichorid",
       "number": "93",
@@ -6911,6 +7005,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "94",
       "multiverseid": 413636,
       "name": "Innocent Blood",
       "number": "94",
@@ -6983,6 +7078,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "95",
       "multiverseid": 413637,
       "name": "Lys Alana Scarblade",
       "number": "95",
@@ -7051,6 +7147,7 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "96",
       "multiverseid": 413638,
       "name": "Malicious Affliction",
       "number": "96",
@@ -7125,6 +7222,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "97",
       "multiverseid": 413639,
       "name": "Nausea",
       "number": "97",
@@ -7192,6 +7290,7 @@
         }
       ],
       "manaCost": "{B}{B}{B}",
+      "mciNumber": "98",
       "multiverseid": 413640,
       "name": "Necropotence",
       "number": "98",
@@ -7271,6 +7370,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "99",
       "multiverseid": 413641,
       "name": "Nekrataal",
       "number": "99",
@@ -7353,6 +7453,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "100",
       "multiverseid": 413642,
       "name": "Night's Whisper",
       "number": "100",
@@ -7418,6 +7519,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "101",
       "multiverseid": 413643,
       "name": "Phyrexian Gargantua",
       "number": "101",
@@ -7495,6 +7597,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "102",
       "multiverseid": 413644,
       "name": "Phyrexian Rager",
       "number": "102",
@@ -7567,6 +7670,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "103",
       "multiverseid": 413645,
       "name": "Plague Witch",
       "number": "103",
@@ -7633,6 +7737,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "104",
       "multiverseid": 413646,
       "name": "Prowling Pangolin",
       "number": "104",
@@ -7702,6 +7807,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "105",
       "multiverseid": 413647,
       "name": "Sengir Autocrat",
       "number": "105",
@@ -7776,6 +7882,7 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "106",
       "multiverseid": 413648,
       "name": "Sinkhole",
       "number": "106",
@@ -7842,6 +7949,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "107",
       "multiverseid": 413649,
       "name": "Skulking Ghost",
       "number": "107",
@@ -7909,6 +8017,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "108",
       "multiverseid": 413650,
       "name": "Toxic Deluge",
       "number": "108",
@@ -7987,6 +8096,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "109",
       "multiverseid": 413651,
       "name": "Tragic Slip",
       "number": "109",
@@ -8057,6 +8167,7 @@
         }
       ],
       "manaCost": "{5}{B}",
+      "mciNumber": "110",
       "multiverseid": 413652,
       "name": "Twisted Abomination",
       "number": "110",
@@ -8147,6 +8258,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "111",
       "multiverseid": 413653,
       "name": "Urborg Uprising",
       "number": "111",
@@ -8218,6 +8330,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "112",
       "multiverseid": 413654,
       "name": "Vampiric Tutor",
       "number": "112",
@@ -8287,6 +8400,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "113",
       "multiverseid": 413655,
       "name": "Victimize",
       "number": "113",
@@ -8373,6 +8487,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}{B}",
+      "mciNumber": "114",
       "multiverseid": 413656,
       "name": "Visara the Dreadful",
       "number": "114",
@@ -8443,6 +8558,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "115",
       "multiverseid": 413657,
       "name": "Wake of Vultures",
       "number": "115",
@@ -8518,6 +8634,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "116",
       "multiverseid": 413658,
       "name": "Wakedancer",
       "number": "116",
@@ -8584,6 +8701,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "117",
       "multiverseid": 413659,
       "name": "Avarax",
       "number": "117",
@@ -8649,6 +8767,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "118",
       "multiverseid": 413660,
       "name": "Battle Squadron",
       "number": "118",
@@ -8716,6 +8835,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "119",
       "multiverseid": 413661,
       "name": "Beetleback Chief",
       "number": "119",
@@ -8790,6 +8910,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "120",
       "multiverseid": 413662,
       "name": "Borderland Marauder",
       "number": "120",
@@ -8861,6 +8982,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "121",
       "multiverseid": 413663,
       "name": "Burning Vengeance",
       "number": "121",
@@ -8935,6 +9057,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "122",
       "multiverseid": 413664,
       "name": "Carbonize",
       "number": "122",
@@ -8996,6 +9119,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "123",
       "multiverseid": 413665,
       "name": "Chain Lightning",
       "number": "123",
@@ -9089,6 +9213,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "124",
       "multiverseid": 413666,
       "name": "Crater Hellion",
       "number": "124",
@@ -9163,6 +9288,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "125",
       "multiverseid": 413667,
       "name": "Desperate Ravings",
       "number": "125",
@@ -9230,6 +9356,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "126",
       "multiverseid": 413668,
       "name": "Dragon Egg",
       "number": "126",
@@ -9291,6 +9418,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "127",
       "multiverseid": 413669,
       "name": "Dualcaster Mage",
       "number": "127",
@@ -9393,6 +9521,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "128",
       "multiverseid": 413670,
       "name": "Faithless Looting",
       "number": "128",
@@ -9467,6 +9596,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "129",
       "multiverseid": 413671,
       "name": "Fervent Cathar",
       "number": "129",
@@ -9539,6 +9669,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "130",
       "multiverseid": 413672,
       "name": "Firebolt",
       "number": "130",
@@ -9607,6 +9738,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "131",
       "multiverseid": 413673,
       "name": "Flame Jab",
       "number": "131",
@@ -9685,6 +9817,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "132",
       "multiverseid": 413674,
       "name": "Gamble",
       "number": "132",
@@ -9755,6 +9888,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "133",
       "multiverseid": 413675,
       "name": "Ghitu Slinger",
       "number": "133",
@@ -9825,6 +9959,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "134",
       "multiverseid": 413676,
       "name": "Honden of Infinite Rage",
       "number": "134",
@@ -9890,6 +10025,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "135",
       "multiverseid": 413677,
       "name": "Keldon Champion",
       "number": "135",
@@ -9961,6 +10097,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "136",
       "multiverseid": 413678,
       "name": "Keldon Marauders",
       "number": "136",
@@ -10028,6 +10165,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "137",
       "multiverseid": 413679,
       "name": "Kird Ape",
       "number": "137",
@@ -10103,6 +10241,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "138",
       "multiverseid": 413680,
       "name": "Mogg Fanatic",
       "number": "138",
@@ -10185,6 +10324,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "139",
       "multiverseid": 413681,
       "name": "Mogg War Marshal",
       "number": "139",
@@ -10250,6 +10390,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "140",
       "multiverseid": 413682,
       "name": "Orcish Oriflamme",
       "number": "140",
@@ -10322,6 +10463,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "141",
       "multiverseid": 413683,
       "name": "Price of Progress",
       "number": "141",
@@ -10383,6 +10525,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "142",
       "multiverseid": 413684,
       "name": "Pyroblast",
       "number": "142",
@@ -10454,6 +10597,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "143",
       "multiverseid": 413685,
       "name": "Pyrokinesis",
       "number": "143",
@@ -10530,6 +10674,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "144",
       "multiverseid": 413686,
       "name": "Reckless Charge",
       "number": "144",
@@ -10592,6 +10737,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}{R}",
+      "mciNumber": "145",
       "multiverseid": 413687,
       "name": "Rorix Bladewing",
       "number": "145",
@@ -10662,6 +10808,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "146",
       "multiverseid": 413688,
       "name": "Seismic Stomp",
       "number": "146",
@@ -10731,6 +10878,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "147",
       "multiverseid": 413689,
       "name": "Siege-Gang Commander",
       "number": "147",
@@ -10809,6 +10957,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "148",
       "multiverseid": 413690,
       "name": "Sneak Attack",
       "number": "148",
@@ -10887,6 +11036,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "149",
       "multiverseid": 413691,
       "name": "Stingscourger",
       "number": "149",
@@ -10953,6 +11103,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "150",
       "multiverseid": 413692,
       "name": "Sulfuric Vortex",
       "number": "150",
@@ -11016,6 +11167,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "151",
       "multiverseid": 413693,
       "name": "Tooth and Claw",
       "number": "151",
@@ -11080,6 +11232,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "152",
       "multiverseid": 413694,
       "name": "Undying Rage",
       "number": "152",
@@ -11158,6 +11311,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "153",
       "multiverseid": 413695,
       "name": "Wildfire Emissary",
       "number": "153",
@@ -11224,6 +11378,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}{R}",
+      "mciNumber": "154",
       "multiverseid": 413696,
       "name": "Worldgorger Dragon",
       "number": "154",
@@ -11305,6 +11460,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "155",
       "multiverseid": 413697,
       "name": "Young Pyromancer",
       "number": "155",
@@ -11381,6 +11537,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "156",
       "multiverseid": 413698,
       "name": "Abundant Growth",
       "number": "156",
@@ -11450,6 +11607,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "157",
       "multiverseid": 413699,
       "name": "Ancestral Mask",
       "number": "157",
@@ -11512,6 +11670,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "158",
       "multiverseid": 413700,
       "name": "Argothian Enchantress",
       "number": "158",
@@ -11593,6 +11752,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "159",
       "multiverseid": 413701,
       "name": "Brawn",
       "number": "159",
@@ -11658,6 +11818,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "160",
       "multiverseid": 413702,
       "name": "Centaur Chieftain",
       "number": "160",
@@ -11737,6 +11898,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "161",
       "multiverseid": 413703,
       "name": "Civic Wayfinder",
       "number": "161",
@@ -11811,6 +11973,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "162",
       "multiverseid": 413704,
       "name": "Commune with the Gods",
       "number": "162",
@@ -11870,6 +12033,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "163",
       "multiverseid": 413705,
       "name": "Elephant Guide",
       "number": "163",
@@ -11943,6 +12107,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "164",
       "multiverseid": 413706,
       "name": "Elvish Vanguard",
       "number": "164",
@@ -12019,6 +12184,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "165",
       "multiverseid": 413707,
       "name": "Emperor Crocodile",
       "number": "165",
@@ -12097,6 +12263,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "166",
       "multiverseid": 413708,
       "name": "Flinthoof Boar",
       "number": "166",
@@ -12166,6 +12333,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "167",
       "multiverseid": 413709,
       "name": "Fog",
       "number": "167",
@@ -12251,6 +12419,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "168",
       "multiverseid": 413710,
       "name": "Gaea's Blessing",
       "number": "168",
@@ -12328,6 +12497,7 @@
         }
       ],
       "manaCost": "{X}{G}",
+      "mciNumber": "169",
       "multiverseid": 413711,
       "name": "Green Sun's Zenith",
       "number": "169",
@@ -12411,6 +12581,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "170",
       "multiverseid": 413712,
       "name": "Harmonize",
       "number": "170",
@@ -12491,6 +12662,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "171",
       "multiverseid": 413713,
       "name": "Heritage Druid",
       "number": "171",
@@ -12567,6 +12739,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "172",
       "multiverseid": 413714,
       "name": "Honden of Life's Web",
       "number": "172",
@@ -12637,6 +12810,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "173",
       "multiverseid": 413715,
       "name": "Imperious Perfect",
       "number": "173",
@@ -12708,6 +12882,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "174",
       "multiverseid": 413716,
       "name": "Invigorate",
       "number": "174",
@@ -12781,6 +12956,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "175",
       "multiverseid": 413717,
       "name": "Llanowar Elves",
       "number": "175",
@@ -12875,6 +13051,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "176",
       "multiverseid": 413718,
       "name": "Lys Alana Huntmaster",
       "number": "176",
@@ -12952,6 +13129,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "177",
       "multiverseid": 413719,
       "name": "Natural Order",
       "number": "177",
@@ -13028,6 +13206,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "178",
       "multiverseid": 413720,
       "name": "Nature's Claim",
       "number": "178",
@@ -13095,6 +13274,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "179",
       "multiverseid": 413721,
       "name": "Nimble Mongoose",
       "number": "179",
@@ -13163,6 +13343,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "180",
       "multiverseid": 413722,
       "name": "Rancor",
       "number": "180",
@@ -13243,6 +13424,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}{G}",
+      "mciNumber": "181",
       "multiverseid": 413723,
       "name": "Regal Force",
       "number": "181",
@@ -13313,6 +13495,7 @@
         }
       ],
       "manaCost": "{6}{G}",
+      "mciNumber": "182",
       "multiverseid": 413724,
       "name": "Roar of the Wurm",
       "number": "182",
@@ -13371,6 +13554,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "183",
       "multiverseid": 413725,
       "name": "Roots",
       "number": "183",
@@ -13435,6 +13619,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "184",
       "multiverseid": 413726,
       "name": "Seal of Strength",
       "number": "184",
@@ -13495,6 +13680,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "185",
       "multiverseid": 413727,
       "name": "Sentinel Spider",
       "number": "185",
@@ -13560,6 +13746,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}{G}",
+      "mciNumber": "186",
       "multiverseid": 413728,
       "name": "Silvos, Rogue Elemental",
       "number": "186",
@@ -13624,6 +13811,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "187",
       "multiverseid": 413729,
       "name": "Sylvan Library",
       "number": "187",
@@ -13718,6 +13906,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "188",
       "multiverseid": 413730,
       "name": "Sylvan Might",
       "number": "188",
@@ -13783,6 +13972,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "189",
       "multiverseid": 413731,
       "name": "Thornweald Archer",
       "number": "189",
@@ -13852,6 +14042,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "190",
       "multiverseid": 413732,
       "name": "Timberwatch Elf",
       "number": "190",
@@ -13927,6 +14118,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "191",
       "multiverseid": 413733,
       "name": "Werebear",
       "number": "191",
@@ -13994,6 +14186,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "192",
       "multiverseid": 413734,
       "name": "Wirewood Symbiote",
       "number": "192",
@@ -14061,6 +14254,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "193",
       "multiverseid": 413735,
       "name": "Xantid Swarm",
       "number": "193",
@@ -14140,6 +14334,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "194",
       "multiverseid": 413736,
       "name": "Yavimaya Enchantress",
       "number": "194",
@@ -14212,6 +14407,7 @@
         }
       ],
       "manaCost": "{1}{G}{W}",
+      "mciNumber": "195",
       "multiverseid": 413737,
       "name": "Armadillo Cloak",
       "number": "195",
@@ -14287,6 +14483,7 @@
         }
       ],
       "manaCost": "{U}{B}",
+      "mciNumber": "196",
       "multiverseid": 413738,
       "name": "Baleful Strix",
       "number": "196",
@@ -14363,6 +14560,7 @@
         }
       ],
       "manaCost": "{2}{R}{G}",
+      "mciNumber": "197",
       "multiverseid": 413739,
       "name": "Bloodbraid Elf",
       "number": "197",
@@ -14461,6 +14659,7 @@
         }
       ],
       "manaCost": "{2}{W}{U}",
+      "mciNumber": "198",
       "multiverseid": 413740,
       "name": "Brago, King Eternal",
       "number": "198",
@@ -14542,6 +14741,7 @@
       ],
       "loyalty": 3,
       "manaCost": "{1}{U}{R}",
+      "mciNumber": "199",
       "multiverseid": 413741,
       "name": "Dack Fayden",
       "number": "199",
@@ -14626,6 +14826,7 @@
         }
       ],
       "manaCost": "{3}{U}{B}",
+      "mciNumber": "200",
       "multiverseid": 413742,
       "name": "Extract from Darkness",
       "number": "200",
@@ -14699,6 +14900,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}{W}",
+      "mciNumber": "201",
       "multiverseid": 413743,
       "name": "Flame-Kin Zealot",
       "number": "201",
@@ -14778,6 +14980,7 @@
         }
       ],
       "manaCost": "{2}{G}{W}",
+      "mciNumber": "202",
       "multiverseid": 413744,
       "name": "Glare of Subdual",
       "number": "202",
@@ -14840,6 +15043,7 @@
         }
       ],
       "manaCost": "{1}{R}{W}",
+      "mciNumber": "203",
       "multiverseid": 413745,
       "name": "Goblin Trenches",
       "number": "203",
@@ -14906,6 +15110,7 @@
         }
       ],
       "manaCost": "{5}{U}{R}{G}",
+      "mciNumber": "204",
       "multiverseid": 413746,
       "name": "Maelstrom Wanderer",
       "number": "204",
@@ -14992,6 +15197,7 @@
         }
       ],
       "manaCost": "{1}{B}{G}",
+      "mciNumber": "205",
       "multiverseid": 413747,
       "name": "Shaman of the Pack",
       "number": "205",
@@ -15061,6 +15267,7 @@
         }
       ],
       "manaCost": "{1}{G}{U}",
+      "mciNumber": "206",
       "multiverseid": 413748,
       "name": "Shardless Agent",
       "number": "206",
@@ -15137,6 +15344,7 @@
         }
       ],
       "manaCost": "{5}{W}{U}{B}",
+      "mciNumber": "207",
       "multiverseid": 413749,
       "name": "Sphinx of the Steel Wind",
       "number": "207",
@@ -15207,6 +15415,7 @@
         }
       ],
       "manaCost": "{2}{W}{U}",
+      "mciNumber": "208",
       "multiverseid": 413750,
       "name": "Thunderclap Wyvern",
       "number": "208",
@@ -15278,6 +15487,7 @@
         }
       ],
       "manaCost": "{1}{G}{U}",
+      "mciNumber": "209",
       "multiverseid": 413751,
       "name": "Trygon Predator",
       "number": "209",
@@ -15347,6 +15557,7 @@
         }
       ],
       "manaCost": "{1}{W}{B}",
+      "mciNumber": "210",
       "multiverseid": 413752,
       "name": "Vindicate",
       "number": "210",
@@ -15418,6 +15629,7 @@
         }
       ],
       "manaCost": "{3}{B}{R}",
+      "mciNumber": "211",
       "multiverseid": 413753,
       "name": "Void",
       "number": "211",
@@ -15495,6 +15707,7 @@
         }
       ],
       "manaCost": "{1}{U}{R}",
+      "mciNumber": "212",
       "multiverseid": 413754,
       "name": "Wee Dragonauts",
       "number": "212",
@@ -15575,6 +15788,7 @@
         }
       ],
       "manaCost": "{W}{B}",
+      "mciNumber": "213",
       "multiverseid": 413755,
       "name": "Zealous Persecution",
       "number": "213",
@@ -15643,6 +15857,7 @@
         }
       ],
       "manaCost": "{5}{U/R}{U/R}",
+      "mciNumber": "214",
       "multiverseid": 413756,
       "name": "Call the Skybreaker",
       "number": "214",
@@ -15728,6 +15943,7 @@
         }
       ],
       "manaCost": "{B/G}",
+      "mciNumber": "215",
       "multiverseid": 413757,
       "name": "Deathrite Shaman",
       "number": "215",
@@ -15810,6 +16026,7 @@
         }
       ],
       "manaCost": "{2}{R/G}{R/G}",
+      "mciNumber": "216",
       "multiverseid": 413758,
       "name": "Giant Solifuge",
       "number": "216",
@@ -15880,6 +16097,7 @@
         }
       ],
       "manaCost": "{4}{B/R}",
+      "mciNumber": "217",
       "multiverseid": 413759,
       "name": "Torrent of Souls",
       "number": "217",
@@ -15947,6 +16165,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "218",
       "multiverseid": 413760,
       "name": "Ashnod's Altar",
       "number": "218",
@@ -16008,6 +16227,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "219",
       "multiverseid": 413761,
       "name": "Chrome Mox",
       "number": "219",
@@ -16077,6 +16297,7 @@
         }
       ],
       "manaCost": "{6}",
+      "mciNumber": "220",
       "multiverseid": 413762,
       "name": "Duplicant",
       "number": "220",
@@ -16162,6 +16383,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "221",
       "multiverseid": 413763,
       "name": "Emmessi Tome",
       "number": "221",
@@ -16220,6 +16442,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "222",
       "multiverseid": 413764,
       "name": "Goblin Charbelcher",
       "number": "222",
@@ -16287,6 +16510,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "223",
       "multiverseid": 413765,
       "name": "Isochron Scepter",
       "number": "223",
@@ -16378,6 +16602,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "224",
       "multiverseid": 413766,
       "name": "Juggernaut",
       "number": "224",
@@ -16456,6 +16681,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "225",
       "multiverseid": 413767,
       "name": "Mana Crypt",
       "number": "225",
@@ -16520,6 +16746,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "226",
       "multiverseid": 413768,
       "name": "Millikin",
       "number": "226",
@@ -16593,6 +16820,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "227",
       "multiverseid": 413769,
       "name": "Mindless Automaton",
       "number": "227",
@@ -16650,6 +16878,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "228",
       "multiverseid": 413770,
       "name": "Nevinyrral's Disk",
       "number": "228",
@@ -16736,6 +16965,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "229",
       "multiverseid": 413771,
       "name": "Pilgrim's Eye",
       "number": "229",
@@ -16805,6 +17035,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "230",
       "multiverseid": 413772,
       "name": "Prismatic Lens",
       "number": "230",
@@ -16863,6 +17094,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "231",
       "multiverseid": 413773,
       "name": "Relic of Progenitus",
       "number": "231",
@@ -16933,6 +17165,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "232",
       "multiverseid": 413774,
       "name": "Sensei's Divining Top",
       "number": "232",
@@ -16997,6 +17230,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "233",
       "multiverseid": 413775,
       "name": "Ticking Gnomes",
       "number": "233",
@@ -17053,6 +17287,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "234",
       "multiverseid": 413776,
       "name": "Winter Orb",
       "number": "234",
@@ -17125,6 +17360,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "235",
       "multiverseid": 413777,
       "name": "Worn Powerstone",
       "number": "235",
@@ -17187,6 +17423,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "236",
       "multiverseid": 413778,
       "name": "Bloodfell Caves",
       "number": "236",
@@ -17247,6 +17484,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "237",
       "multiverseid": 413779,
       "name": "Blossoming Sands",
       "number": "237",
@@ -17307,6 +17545,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "238",
       "multiverseid": 413780,
       "name": "Dismal Backwater",
       "number": "238",
@@ -17369,6 +17608,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "239",
       "multiverseid": 413781,
       "name": "Jungle Hollow",
       "number": "239",
@@ -17423,6 +17663,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "240",
       "multiverseid": 413782,
       "name": "Karakas",
       "number": "240",
@@ -17475,6 +17716,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "241",
       "multiverseid": 413783,
       "name": "Maze of Ith",
       "number": "241",
@@ -17539,6 +17781,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "242",
       "multiverseid": 413784,
       "name": "Mishra's Factory",
       "number": "242",
@@ -17624,6 +17867,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "243",
       "multiverseid": 413785,
       "name": "Rugged Highlands",
       "number": "243",
@@ -17686,6 +17930,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "244",
       "multiverseid": 413786,
       "name": "Scoured Barrens",
       "number": "244",
@@ -17747,6 +17992,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "245",
       "multiverseid": 413787,
       "name": "Swiftwater Cliffs",
       "number": "245",
@@ -17810,6 +18056,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "246",
       "multiverseid": 413788,
       "name": "Thornwood Falls",
       "number": "246",
@@ -17872,6 +18119,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "247",
       "multiverseid": 413789,
       "name": "Tranquil Cove",
       "number": "247",
@@ -17926,6 +18174,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "248",
       "multiverseid": 413790,
       "name": "Wasteland",
       "number": "248",
@@ -17989,6 +18238,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "249",
       "multiverseid": 413791,
       "name": "Wind-Scarred Crag",
       "number": "249",

--- a/json/HOU.json
+++ b/json/HOU.json
@@ -1,6 +1,7 @@
 {
   "name": "Hour of Devastation",
   "code": "HOU",
+  "magicCardsInfoCode": "hou",
   "releaseDate": "2017-07-14",
   "border": "black",
   "block": "Amonkhet",
@@ -119,6 +120,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "1",
       "multiverseid": 430690,
       "name": "Act of Heroism",
       "number": "1",
@@ -243,6 +245,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "2",
       "multiverseid": 430691,
       "name": "Adorned Pouncer",
       "number": "2",
@@ -376,6 +379,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "3",
       "multiverseid": 430692,
       "name": "Angel of Condemnation",
       "number": "3",
@@ -530,6 +534,7 @@
         }
       ],
       "manaCost": "{4}{W}{W}",
+      "mciNumber": "4",
       "multiverseid": 430693,
       "name": "Angel of the God-Pharaoh",
       "number": "4",
@@ -642,6 +647,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "5",
       "multiverseid": 430694,
       "name": "Aven of Enduring Hope",
       "number": "5",
@@ -755,6 +761,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "6",
       "multiverseid": 430695,
       "name": "Crested Sunmare",
       "number": "6",
@@ -881,6 +888,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "7",
       "multiverseid": 430696,
       "name": "Dauntless Aven",
       "number": "7",
@@ -1003,6 +1011,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "8",
       "multiverseid": 430697,
       "name": "Desert's Hold",
       "number": "8",
@@ -1127,6 +1136,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "9",
       "multiverseid": 430698,
       "name": "Disposal Mummy",
       "number": "9",
@@ -1239,6 +1249,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "10",
       "multiverseid": 430699,
       "name": "Djeru, With Eyes Open",
       "number": "10",
@@ -1361,6 +1372,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "11",
       "multiverseid": 430700,
       "name": "Djeru's Renunciation",
       "number": "11",
@@ -1468,6 +1480,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "12",
       "multiverseid": 430701,
       "name": "Dutiful Servants",
       "number": "12",
@@ -1578,6 +1591,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "13",
       "multiverseid": 430702,
       "name": "Gideon's Defeat",
       "number": "13",
@@ -1685,6 +1699,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "14",
       "multiverseid": 430703,
       "name": "God-Pharaoh's Faithful",
       "number": "14",
@@ -1808,6 +1823,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}{W}",
+      "mciNumber": "15",
       "multiverseid": 430704,
       "name": "Hour of Revelation",
       "number": "15",
@@ -1925,6 +1941,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "16",
       "multiverseid": 430705,
       "name": "Mummy Paramount",
       "number": "16",
@@ -2037,6 +2054,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "17",
       "multiverseid": 430706,
       "name": "Oketra's Avenger",
       "number": "17",
@@ -2168,6 +2186,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "18",
       "multiverseid": 430707,
       "name": "Oketra's Last Mercy",
       "number": "18",
@@ -2292,6 +2311,7 @@
         }
       ],
       "manaCost": "{6}{W}{W}",
+      "mciNumber": "19",
       "multiverseid": 430708,
       "name": "Overwhelming Splendor",
       "number": "19",
@@ -2445,6 +2465,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "20",
       "multiverseid": 430709,
       "name": "Sandblast",
       "number": "20",
@@ -2552,6 +2573,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "21",
       "multiverseid": 430710,
       "name": "Saving Grace",
       "number": "21",
@@ -2688,6 +2710,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "22",
       "multiverseid": 430711,
       "name": "Solemnity",
       "number": "22",
@@ -2833,6 +2856,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "23",
       "multiverseid": 430712,
       "name": "Solitary Camel",
       "number": "23",
@@ -2950,6 +2974,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "24",
       "multiverseid": 430713,
       "name": "Steadfast Sentinel",
       "number": "24",
@@ -3085,6 +3110,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "25",
       "multiverseid": 430714,
       "name": "Steward of Solidarity",
       "number": "25",
@@ -3215,6 +3241,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "26",
       "multiverseid": 430715,
       "name": "Sunscourge Champion",
       "number": "26",
@@ -3365,6 +3392,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "27",
       "multiverseid": 430716,
       "name": "Unconventional Tactics",
       "number": "27",
@@ -3472,6 +3500,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "28",
       "multiverseid": 430717,
       "name": "Vizier of the True",
       "number": "28",
@@ -3611,6 +3640,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "29",
       "multiverseid": 430718,
       "name": "Aerial Guide",
       "number": "29",
@@ -3723,6 +3753,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "30",
       "multiverseid": 430719,
       "name": "Aven Reedstalker",
       "number": "30",
@@ -3835,6 +3866,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "31",
       "multiverseid": 430720,
       "name": "Champion of Wits",
       "number": "31",
@@ -3978,6 +4010,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "32",
       "multiverseid": 430721,
       "name": "Countervailing Winds",
       "number": "32",
@@ -4091,6 +4124,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "33",
       "multiverseid": 430722,
       "name": "Cunning Survivor",
       "number": "33",
@@ -4222,6 +4256,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "34",
       "multiverseid": 430723,
       "name": "Eternal of Harsh Truths",
       "number": "34",
@@ -4357,6 +4392,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "35",
       "multiverseid": 430724,
       "name": "Fraying Sanity",
       "number": "35",
@@ -4478,6 +4514,7 @@
         }
       ],
       "manaCost": "{X}{X}{U}{U}{U}",
+      "mciNumber": "36",
       "multiverseid": 430725,
       "name": "Hour of Eternity",
       "number": "36",
@@ -4607,6 +4644,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "37",
       "multiverseid": 430726,
       "name": "Imaginary Threats",
       "number": "37",
@@ -4728,6 +4766,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "38",
       "multiverseid": 430727,
       "name": "Jace's Defeat",
       "number": "38",
@@ -4835,6 +4874,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "39",
       "multiverseid": 430728,
       "name": "Kefnet's Last Word",
       "number": "39",
@@ -4967,6 +5007,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "40",
       "multiverseid": 430729,
       "name": "Nimble Obstructionist",
       "number": "40",
@@ -5114,6 +5155,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "41",
       "multiverseid": 430730,
       "name": "Ominous Sphinx",
       "number": "41",
@@ -5244,6 +5286,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "42",
       "multiverseid": 430731,
       "name": "Proven Combatant",
       "number": "42",
@@ -5378,6 +5421,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "43",
       "multiverseid": 430732,
       "name": "Riddleform",
       "number": "43",
@@ -5495,6 +5539,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "44",
       "multiverseid": 430733,
       "name": "Seer of the Last Tomorrow",
       "number": "44",
@@ -5607,6 +5652,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "45",
       "multiverseid": 430734,
       "name": "Sinuous Striker",
       "number": "45",
@@ -5746,6 +5792,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "46",
       "multiverseid": 430735,
       "name": "Spellweaver Eternal",
       "number": "46",
@@ -5878,6 +5925,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "47",
       "multiverseid": 430736,
       "name": "Strategic Planning",
       "number": "47",
@@ -5994,6 +6042,7 @@
         }
       ],
       "manaCost": "{6}{U}",
+      "mciNumber": "48",
       "multiverseid": 430737,
       "name": "Striped Riverwinder",
       "number": "48",
@@ -6105,6 +6154,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "49",
       "multiverseid": 430738,
       "name": "Supreme Will",
       "number": "49",
@@ -6212,6 +6262,7 @@
         }
       ],
       "manaCost": "{6}{U}",
+      "mciNumber": "50",
       "multiverseid": 430739,
       "name": "Swarm Intelligence",
       "number": "50",
@@ -6353,6 +6404,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "51",
       "multiverseid": 430740,
       "name": "Tragic Lesson",
       "number": "51",
@@ -6465,6 +6517,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "52",
       "multiverseid": 430741,
       "name": "Unesh, Criosphinx Sovereign",
       "number": "52",
@@ -6601,6 +6654,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "53",
       "multiverseid": 430742,
       "name": "Unquenchable Thirst",
       "number": "53",
@@ -6725,6 +6779,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "54",
       "multiverseid": 430743,
       "name": "Unsummon",
       "number": "54",
@@ -6851,6 +6906,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "55",
       "multiverseid": 430744,
       "name": "Vizier of the Anointed",
       "number": "55",
@@ -6969,6 +7025,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "56",
       "multiverseid": 430745,
       "name": "Accursed Horde",
       "number": "56",
@@ -7090,6 +7147,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "57",
       "multiverseid": 430746,
       "name": "Ammit Eternal",
       "number": "57",
@@ -7225,6 +7283,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "58",
       "multiverseid": 430747,
       "name": "Apocalypse Demon",
       "number": "58",
@@ -7343,6 +7402,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "59",
       "multiverseid": 430748,
       "name": "Banewhip Punisher",
       "number": "59",
@@ -7456,6 +7516,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "60",
       "multiverseid": 430749,
       "name": "Bontu's Last Reckoning",
       "number": "60",
@@ -7573,6 +7634,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "61",
       "multiverseid": 430750,
       "name": "Carrion Screecher",
       "number": "61",
@@ -7686,6 +7748,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "62",
       "multiverseid": 430751,
       "name": "Doomfall",
       "number": "62",
@@ -7802,6 +7865,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "63",
       "multiverseid": 430752,
       "name": "Dreamstealer",
       "number": "63",
@@ -7941,6 +8005,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "64",
       "multiverseid": 430753,
       "name": "Grisly Survivor",
       "number": "64",
@@ -8072,6 +8137,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "65",
       "multiverseid": 430754,
       "name": "Hour of Glory",
       "number": "65",
@@ -8189,6 +8255,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "66",
       "multiverseid": 430755,
       "name": "Khenra Eternal",
       "number": "66",
@@ -8321,6 +8388,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "67",
       "multiverseid": 430756,
       "name": "Lethal Sting",
       "number": "67",
@@ -8434,6 +8502,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "68",
       "multiverseid": 430757,
       "name": "Liliana's Defeat",
       "number": "68",
@@ -8541,6 +8610,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "69",
       "multiverseid": 430758,
       "name": "Lurching Rotbeast",
       "number": "69",
@@ -8654,6 +8724,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "70",
       "multiverseid": 430759,
       "name": "Marauding Boneslasher",
       "number": "70",
@@ -8777,6 +8848,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "71",
       "multiverseid": 430760,
       "name": "Merciless Eternal",
       "number": "71",
@@ -8908,6 +8980,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "72",
       "multiverseid": 430761,
       "name": "Moaning Wall",
       "number": "72",
@@ -9021,6 +9094,7 @@
         }
       ],
       "manaCost": "{5}{B}{B}{B}",
+      "mciNumber": "73",
       "multiverseid": 430762,
       "name": "Razaketh, the Foulblooded",
       "number": "73",
@@ -9136,6 +9210,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "74",
       "multiverseid": 430763,
       "name": "Razaketh's Rite",
       "number": "74",
@@ -9243,6 +9318,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "75",
       "multiverseid": 430764,
       "name": "Ruin Rat",
       "number": "75",
@@ -9361,6 +9437,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "76",
       "multiverseid": 430765,
       "name": "Scrounger of Souls",
       "number": "76",
@@ -9473,6 +9550,7 @@
         }
       ],
       "manaCost": "{X}{B}{B}",
+      "mciNumber": "77",
       "multiverseid": 430766,
       "name": "Torment of Hailfire",
       "number": "77",
@@ -9606,6 +9684,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "78",
       "multiverseid": 430767,
       "name": "Torment of Scarabs",
       "number": "78",
@@ -9723,6 +9802,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "79",
       "multiverseid": 430768,
       "name": "Torment of Venom",
       "number": "79",
@@ -9844,6 +9924,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "80",
       "multiverseid": 430769,
       "name": "Vile Manifestation",
       "number": "80",
@@ -9969,6 +10050,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "81",
       "multiverseid": 430770,
       "name": "Without Weakness",
       "number": "81",
@@ -10076,6 +10158,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "82",
       "multiverseid": 430771,
       "name": "Wretched Camel",
       "number": "82",
@@ -10199,6 +10282,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "83",
       "multiverseid": 430772,
       "name": "Abrade",
       "number": "83",
@@ -10306,6 +10390,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "84",
       "multiverseid": 430773,
       "name": "Blur of Blades",
       "number": "84",
@@ -10419,6 +10504,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "85",
       "multiverseid": 430774,
       "name": "Burning-Fist Minotaur",
       "number": "85",
@@ -10532,6 +10618,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "86",
       "multiverseid": 430775,
       "name": "Chandra's Defeat",
       "number": "86",
@@ -10639,6 +10726,7 @@
         }
       ],
       "manaCost": "{5}{R}{R}",
+      "mciNumber": "87",
       "multiverseid": 430776,
       "name": "Chaos Maw",
       "number": "87",
@@ -10751,6 +10839,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "88",
       "multiverseid": 430777,
       "name": "Crash Through",
       "number": "88",
@@ -10864,6 +10953,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "89",
       "multiverseid": 430778,
       "name": "Defiant Khenra",
       "number": "89",
@@ -10974,6 +11064,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "90",
       "multiverseid": 430779,
       "name": "Earthshaker Khenra",
       "number": "90",
@@ -11121,6 +11212,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "91",
       "multiverseid": 430780,
       "name": "Fervent Paincaster",
       "number": "91",
@@ -11252,6 +11344,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "92",
       "multiverseid": 430781,
       "name": "Firebrand Archer",
       "number": "92",
@@ -11375,6 +11468,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "93",
       "multiverseid": 430782,
       "name": "Frontline Devastator",
       "number": "93",
@@ -11507,6 +11601,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "94",
       "multiverseid": 430783,
       "name": "Gilded Cerodon",
       "number": "94",
@@ -11629,6 +11724,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "95",
       "multiverseid": 430784,
       "name": "Granitic Titan",
       "number": "95",
@@ -11740,6 +11836,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "96",
       "multiverseid": 430785,
       "name": "Hazoret's Undying Fury",
       "number": "96",
@@ -12005,6 +12102,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "98",
       "multiverseid": 430787,
       "name": "Imminent Doom",
       "number": "98",
@@ -12126,6 +12224,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "99",
       "multiverseid": 430788,
       "name": "Inferno Jet",
       "number": "99",
@@ -12233,6 +12332,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "100",
       "multiverseid": 430789,
       "name": "Khenra Scrapper",
       "number": "100",
@@ -12372,6 +12472,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "101",
       "multiverseid": 430790,
       "name": "Kindled Fury",
       "number": "101",
@@ -12489,6 +12590,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "102",
       "multiverseid": 430791,
       "name": "Magmaroth",
       "number": "102",
@@ -12607,6 +12709,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "103",
       "multiverseid": 430792,
       "name": "Manticore Eternal",
       "number": "103",
@@ -12742,6 +12845,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "104",
       "multiverseid": 430793,
       "name": "Neheb, the Eternal",
       "number": "104",
@@ -12905,6 +13009,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "105",
       "multiverseid": 430794,
       "name": "Open Fire",
       "number": "105",
@@ -13012,6 +13117,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "106",
       "multiverseid": 430795,
       "name": "Puncturing Blow",
       "number": "106",
@@ -13125,6 +13231,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "107",
       "multiverseid": 430796,
       "name": "Sand Strangler",
       "number": "107",
@@ -13247,6 +13354,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "108",
       "multiverseid": 430797,
       "name": "Thorned Moloch",
       "number": "108",
@@ -13358,6 +13466,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "109",
       "multiverseid": 430798,
       "name": "Wildfire Eternal",
       "number": "109",
@@ -13506,6 +13615,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "110",
       "multiverseid": 430799,
       "name": "Ambuscade",
       "number": "110",
@@ -13619,6 +13729,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "111",
       "multiverseid": 430800,
       "name": "Beneath the Sands",
       "number": "111",
@@ -13726,6 +13837,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "112",
       "multiverseid": 430801,
       "name": "Bitterbow Sharpshooters",
       "number": "112",
@@ -13839,6 +13951,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "113",
       "multiverseid": 430802,
       "name": "Devotee of Strength",
       "number": "113",
@@ -13952,6 +14065,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "114",
       "multiverseid": 430803,
       "name": "Dune Diviner",
       "number": "114",
@@ -14071,6 +14185,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "115",
       "multiverseid": 430804,
       "name": "Feral Prowler",
       "number": "115",
@@ -14183,6 +14298,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "116",
       "multiverseid": 430805,
       "name": "Frilled Sandwalla",
       "number": "116",
@@ -14295,6 +14411,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "117",
       "multiverseid": 430806,
       "name": "Gift of Strength",
       "number": "117",
@@ -14402,6 +14519,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "118",
       "multiverseid": 430807,
       "name": "Harrier Naga",
       "number": "118",
@@ -14513,6 +14631,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "119",
       "multiverseid": 430808,
       "name": "Hope Tender",
       "number": "119",
@@ -14644,6 +14763,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "120",
       "multiverseid": 430809,
       "name": "Hour of Promise",
       "number": "120",
@@ -14761,6 +14881,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "121",
       "multiverseid": 430810,
       "name": "Life Goes On",
       "number": "121",
@@ -14877,6 +14998,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "122",
       "multiverseid": 430811,
       "name": "Majestic Myriarch",
       "number": "122",
@@ -15015,6 +15137,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "123",
       "multiverseid": 430812,
       "name": "Nissa's Defeat",
       "number": "123",
@@ -15128,6 +15251,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "124",
       "multiverseid": 430813,
       "name": "Oasis Ritualist",
       "number": "124",
@@ -15259,6 +15383,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "125",
       "multiverseid": 430814,
       "name": "Overcome",
       "number": "125",
@@ -15366,6 +15491,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "126",
       "multiverseid": 430815,
       "name": "Pride Sovereign",
       "number": "126",
@@ -15500,6 +15626,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "127",
       "multiverseid": 430816,
       "name": "Quarry Beetle",
       "number": "127",
@@ -15618,6 +15745,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "128",
       "multiverseid": 430817,
       "name": "Rampaging Hippo",
       "number": "128",
@@ -15730,6 +15858,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "129",
       "multiverseid": 430818,
       "name": "Ramunap Excavator",
       "number": "129",
@@ -15852,6 +15981,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "130",
       "multiverseid": 430819,
       "name": "Ramunap Hydra",
       "number": "130",
@@ -15970,6 +16100,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "131",
       "multiverseid": 430820,
       "name": "Resilient Khenra",
       "number": "131",
@@ -16121,6 +16252,7 @@
         }
       ],
       "manaCost": "{G}{G}",
+      "mciNumber": "132",
       "multiverseid": 430821,
       "name": "Rhonas's Last Stand",
       "number": "132",
@@ -16238,6 +16370,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "133",
       "multiverseid": 430822,
       "name": "Rhonas's Stalwart",
       "number": "133",
@@ -16373,6 +16506,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "134",
       "multiverseid": 430823,
       "name": "Sidewinder Naga",
       "number": "134",
@@ -16492,6 +16626,7 @@
         }
       ],
       "manaCost": "{5}{G}{G}",
+      "mciNumber": "135",
       "multiverseid": 430824,
       "name": "Sifter Wurm",
       "number": "135",
@@ -16618,6 +16753,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "136",
       "multiverseid": 430825,
       "name": "Tenacious Hunter",
       "number": "136",
@@ -16740,6 +16876,7 @@
         }
       ],
       "manaCost": "{X}{G}{G}",
+      "mciNumber": "137",
       "multiverseid": 430826,
       "name": "Uncage the Menagerie",
       "number": "137",
@@ -16858,6 +16995,7 @@
         }
       ],
       "manaCost": "{1}{U}{R}",
+      "mciNumber": "138",
       "multiverseid": 430827,
       "name": "Bloodwater Entity",
       "number": "138",
@@ -16971,6 +17109,7 @@
         }
       ],
       "manaCost": "{4}{U}{R}",
+      "mciNumber": "139",
       "multiverseid": 430828,
       "name": "The Locust God",
       "number": "139",
@@ -17105,6 +17244,7 @@
       ],
       "loyalty": 7,
       "manaCost": "{4}{U}{B}{R}",
+      "mciNumber": "140",
       "multiverseid": 430829,
       "name": "Nicol Bolas, God-Pharaoh",
       "number": "140",
@@ -17250,6 +17390,7 @@
         }
       ],
       "manaCost": "{1}{B}{G}",
+      "mciNumber": "141",
       "multiverseid": 430830,
       "name": "Obelisk Spider",
       "number": "141",
@@ -17394,6 +17535,7 @@
         }
       ],
       "manaCost": "{1}{R}{W}",
+      "mciNumber": "142",
       "multiverseid": 430831,
       "name": "Resolute Survivors",
       "number": "142",
@@ -17535,6 +17677,7 @@
         }
       ],
       "manaCost": "{G}{U}",
+      "mciNumber": "143",
       "multiverseid": 430832,
       "name": "River Hoopoe",
       "number": "143",
@@ -17649,6 +17792,7 @@
       ],
       "loyalty": 4,
       "manaCost": "{2}{R}{G}",
+      "mciNumber": "144",
       "multiverseid": 430833,
       "name": "Samut, the Tested",
       "number": "144",
@@ -17774,6 +17918,7 @@
         }
       ],
       "manaCost": "{3}{U}{B}",
+      "mciNumber": "145",
       "multiverseid": 430834,
       "name": "The Scarab God",
       "number": "145",
@@ -17925,6 +18070,7 @@
         }
       ],
       "manaCost": "{3}{B}{R}",
+      "mciNumber": "146",
       "multiverseid": 430835,
       "name": "The Scorpion God",
       "number": "146",
@@ -18061,6 +18207,7 @@
         }
       ],
       "manaCost": "{1}{W}{B}",
+      "mciNumber": "147",
       "multiverseid": 430836,
       "name": "Unraveling Mummy",
       "number": "147",
@@ -20933,6 +21080,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "158",
       "multiverseid": 430847,
       "name": "Abandoned Sarcophagus",
       "number": "158",
@@ -21052,6 +21200,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "159",
       "multiverseid": 430848,
       "name": "Crook of Condemnation",
       "number": "159",
@@ -21152,6 +21301,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "160",
       "multiverseid": 430849,
       "name": "Dagger of the Worthy",
       "number": "160",
@@ -21277,6 +21427,7 @@
         }
       ],
       "manaCost": "{7}",
+      "mciNumber": "161",
       "multiverseid": 430850,
       "name": "God-Pharaoh's Gift",
       "number": "161",
@@ -21400,6 +21551,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "162",
       "multiverseid": 430851,
       "name": "Graven Abomination",
       "number": "162",
@@ -21507,6 +21659,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "163",
       "multiverseid": 430852,
       "name": "Hollow One",
       "number": "163",
@@ -21628,6 +21781,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "164",
       "multiverseid": 430853,
       "name": "Manalith",
       "number": "164",
@@ -21730,6 +21884,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "165",
       "multiverseid": 430854,
       "name": "Mirage Mirror",
       "number": "165",
@@ -21865,6 +22020,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "166",
       "multiverseid": 430855,
       "name": "Sunset Pyramid",
       "number": "166",
@@ -21974,6 +22130,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "167",
       "multiverseid": 430856,
       "name": "Traveler's Amulet",
       "number": "167",
@@ -22076,6 +22233,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "168",
       "multiverseid": 430857,
       "name": "Wall of Forgotten Pharaohs",
       "number": "168",
@@ -22192,6 +22350,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "169",
       "multiverseid": 430858,
       "name": "Crypt of the Eternals",
       "number": "169",
@@ -22293,6 +22452,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "170",
       "multiverseid": 430859,
       "name": "Desert of the Fervent",
       "number": "170",
@@ -22403,6 +22563,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "171",
       "multiverseid": 430860,
       "name": "Desert of the Glorified",
       "number": "171",
@@ -22513,6 +22674,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "172",
       "multiverseid": 430861,
       "name": "Desert of the Indomitable",
       "number": "172",
@@ -22623,6 +22785,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "173",
       "multiverseid": 430862,
       "name": "Desert of the Mindful",
       "number": "173",
@@ -22733,6 +22896,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "174",
       "multiverseid": 430863,
       "name": "Desert of the True",
       "number": "174",
@@ -22841,6 +23005,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "175",
       "multiverseid": 430864,
       "name": "Dunes of the Dead",
       "number": "175",
@@ -22956,6 +23121,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "176",
       "multiverseid": 430865,
       "name": "Endless Sands",
       "number": "176",
@@ -23074,6 +23240,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "177",
       "multiverseid": 430866,
       "name": "Hashep Oasis",
       "number": "177",
@@ -23186,6 +23353,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "178",
       "multiverseid": 430867,
       "name": "Hostile Desert",
       "number": "178",
@@ -23300,6 +23468,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "179",
       "multiverseid": 430868,
       "name": "Ifnir Deadlands",
       "number": "179",
@@ -23414,6 +23583,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "180",
       "multiverseid": 430869,
       "name": "Ipnu Rivulet",
       "number": "180",
@@ -23528,6 +23698,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "181",
       "multiverseid": 430870,
       "name": "Ramunap Ruins",
       "number": "181",
@@ -23644,6 +23815,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "182",
       "multiverseid": 430871,
       "name": "Scavenger Grounds",
       "number": "182",
@@ -23762,6 +23934,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "183",
       "multiverseid": 430872,
       "name": "Shefet Dunes",
       "number": "183",
@@ -23874,6 +24047,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "184",
       "multiverseid": 430873,
       "name": "Survivors' Encampment",
       "number": "184",
@@ -29715,6 +29889,7 @@
       ],
       "loyalty": 5,
       "manaCost": "{5}{G}{G}",
+      "mciNumber": "200",
       "multiverseid": 432879,
       "name": "Nissa, Genesis Mage",
       "number": "200",
@@ -29836,6 +30011,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "201",
       "multiverseid": 432880,
       "name": "Avid Reclaimer",
       "number": "201",
@@ -29959,6 +30135,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "202",
       "multiverseid": 432881,
       "name": "Brambleweft Behemoth",
       "number": "202",
@@ -30070,6 +30247,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "203",
       "multiverseid": 432882,
       "name": "Nissa's Encouragement",
       "number": "203",
@@ -30191,6 +30369,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "204",
       "multiverseid": 432883,
       "name": "Woodland Stream",
       "number": "204",
@@ -30305,6 +30484,7 @@
       ],
       "loyalty": 5,
       "manaCost": "{5}{U}{B}{R}",
+      "mciNumber": "205",
       "multiverseid": 432884,
       "name": "Nicol Bolas, the Deceiver",
       "number": "205",
@@ -30433,6 +30613,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "206",
       "multiverseid": 432885,
       "name": "Wasp of the Bitter End",
       "number": "206",
@@ -30552,6 +30733,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "207",
       "multiverseid": 432886,
       "name": "Zealot of the God-Pharaoh",
       "number": "207",
@@ -30663,6 +30845,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "208",
       "multiverseid": 432887,
       "name": "Visage of Bolas",
       "number": "208",
@@ -30770,6 +30953,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "209",
       "multiverseid": 432888,
       "name": "Cinder Barrens",
       "number": "209",

--- a/json/KLD.json
+++ b/json/KLD.json
@@ -1,6 +1,7 @@
 {
   "name": "Kaladesh",
   "code": "KLD",
+  "magicCardsInfoCode": "kld",
   "releaseDate": "2016-09-30",
   "border": "black",
   "type": "expansion",
@@ -119,6 +120,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "1",
       "multiverseid": 417574,
       "name": "Acrobatic Maneuver",
       "number": "1",
@@ -236,6 +238,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "2",
       "multiverseid": 417575,
       "name": "Aerial Responder",
       "number": "2",
@@ -349,6 +352,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "3",
       "multiverseid": 417576,
       "name": "Aetherstorm Roc",
       "number": "3",
@@ -506,6 +510,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "4",
       "multiverseid": 417577,
       "name": "Angel of Invention",
       "number": "4",
@@ -632,6 +637,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "5",
       "multiverseid": 417578,
       "name": "Authority of the Consuls",
       "number": "5",
@@ -739,6 +745,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "6",
       "multiverseid": 417579,
       "name": "Aviary Mechanic",
       "number": "6",
@@ -852,6 +859,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "7",
       "multiverseid": 417580,
       "name": "Built to Last",
       "number": "7",
@@ -965,6 +973,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "8",
       "multiverseid": 417581,
       "name": "Captured by the Consulate",
       "number": "8",
@@ -1101,6 +1110,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "9",
       "multiverseid": 417582,
       "name": "Cataclysmic Gearhulk",
       "number": "9",
@@ -1236,6 +1246,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "10",
       "multiverseid": 417583,
       "name": "Consulate Surveillance",
       "number": "10",
@@ -1380,6 +1391,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "11",
       "multiverseid": 417584,
       "name": "Consul's Shieldguard",
       "number": "11",
@@ -1526,6 +1538,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "12",
       "multiverseid": 417585,
       "name": "Eddytrail Hawk",
       "number": "12",
@@ -1672,6 +1685,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "13",
       "multiverseid": 417586,
       "name": "Fairgrounds Warden",
       "number": "13",
@@ -1807,6 +1821,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "14",
       "multiverseid": 417587,
       "name": "Fragmentize",
       "number": "14",
@@ -1924,6 +1939,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "15",
       "multiverseid": 417588,
       "name": "Fumigate",
       "number": "15",
@@ -2041,6 +2057,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "16",
       "multiverseid": 417589,
       "name": "Gearshift Ace",
       "number": "16",
@@ -2160,6 +2177,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "17",
       "multiverseid": 417590,
       "name": "Glint-Sleeve Artisan",
       "number": "17",
@@ -2287,6 +2305,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "18",
       "multiverseid": 417591,
       "name": "Herald of the Fair",
       "number": "18",
@@ -2403,6 +2422,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "19",
       "multiverseid": 417592,
       "name": "Impeccable Timing",
       "number": "19",
@@ -2515,6 +2535,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "20",
       "multiverseid": 417593,
       "name": "Inspired Charge",
       "number": "20",
@@ -2635,6 +2656,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "21",
       "multiverseid": 417594,
       "name": "Master Trinketeer",
       "number": "21",
@@ -2754,6 +2776,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "22",
       "multiverseid": 417595,
       "name": "Ninth Bridge Patrol",
       "number": "22",
@@ -2881,6 +2904,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "23",
       "multiverseid": 417596,
       "name": "Pressure Point",
       "number": "23",
@@ -2989,6 +3013,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "24",
       "multiverseid": 417597,
       "name": "Propeller Pioneer",
       "number": "24",
@@ -3116,6 +3141,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "25",
       "multiverseid": 417598,
       "name": "Refurbish",
       "number": "25",
@@ -3223,6 +3249,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "26",
       "multiverseid": 417599,
       "name": "Revoke Privileges",
       "number": "26",
@@ -3333,6 +3360,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "27",
       "multiverseid": 417600,
       "name": "Servo Exhibition",
       "number": "27",
@@ -3440,6 +3468,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "28",
       "multiverseid": 417601,
       "name": "Skyswirl Harrier",
       "number": "28",
@@ -3552,6 +3581,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "29",
       "multiverseid": 417602,
       "name": "Skywhaler's Shot",
       "number": "29",
@@ -3665,6 +3695,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "30",
       "multiverseid": 417603,
       "name": "Tasseled Dromedary",
       "number": "30",
@@ -3775,6 +3806,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "31",
       "multiverseid": 417604,
       "name": "Thriving Ibex",
       "number": "31",
@@ -3917,6 +3949,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "32",
       "multiverseid": 417605,
       "name": "Toolcraft Exemplar",
       "number": "32",
@@ -4040,6 +4073,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "33",
       "multiverseid": 417606,
       "name": "Trusty Companion",
       "number": "33",
@@ -4174,6 +4208,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "34",
       "multiverseid": 417607,
       "name": "Visionary Augmenter",
       "number": "34",
@@ -4300,6 +4335,7 @@
         }
       ],
       "manaCost": "{4}{W}{W}",
+      "mciNumber": "35",
       "multiverseid": 417608,
       "name": "Wispweaver Angel",
       "number": "35",
@@ -4425,6 +4461,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "36",
       "multiverseid": 417609,
       "name": "Aether Meltdown",
       "number": "36",
@@ -4564,6 +4601,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "37",
       "multiverseid": 417610,
       "name": "Aether Theorist",
       "number": "37",
@@ -4707,6 +4745,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "38",
       "multiverseid": 417611,
       "name": "Aether Tradewinds",
       "number": "38",
@@ -4821,6 +4860,7 @@
         }
       ],
       "manaCost": "{5}{U}{U}",
+      "mciNumber": "39",
       "multiverseid": 417612,
       "name": "Aethersquall Ancient",
       "number": "39",
@@ -4959,6 +4999,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "40",
       "multiverseid": 417613,
       "name": "Ceremonious Rejection",
       "number": "40",
@@ -5066,6 +5107,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "41",
       "multiverseid": 417614,
       "name": "Confiscation Coup",
       "number": "41",
@@ -5224,6 +5266,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "42",
       "multiverseid": 417615,
       "name": "Curio Vendor",
       "number": "42",
@@ -5334,6 +5377,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "43",
       "multiverseid": 417616,
       "name": "Disappearing Act",
       "number": "43",
@@ -5441,6 +5485,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "44",
       "multiverseid": 417617,
       "name": "Dramatic Reversal",
       "number": "44",
@@ -5547,6 +5592,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "45",
       "multiverseid": 417618,
       "name": "Era of Innovation",
       "number": "45",
@@ -5688,6 +5734,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "46",
       "multiverseid": 417619,
       "name": "Experimental Aviator",
       "number": "46",
@@ -5801,6 +5848,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "47",
       "multiverseid": 417620,
       "name": "Failed Inspection",
       "number": "47",
@@ -5908,6 +5956,7 @@
         }
       ],
       "manaCost": "{5}{U}{U}",
+      "mciNumber": "48",
       "multiverseid": 417621,
       "name": "Gearseeker Serpent",
       "number": "48",
@@ -6038,6 +6087,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "49",
       "multiverseid": 417622,
       "name": "Glimmer of Genius",
       "number": "49",
@@ -6170,6 +6220,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "50",
       "multiverseid": 417623,
       "name": "Glint-Nest Crane",
       "number": "50",
@@ -6281,6 +6332,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "51",
       "multiverseid": 417624,
       "name": "Hightide Hermit",
       "number": "51",
@@ -6419,6 +6471,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "52",
       "multiverseid": 417625,
       "name": "Insidious Will",
       "number": "52",
@@ -6564,6 +6617,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "53",
       "multiverseid": 417626,
       "name": "Janjeet Sentry",
       "number": "53",
@@ -6703,6 +6757,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "54",
       "multiverseid": 417627,
       "name": "Long-Finned Skywhale",
       "number": "54",
@@ -6815,6 +6870,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "55",
       "multiverseid": 417628,
       "name": "Malfunction",
       "number": "55",
@@ -6924,6 +6980,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "56",
       "multiverseid": 417629,
       "name": "Metallurgic Summonings",
       "number": "56",
@@ -7049,6 +7106,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "57",
       "multiverseid": 417630,
       "name": "Minister of Inquiries",
       "number": "57",
@@ -7188,6 +7246,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "58",
       "multiverseid": 417631,
       "name": "Nimble Innovator",
       "number": "58",
@@ -7301,6 +7360,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "59",
       "multiverseid": 417632,
       "name": "Padeem, Consul of Innovation",
       "number": "59",
@@ -7435,6 +7495,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "60",
       "multiverseid": 417633,
       "name": "Paradoxical Outcome",
       "number": "60",
@@ -7552,6 +7613,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "61",
       "multiverseid": 417634,
       "name": "Revolutionary Rebuff",
       "number": "61",
@@ -7659,6 +7721,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "62",
       "multiverseid": 417635,
       "name": "Saheeli's Artistry",
       "number": "62",
@@ -7803,6 +7866,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "63",
       "multiverseid": 417636,
       "name": "Select for Inspection",
       "number": "63",
@@ -7916,6 +7980,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "64",
       "multiverseid": 417637,
       "name": "Shrewd Negotiation",
       "number": "64",
@@ -8037,6 +8102,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "65",
       "multiverseid": 417638,
       "name": "Tezzeret's Ambition",
       "number": "65",
@@ -8150,6 +8216,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "66",
       "multiverseid": 417639,
       "name": "Thriving Turtle",
       "number": "66",
@@ -8291,6 +8358,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "67",
       "multiverseid": 417640,
       "name": "Torrential Gearhulk",
       "number": "67",
@@ -8419,6 +8487,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "68",
       "multiverseid": 417641,
       "name": "Vedalken Blademaster",
       "number": "68",
@@ -8532,6 +8601,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "69",
       "multiverseid": 417642,
       "name": "Weldfast Wingsmith",
       "number": "69",
@@ -8653,6 +8723,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "70",
       "multiverseid": 417643,
       "name": "Wind Drake",
       "number": "70",
@@ -8778,6 +8849,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "71",
       "multiverseid": 417644,
       "name": "Aetherborn Marauder",
       "number": "71",
@@ -8909,6 +8981,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "72",
       "multiverseid": 417645,
       "name": "Ambitious Aetherborn",
       "number": "72",
@@ -9035,6 +9108,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}{B}",
+      "mciNumber": "73",
       "multiverseid": 417646,
       "name": "Demon of Dark Schemes",
       "number": "73",
@@ -9189,6 +9263,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "74",
       "multiverseid": 417647,
       "name": "Dhund Operative",
       "number": "74",
@@ -9306,6 +9381,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "75",
       "multiverseid": 417648,
       "name": "Diabolic Tutor",
       "number": "75",
@@ -9424,6 +9500,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "76",
       "multiverseid": 417649,
       "name": "Die Young",
       "number": "76",
@@ -9565,6 +9642,7 @@
         }
       ],
       "manaCost": "{5}{B}",
+      "mciNumber": "77",
       "multiverseid": 417650,
       "name": "Dukhara Scavenger",
       "number": "77",
@@ -9677,6 +9755,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "78",
       "multiverseid": 417651,
       "name": "Eliminate the Competition",
       "number": "78",
@@ -9794,6 +9873,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "79",
       "multiverseid": 417652,
       "name": "Embraal Bruiser",
       "number": "79",
@@ -9913,6 +9993,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "80",
       "multiverseid": 417653,
       "name": "Essence Extraction",
       "number": "80",
@@ -10026,6 +10107,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "81",
       "multiverseid": 417654,
       "name": "Fortuitous Find",
       "number": "81",
@@ -10133,6 +10215,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "82",
       "multiverseid": 417655,
       "name": "Foundry Screecher",
       "number": "82",
@@ -10245,6 +10328,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "83",
       "multiverseid": 417656,
       "name": "Fretwork Colony",
       "number": "83",
@@ -10362,6 +10446,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "84",
       "multiverseid": 417657,
       "name": "Gonti, Lord of Luxury",
       "number": "84",
@@ -10504,6 +10589,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "85",
       "multiverseid": 417658,
       "name": "Harsh Scrutiny",
       "number": "85",
@@ -10617,6 +10703,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "86",
       "multiverseid": 417659,
       "name": "Lawless Broker",
       "number": "86",
@@ -10730,6 +10817,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "87",
       "multiverseid": 417660,
       "name": "Live Fast",
       "number": "87",
@@ -10863,6 +10951,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "88",
       "multiverseid": 417661,
       "name": "Lost Legacy",
       "number": "88",
@@ -10970,6 +11059,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "89",
       "multiverseid": 417662,
       "name": "Make Obsolete",
       "number": "89",
@@ -11082,6 +11172,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "90",
       "multiverseid": 417663,
       "name": "Marionette Master",
       "number": "90",
@@ -11225,6 +11316,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "91",
       "multiverseid": 417664,
       "name": "Maulfist Squad",
       "number": "91",
@@ -11351,6 +11443,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "92",
       "multiverseid": 417665,
       "name": "Midnight Oil",
       "number": "92",
@@ -11488,6 +11581,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "93",
       "multiverseid": 417666,
       "name": "Mind Rot",
       "number": "93",
@@ -11613,6 +11707,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "94",
       "multiverseid": 417667,
       "name": "Morbid Curiosity",
       "number": "94",
@@ -11734,6 +11829,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "95",
       "multiverseid": 417668,
       "name": "Night Market Lookout",
       "number": "95",
@@ -11860,6 +11956,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "96",
       "multiverseid": 417669,
       "name": "Noxious Gearhulk",
       "number": "96",
@@ -11984,6 +12081,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "97",
       "multiverseid": 417670,
       "name": "Ovalchase Daredevil",
       "number": "97",
@@ -12103,6 +12201,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "98",
       "multiverseid": 417671,
       "name": "Prakhata Club Security",
       "number": "98",
@@ -12214,6 +12313,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "99",
       "multiverseid": 417672,
       "name": "Rush of Vitality",
       "number": "99",
@@ -12321,6 +12421,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "100",
       "multiverseid": 417673,
       "name": "Subtle Strike",
       "number": "100",
@@ -12428,6 +12529,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "101",
       "multiverseid": 417674,
       "name": "Syndicate Trafficker",
       "number": "101",
@@ -12541,6 +12643,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "102",
       "multiverseid": 417675,
       "name": "Thriving Rats",
       "number": "102",
@@ -12683,6 +12786,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "103",
       "multiverseid": 417676,
       "name": "Tidy Conclusion",
       "number": "103",
@@ -12799,6 +12903,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "104",
       "multiverseid": 417677,
       "name": "Underhanded Designs",
       "number": "104",
@@ -12920,6 +13025,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "105",
       "multiverseid": 417678,
       "name": "Weaponcraft Enthusiast",
       "number": "105",
@@ -13046,6 +13152,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "106",
       "multiverseid": 417679,
       "name": "Aethertorch Renegade",
       "number": "106",
@@ -13185,6 +13292,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "107",
       "multiverseid": 417680,
       "name": "Brazen Scourge",
       "number": "107",
@@ -13297,6 +13405,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "108",
       "multiverseid": 417681,
       "name": "Built to Smash",
       "number": "108",
@@ -13410,6 +13519,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "109",
       "multiverseid": 417682,
       "name": "Cathartic Reunion",
       "number": "109",
@@ -13523,6 +13633,7 @@
       ],
       "loyalty": 4,
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "110",
       "multiverseid": 417683,
       "name": "Chandra, Torch of Defiance",
       "number": "110",
@@ -13663,6 +13774,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "111",
       "multiverseid": 417684,
       "name": "Chandra's Pyrohelix",
       "number": "111",
@@ -13779,6 +13891,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "112",
       "multiverseid": 417685,
       "name": "Combustible Gearhulk",
       "number": "112",
@@ -13923,6 +14036,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "113",
       "multiverseid": 417686,
       "name": "Demolish",
       "number": "113",
@@ -14040,6 +14154,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "114",
       "multiverseid": 417687,
       "name": "Fateful Showdown",
       "number": "114",
@@ -14162,6 +14277,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "115",
       "multiverseid": 417688,
       "name": "Furious Reprisal",
       "number": "115",
@@ -14275,6 +14391,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "116",
       "multiverseid": 417689,
       "name": "Giant Spectacle",
       "number": "116",
@@ -14384,6 +14501,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "117",
       "multiverseid": 417690,
       "name": "Harnessed Lightning",
       "number": "117",
@@ -14525,6 +14643,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "118",
       "multiverseid": 417691,
       "name": "Hijack",
       "number": "118",
@@ -14632,6 +14751,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "119",
       "multiverseid": 417692,
       "name": "Incendiary Sabotage",
       "number": "119",
@@ -14739,6 +14859,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "120",
       "multiverseid": 417693,
       "name": "Inventor's Apprentice",
       "number": "120",
@@ -14851,6 +14972,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "121",
       "multiverseid": 417694,
       "name": "Lathnu Hellion",
       "number": "121",
@@ -14988,6 +15110,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "122",
       "multiverseid": 417695,
       "name": "Madcap Experiment",
       "number": "122",
@@ -15113,6 +15236,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "123",
       "multiverseid": 417696,
       "name": "Maulfist Doorbuster",
       "number": "123",
@@ -15263,6 +15387,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "124",
       "multiverseid": 417697,
       "name": "Pia Nalaar",
       "number": "124",
@@ -15389,6 +15514,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "125",
       "multiverseid": 417698,
       "name": "Quicksmith Genius",
       "number": "125",
@@ -15502,6 +15628,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "126",
       "multiverseid": 417699,
       "name": "Reckless Fireweaver",
       "number": "126",
@@ -15621,6 +15748,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "127",
       "multiverseid": 417700,
       "name": "Renegade Tactics",
       "number": "127",
@@ -15728,6 +15856,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "128",
       "multiverseid": 417701,
       "name": "Ruinous Gremlin",
       "number": "128",
@@ -15840,6 +15969,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "129",
       "multiverseid": 417702,
       "name": "Salivating Gremlins",
       "number": "129",
@@ -15951,6 +16081,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "130",
       "multiverseid": 417703,
       "name": "Skyship Stalker",
       "number": "130",
@@ -16063,6 +16194,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "131",
       "multiverseid": 417704,
       "name": "Spark of Creativity",
       "number": "131",
@@ -16192,6 +16324,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "132",
       "multiverseid": 417705,
       "name": "Speedway Fanatic",
       "number": "132",
@@ -16311,6 +16444,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "133",
       "multiverseid": 417706,
       "name": "Spireside Infiltrator",
       "number": "133",
@@ -16434,6 +16568,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "134",
       "multiverseid": 417707,
       "name": "Spontaneous Artist",
       "number": "134",
@@ -16573,6 +16708,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "135",
       "multiverseid": 417708,
       "name": "Start Your Engines",
       "number": "135",
@@ -16690,6 +16826,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "136",
       "multiverseid": 417709,
       "name": "Territorial Gorger",
       "number": "136",
@@ -16832,6 +16969,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "137",
       "multiverseid": 417710,
       "name": "Terror of the Fairgrounds",
       "number": "137",
@@ -16942,6 +17080,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "138",
       "multiverseid": 417711,
       "name": "Thriving Grubs",
       "number": "138",
@@ -17084,6 +17223,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "139",
       "multiverseid": 417712,
       "name": "Wayward Giant",
       "number": "139",
@@ -17196,6 +17336,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "140",
       "multiverseid": 417713,
       "name": "Welding Sparks",
       "number": "140",
@@ -17313,6 +17454,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "141",
       "multiverseid": 417714,
       "name": "Appetite for the Unnatural",
       "number": "141",
@@ -17420,6 +17562,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "142",
       "multiverseid": 417715,
       "name": "Arborback Stomper",
       "number": "142",
@@ -17532,6 +17675,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "143",
       "multiverseid": 417716,
       "name": "Architect of the Untamed",
       "number": "143",
@@ -17672,6 +17816,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "144",
       "multiverseid": 417717,
       "name": "Armorcraft Judge",
       "number": "144",
@@ -17795,6 +17940,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "145",
       "multiverseid": 417718,
       "name": "Attune with Aether",
       "number": "145",
@@ -17928,6 +18074,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "146",
       "multiverseid": 417719,
       "name": "Blossoming Defense",
       "number": "146",
@@ -18034,6 +18181,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "147",
       "multiverseid": 417720,
       "name": "Bristling Hydra",
       "number": "147",
@@ -18172,6 +18320,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "148",
       "multiverseid": 417721,
       "name": "Commencement of Festivities",
       "number": "148",
@@ -18279,6 +18428,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "149",
       "multiverseid": 417722,
       "name": "Cowl Prowler",
       "number": "149",
@@ -18397,6 +18547,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "150",
       "multiverseid": 417723,
       "name": "Creeping Mold",
       "number": "150",
@@ -18511,6 +18662,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "151",
       "multiverseid": 417724,
       "name": "Cultivator of Blades",
       "number": "151",
@@ -18649,6 +18801,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "152",
       "multiverseid": 417725,
       "name": "Dubious Challenge",
       "number": "152",
@@ -18777,6 +18930,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "153",
       "multiverseid": 417726,
       "name": "Durable Handicraft",
       "number": "153",
@@ -18893,6 +19047,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "154",
       "multiverseid": 417727,
       "name": "Elegant Edgecrafters",
       "number": "154",
@@ -19024,6 +19179,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "155",
       "multiverseid": 417728,
       "name": "Fairgrounds Trumpeter",
       "number": "155",
@@ -19146,6 +19302,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "156",
       "multiverseid": 417729,
       "name": "Ghirapur Guide",
       "number": "156",
@@ -19264,6 +19421,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "157",
       "multiverseid": 417730,
       "name": "Highspire Artisan",
       "number": "157",
@@ -19395,6 +19553,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "158",
       "multiverseid": 417731,
       "name": "Hunt the Weak",
       "number": "158",
@@ -19519,6 +19678,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "159",
       "multiverseid": 417732,
       "name": "Kujar Seedsculptor",
       "number": "159",
@@ -19638,6 +19798,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "160",
       "multiverseid": 417733,
       "name": "Larger Than Life",
       "number": "160",
@@ -19745,6 +19906,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "161",
       "multiverseid": 417734,
       "name": "Longtusk Cub",
       "number": "161",
@@ -19883,6 +20045,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "162",
       "multiverseid": 417735,
       "name": "Nature's Way",
       "number": "162",
@@ -20008,6 +20171,7 @@
       ],
       "loyalty": 5,
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "163",
       "multiverseid": 417736,
       "name": "Nissa, Vital Force",
       "number": "163",
@@ -20132,6 +20296,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "164",
       "multiverseid": 417737,
       "name": "Ornamental Courage",
       "number": "164",
@@ -20245,6 +20410,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "165",
       "multiverseid": 417738,
       "name": "Oviya Pashiri, Sage Lifecrafter",
       "number": "165",
@@ -20371,6 +20537,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "166",
       "multiverseid": 417739,
       "name": "Peema Outrider",
       "number": "166",
@@ -20497,6 +20664,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "167",
       "multiverseid": 417740,
       "name": "Riparian Tiger",
       "number": "167",
@@ -20639,6 +20807,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "168",
       "multiverseid": 417741,
       "name": "Sage of Shaila's Claim",
       "number": "168",
@@ -20778,6 +20947,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "169",
       "multiverseid": 417742,
       "name": "Servant of the Conduit",
       "number": "169",
@@ -20917,6 +21087,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "170",
       "multiverseid": 417743,
       "name": "Take Down",
       "number": "170",
@@ -21024,6 +21195,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "171",
       "multiverseid": 417744,
       "name": "Thriving Rhino",
       "number": "171",
@@ -21165,6 +21337,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "172",
       "multiverseid": 417745,
       "name": "Verdurous Gearhulk",
       "number": "172",
@@ -21293,6 +21466,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "173",
       "multiverseid": 417746,
       "name": "Wild Wanderer",
       "number": "173",
@@ -21406,6 +21580,7 @@
         }
       ],
       "manaCost": "{X}{X}{G}",
+      "mciNumber": "174",
       "multiverseid": 417747,
       "name": "Wildest Dreams",
       "number": "174",
@@ -21519,6 +21694,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "175",
       "multiverseid": 417748,
       "name": "Wily Bandar",
       "number": "175",
@@ -21634,6 +21810,7 @@
         }
       ],
       "manaCost": "{3}{W}{U}",
+      "mciNumber": "176",
       "multiverseid": 417749,
       "name": "Cloudblazer",
       "number": "176",
@@ -21749,6 +21926,7 @@
         }
       ],
       "manaCost": "{U}{B}",
+      "mciNumber": "177",
       "multiverseid": 417750,
       "name": "Contraband Kingpin",
       "number": "177",
@@ -21869,6 +22047,7 @@
         }
       ],
       "manaCost": "{1}{R}{W}",
+      "mciNumber": "178",
       "multiverseid": 417751,
       "name": "Depala, Pilot Exemplar",
       "number": "178",
@@ -21997,6 +22176,7 @@
       ],
       "loyalty": 3,
       "manaCost": "{2}{W}{U}",
+      "mciNumber": "179",
       "multiverseid": 417752,
       "name": "Dovin Baan",
       "number": "179",
@@ -22123,6 +22303,7 @@
         }
       ],
       "manaCost": "{1}{G}{U}",
+      "mciNumber": "180",
       "multiverseid": 417753,
       "name": "Empyreal Voyager",
       "number": "180",
@@ -22263,6 +22444,7 @@
         }
       ],
       "manaCost": "{3}{G}{W}",
+      "mciNumber": "181",
       "multiverseid": 417754,
       "name": "Engineered Might",
       "number": "181",
@@ -22378,6 +22560,7 @@
         }
       ],
       "manaCost": "{2}{B}{G}",
+      "mciNumber": "182",
       "multiverseid": 417755,
       "name": "Hazardous Conditions",
       "number": "182",
@@ -22497,6 +22680,7 @@
         }
       ],
       "manaCost": "{1}{W}{B}",
+      "mciNumber": "183",
       "multiverseid": 417756,
       "name": "Kambal, Consul of Allocation",
       "number": "183",
@@ -22624,6 +22808,7 @@
         }
       ],
       "manaCost": "{2}{G}{U}",
+      "mciNumber": "184",
       "multiverseid": 417757,
       "name": "Rashmi, Eternities Crafter",
       "number": "184",
@@ -22780,6 +22965,7 @@
         }
       ],
       "manaCost": "{2}{W}{B}",
+      "mciNumber": "185",
       "multiverseid": 417758,
       "name": "Restoration Gearsmith",
       "number": "185",
@@ -22895,6 +23081,7 @@
       ],
       "loyalty": 3,
       "manaCost": "{1}{U}{R}",
+      "mciNumber": "186",
       "multiverseid": 417759,
       "name": "Saheeli Rai",
       "number": "186",
@@ -23041,6 +23228,7 @@
         }
       ],
       "manaCost": "{1}{B}{R}",
+      "mciNumber": "187",
       "multiverseid": 417760,
       "name": "Unlicensed Disintegration",
       "number": "187",
@@ -23164,6 +23352,7 @@
         }
       ],
       "manaCost": "{R}{W}",
+      "mciNumber": "188",
       "multiverseid": 417761,
       "name": "Veteran Motorist",
       "number": "188",
@@ -23288,6 +23477,7 @@
         }
       ],
       "manaCost": "{R}{G}",
+      "mciNumber": "189",
       "multiverseid": 417762,
       "name": "Voltaic Brawler",
       "number": "189",
@@ -23433,6 +23623,7 @@
         }
       ],
       "manaCost": "{1}{U}{R}",
+      "mciNumber": "190",
       "multiverseid": 417763,
       "name": "Whirler Virtuoso",
       "number": "190",
@@ -23566,6 +23757,7 @@
         }
       ],
       "manaCost": "{7}",
+      "mciNumber": "191",
       "multiverseid": 417764,
       "name": "Accomplished Automaton",
       "number": "191",
@@ -23687,6 +23879,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "192",
       "multiverseid": 417765,
       "name": "Aetherflux Reservoir",
       "number": "192",
@@ -23805,6 +23998,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "193",
       "multiverseid": 417766,
       "name": "Aetherworks Marvel",
       "number": "193",
@@ -23955,6 +24149,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "194",
       "multiverseid": 417767,
       "name": "Animation Module",
       "number": "194",
@@ -24070,6 +24265,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "195",
       "multiverseid": 417768,
       "name": "Aradara Express",
       "number": "195",
@@ -24225,6 +24421,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "196",
       "multiverseid": 417769,
       "name": "Ballista Charger",
       "number": "196",
@@ -24388,6 +24585,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "197",
       "multiverseid": 417770,
       "name": "Bastion Mastodon",
       "number": "197",
@@ -24500,6 +24698,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "198",
       "multiverseid": 417771,
       "name": "Bomat Bazaar Barge",
       "number": "198",
@@ -24658,6 +24857,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "199",
       "multiverseid": 417772,
       "name": "Bomat Courier",
       "number": "199",
@@ -24779,6 +24979,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "200",
       "multiverseid": 417773,
       "name": "Chief of the Foundry",
       "number": "200",
@@ -24889,6 +25090,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "201",
       "multiverseid": 417774,
       "name": "Cogworker's Puzzleknot",
       "number": "201",
@@ -24990,6 +25192,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "202",
       "multiverseid": 417775,
       "name": "Consulate Skygate",
       "number": "202",
@@ -25096,6 +25299,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "203",
       "multiverseid": 417776,
       "name": "Cultivator's Caravan",
       "number": "203",
@@ -25255,6 +25459,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "204",
       "multiverseid": 417777,
       "name": "Deadlock Trap",
       "number": "204",
@@ -25411,6 +25616,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "205",
       "multiverseid": 417778,
       "name": "Decoction Module",
       "number": "205",
@@ -25537,6 +25743,7 @@
         }
       ],
       "manaCost": "{6}",
+      "mciNumber": "206",
       "multiverseid": 417779,
       "name": "Demolition Stomper",
       "number": "206",
@@ -25700,6 +25907,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "207",
       "multiverseid": 417780,
       "name": "Dukhara Peafowl",
       "number": "207",
@@ -25813,6 +26021,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "208",
       "multiverseid": 417781,
       "name": "Dynavolt Tower",
       "number": "208",
@@ -25944,6 +26153,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "209",
       "multiverseid": 417782,
       "name": "Eager Construct",
       "number": "209",
@@ -26056,6 +26266,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "210",
       "multiverseid": 417783,
       "name": "Electrostatic Pummeler",
       "number": "210",
@@ -26197,6 +26408,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "211",
       "multiverseid": 417784,
       "name": "Fabrication Module",
       "number": "211",
@@ -26328,6 +26540,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "212",
       "multiverseid": 417785,
       "name": "Filigree Familiar",
       "number": "212",
@@ -26437,6 +26650,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "213",
       "multiverseid": 417786,
       "name": "Fireforger's Puzzleknot",
       "number": "213",
@@ -26537,6 +26751,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "214",
       "multiverseid": 417787,
       "name": "Fleetwheel Cruiser",
       "number": "214",
@@ -26693,6 +26908,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "215",
       "multiverseid": 417788,
       "name": "Foundry Inspector",
       "number": "215",
@@ -26810,6 +27026,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "216",
       "multiverseid": 417789,
       "name": "Ghirapur Orrery",
       "number": "216",
@@ -26939,6 +27156,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "217",
       "multiverseid": 417790,
       "name": "Glassblower's Puzzleknot",
       "number": "217",
@@ -27065,6 +27283,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "218",
       "multiverseid": 417791,
       "name": "Inventor's Goggles",
       "number": "218",
@@ -27175,6 +27394,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "219",
       "multiverseid": 417792,
       "name": "Iron League Steed",
       "number": "219",
@@ -27296,6 +27516,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "220",
       "multiverseid": 417793,
       "name": "Key to the City",
       "number": "220",
@@ -27417,6 +27638,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "221",
       "multiverseid": 417794,
       "name": "Metalspinner's Puzzleknot",
       "number": "221",
@@ -27517,6 +27739,7 @@
         }
       ],
       "manaCost": "{11}",
+      "mciNumber": "222",
       "multiverseid": 417795,
       "name": "Metalwork Colossus",
       "number": "222",
@@ -27645,6 +27868,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "223",
       "multiverseid": 417796,
       "name": "Multiform Wonder",
       "number": "223",
@@ -27789,6 +28013,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "224",
       "multiverseid": 417797,
       "name": "Narnam Cobra",
       "number": "224",
@@ -27896,6 +28121,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "225",
       "multiverseid": 417798,
       "name": "Ovalchase Dragster",
       "number": "225",
@@ -28052,6 +28278,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "226",
       "multiverseid": 417799,
       "name": "Panharmonicon",
       "number": "226",
@@ -28199,6 +28426,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "227",
       "multiverseid": 417800,
       "name": "Perpetual Timepiece",
       "number": "227",
@@ -28309,6 +28537,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "228",
       "multiverseid": 417801,
       "name": "Prakhata Pillar-Bug",
       "number": "228",
@@ -28430,6 +28659,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "229",
       "multiverseid": 417802,
       "name": "Prophetic Prism",
       "number": "229",
@@ -28533,6 +28763,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "230",
       "multiverseid": 417803,
       "name": "Renegade Freighter",
       "number": "230",
@@ -28692,6 +28923,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "231",
       "multiverseid": 417804,
       "name": "Scrapheap Scrounger",
       "number": "231",
@@ -28799,6 +29031,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "232",
       "multiverseid": 417805,
       "name": "Self-Assembler",
       "number": "232",
@@ -28905,6 +29138,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "233",
       "multiverseid": 417806,
       "name": "Sky Skiff",
       "number": "233",
@@ -29060,6 +29294,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "234",
       "multiverseid": 417807,
       "name": "Skysovereign, Consul Flagship",
       "number": "234",
@@ -29218,6 +29453,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "235",
       "multiverseid": 417808,
       "name": "Smuggler's Copter",
       "number": "235",
@@ -29374,6 +29610,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "236",
       "multiverseid": 417809,
       "name": "Snare Thopter",
       "number": "236",
@@ -29481,6 +29718,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "237",
       "multiverseid": 417810,
       "name": "Torch Gauntlet",
       "number": "237",
@@ -29588,6 +29826,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "238",
       "multiverseid": 417811,
       "name": "Weldfast Monitor",
       "number": "238",
@@ -29705,6 +29944,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "239",
       "multiverseid": 417812,
       "name": "Whirlermaker",
       "number": "239",
@@ -29808,6 +30048,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "240",
       "multiverseid": 417813,
       "name": "Woodweaver's Puzzleknot",
       "number": "240",
@@ -29935,6 +30176,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "241",
       "multiverseid": 417814,
       "name": "Workshop Assistant",
       "number": "241",
@@ -30046,6 +30288,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "242",
       "multiverseid": 417815,
       "name": "Aether Hub",
       "number": "242",
@@ -30175,6 +30418,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "243",
       "multiverseid": 417816,
       "name": "Blooming Marsh",
       "number": "243",
@@ -30288,6 +30532,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "244",
       "multiverseid": 417817,
       "name": "Botanical Sanctum",
       "number": "244",
@@ -30401,6 +30646,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "245",
       "multiverseid": 417818,
       "name": "Concealed Courtyard",
       "number": "245",
@@ -30514,6 +30760,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "246",
       "multiverseid": 417819,
       "name": "Inspiring Vantage",
       "number": "246",
@@ -30622,6 +30869,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "247",
       "multiverseid": 417820,
       "name": "Inventors' Fair",
       "number": "247",
@@ -30742,6 +30990,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "248",
       "multiverseid": 417821,
       "name": "Sequestered Stash",
       "number": "248",
@@ -30851,6 +31100,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "249",
       "multiverseid": 417822,
       "name": "Spirebluff Canal",
       "number": "249",
@@ -36689,6 +36939,7 @@
       ],
       "loyalty": 5,
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "265",
       "multiverseid": 420478,
       "name": "Chandra, Pyrogenius",
       "number": "265",
@@ -36809,6 +37060,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "266",
       "multiverseid": 420479,
       "name": "Flame Lash",
       "number": "266",
@@ -36915,6 +37167,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "267",
       "multiverseid": 420480,
       "name": "Liberating Combustion",
       "number": "267",
@@ -37028,6 +37281,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "268",
       "multiverseid": 420481,
       "name": "Renegade Firebrand",
       "number": "268",
@@ -37145,6 +37399,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "269",
       "multiverseid": 420482,
       "name": "Stone Quarry",
       "number": "269",
@@ -37254,6 +37509,7 @@
       ],
       "loyalty": 5,
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "270",
       "multiverseid": 420483,
       "name": "Nissa, Nature's Artisan",
       "number": "270",
@@ -37369,6 +37625,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "271",
       "multiverseid": 420484,
       "name": "Guardian of the Great Conduit",
       "number": "271",
@@ -37487,6 +37744,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "272",
       "multiverseid": 420485,
       "name": "Terrain Elemental",
       "number": "272",
@@ -37602,6 +37860,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "273",
       "multiverseid": 420486,
       "name": "Verdant Crescendo",
       "number": "273",
@@ -37713,6 +37972,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "274",
       "multiverseid": 420487,
       "name": "Woodland Stream",
       "number": "274",

--- a/json/MM3.json
+++ b/json/MM3.json
@@ -1,6 +1,7 @@
 {
   "name": "Modern Masters 2017 Edition",
   "code": "MM3",
+  "magicCardsInfoCode": "mm3",
   "releaseDate": "2017-03-17",
   "border": "black",
   "type": "reprint",
@@ -74,6 +75,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "1",
       "multiverseid": 425826,
       "name": "Attended Knight",
       "number": "1",
@@ -143,6 +145,7 @@
         }
       ],
       "manaCost": "{5}{W}",
+      "mciNumber": "2",
       "multiverseid": 425827,
       "name": "Banishing Stroke",
       "number": "2",
@@ -207,6 +210,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "3",
       "multiverseid": 425828,
       "name": "Blade Splicer",
       "number": "3",
@@ -276,6 +280,7 @@
         }
       ],
       "manaCost": "{X}{X}{W}{W}{W}",
+      "mciNumber": "4",
       "multiverseid": 425829,
       "name": "Entreat the Angels",
       "number": "4",
@@ -351,6 +356,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "5",
       "multiverseid": 425830,
       "name": "Eyes in the Skies",
       "number": "5",
@@ -441,6 +447,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "6",
       "multiverseid": 425831,
       "name": "Flickerwisp",
       "number": "6",
@@ -521,6 +528,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "7",
       "multiverseid": 425832,
       "name": "Gideon's Lawkeeper",
       "number": "7",
@@ -592,6 +600,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "8",
       "multiverseid": 425833,
       "name": "Graceful Reprieve",
       "number": "8",
@@ -666,6 +675,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "9",
       "multiverseid": 425834,
       "name": "Intangible Virtue",
       "number": "9",
@@ -733,6 +743,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "10",
       "multiverseid": 425835,
       "name": "Kor Hookmaster",
       "number": "10",
@@ -812,6 +823,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "11",
       "multiverseid": 425836,
       "name": "Kor Skyfisher",
       "number": "11",
@@ -896,6 +908,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "12",
       "multiverseid": 425837,
       "name": "Lingering Souls",
       "number": "12",
@@ -963,6 +976,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "13",
       "multiverseid": 425838,
       "name": "Linvala, Keeper of Silence",
       "number": "13",
@@ -1049,6 +1063,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "14",
       "multiverseid": 425839,
       "name": "Lone Missionary",
       "number": "14",
@@ -1120,6 +1135,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "15",
       "multiverseid": 425840,
       "name": "Master Splicer",
       "number": "15",
@@ -1196,6 +1212,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "16",
       "multiverseid": 425841,
       "name": "Momentary Blink",
       "number": "16",
@@ -1274,6 +1291,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "17",
       "multiverseid": 425842,
       "name": "Path to Exile",
       "number": "17",
@@ -1356,6 +1374,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "18",
       "multiverseid": 425843,
       "name": "Pitfall Trap",
       "number": "18",
@@ -1437,6 +1456,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "19",
       "multiverseid": 425844,
       "name": "Ranger of Eos",
       "number": "19",
@@ -1512,6 +1532,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "20",
       "multiverseid": 425845,
       "name": "Restoration Angel",
       "number": "20",
@@ -1581,6 +1602,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "21",
       "multiverseid": 425846,
       "name": "Rootborn Defenses",
       "number": "21",
@@ -1674,6 +1696,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "22",
       "multiverseid": 425847,
       "name": "Séance",
       "number": "22",
@@ -1764,6 +1787,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "23",
       "multiverseid": 425848,
       "name": "Sensor Splicer",
       "number": "23",
@@ -1833,6 +1857,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "24",
       "multiverseid": 425849,
       "name": "Soul Warden",
       "number": "24",
@@ -1927,6 +1952,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "25",
       "multiverseid": 425850,
       "name": "Stony Silence",
       "number": "25",
@@ -2004,6 +2030,7 @@
         }
       ],
       "manaCost": "{4}{W}{W}",
+      "mciNumber": "26",
       "multiverseid": 425851,
       "name": "Terminus",
       "number": "26",
@@ -2075,6 +2102,7 @@
         }
       ],
       "manaCost": "{4}{W}{W}",
+      "mciNumber": "27",
       "multiverseid": 425852,
       "name": "Urbis Protector",
       "number": "27",
@@ -2145,6 +2173,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "28",
       "multiverseid": 425853,
       "name": "Wake the Reflections",
       "number": "28",
@@ -2235,6 +2264,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "29",
       "multiverseid": 425854,
       "name": "Youthful Knight",
       "number": "29",
@@ -2304,6 +2334,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "30",
       "multiverseid": 425855,
       "name": "Augur of Bolas",
       "number": "30",
@@ -2381,6 +2412,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "31",
       "multiverseid": 425856,
       "name": "Azure Mage",
       "number": "31",
@@ -2451,6 +2483,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "32",
       "multiverseid": 425857,
       "name": "Cackling Counterpart",
       "number": "32",
@@ -2538,6 +2571,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "33",
       "multiverseid": 425858,
       "name": "Compulsive Research",
       "number": "33",
@@ -2615,6 +2649,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "34",
       "multiverseid": 425859,
       "name": "Crippling Chill",
       "number": "34",
@@ -2686,6 +2721,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "35",
       "multiverseid": 425860,
       "name": "Cyclonic Rift",
       "number": "35",
@@ -2780,6 +2816,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "36",
       "multiverseid": 425861,
       "name": "Deadeye Navigator",
       "number": "36",
@@ -2859,6 +2896,7 @@
         }
       ],
       "manaCost": "{U}{U}",
+      "mciNumber": "37",
       "multiverseid": 425862,
       "name": "Familiar's Ruse",
       "number": "37",
@@ -2929,6 +2967,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "38",
       "multiverseid": 425863,
       "name": "Forbidden Alchemy",
       "number": "38",
@@ -3001,6 +3040,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "39",
       "multiverseid": 425864,
       "name": "Ghostly Flicker",
       "number": "39",
@@ -3070,6 +3110,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "40",
       "multiverseid": 425865,
       "name": "Gifts Ungiven",
       "number": "40",
@@ -3141,6 +3182,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "41",
       "multiverseid": 425866,
       "name": "Grasp of Phantoms",
       "number": "41",
@@ -3205,6 +3247,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "42",
       "multiverseid": 425867,
       "name": "Kraken Hatchling",
       "number": "42",
@@ -3273,6 +3316,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "43",
       "multiverseid": 425868,
       "name": "Mist Raven",
       "number": "43",
@@ -3349,6 +3393,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "44",
       "multiverseid": 425869,
       "name": "Mystical Teachings",
       "number": "44",
@@ -3413,6 +3458,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "45",
       "multiverseid": 425870,
       "name": "Opportunity",
       "number": "45",
@@ -3476,6 +3522,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "46",
       "multiverseid": 425871,
       "name": "Phantasmal Image",
       "number": "46",
@@ -3575,6 +3622,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "47",
       "multiverseid": 425872,
       "name": "Rewind",
       "number": "47",
@@ -3661,6 +3709,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "48",
       "multiverseid": 425873,
       "name": "Sea Gate Oracle",
       "number": "48",
@@ -3739,6 +3788,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "49",
       "multiverseid": 425874,
       "name": "Serum Visions",
       "number": "49",
@@ -3805,6 +3855,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "50",
       "multiverseid": 425875,
       "name": "Snapcaster Mage",
       "number": "50",
@@ -3894,6 +3945,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "51",
       "multiverseid": 425876,
       "name": "Spell Pierce",
       "number": "51",
@@ -3959,6 +4011,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "52",
       "multiverseid": 425877,
       "name": "Spire Monitor",
       "number": "52",
@@ -4027,6 +4080,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "53",
       "multiverseid": 425878,
       "name": "Tandem Lookout",
       "number": "53",
@@ -4104,6 +4158,7 @@
         }
       ],
       "manaCost": "{5}{U}{U}",
+      "mciNumber": "54",
       "multiverseid": 425879,
       "name": "Temporal Mastery",
       "number": "54",
@@ -4168,6 +4223,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "55",
       "multiverseid": 425880,
       "name": "Venser, Shaper Savant",
       "number": "55",
@@ -4252,6 +4308,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "56",
       "multiverseid": 425881,
       "name": "Wall of Frost",
       "number": "56",
@@ -4336,6 +4393,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "57",
       "multiverseid": 425882,
       "name": "Wing Splicer",
       "number": "57",
@@ -4405,6 +4463,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "58",
       "multiverseid": 425883,
       "name": "Wingcrafter",
       "number": "58",
@@ -4475,6 +4534,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "59",
       "multiverseid": 425884,
       "name": "Abyssal Specter",
       "number": "59",
@@ -4565,6 +4625,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "60",
       "multiverseid": 425885,
       "name": "Bone Splinters",
       "number": "60",
@@ -4646,6 +4707,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "61",
       "multiverseid": 425886,
       "name": "Corpse Connoisseur",
       "number": "61",
@@ -4736,6 +4798,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "62",
       "multiverseid": 425887,
       "name": "Cower in Fear",
       "number": "62",
@@ -4805,6 +4868,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "63",
       "multiverseid": 425888,
       "name": "Damnation",
       "number": "63",
@@ -4878,6 +4942,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "64",
       "multiverseid": 425889,
       "name": "Death's Shadow",
       "number": "64",
@@ -4969,6 +5034,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "65",
       "multiverseid": 425890,
       "name": "Delirium Skeins",
       "number": "65",
@@ -5038,6 +5104,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "66",
       "multiverseid": 425891,
       "name": "Desecration Demon",
       "number": "66",
@@ -5118,6 +5185,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "67",
       "multiverseid": 425892,
       "name": "Dregscape Zombie",
       "number": "67",
@@ -5211,6 +5279,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "68",
       "multiverseid": 425893,
       "name": "Entomber Exarch",
       "number": "68",
@@ -5279,6 +5348,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "69",
       "multiverseid": 425894,
       "name": "Extractor Demon",
       "number": "69",
@@ -5362,6 +5432,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "70",
       "multiverseid": 425895,
       "name": "Falkenrath Noble",
       "number": "70",
@@ -5434,6 +5505,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "71",
       "multiverseid": 425896,
       "name": "Gnawing Zombie",
       "number": "71",
@@ -5503,6 +5575,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}{B}{B}",
+      "mciNumber": "72",
       "multiverseid": 425897,
       "name": "Griselbrand",
       "number": "72",
@@ -5581,6 +5654,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "73",
       "multiverseid": 425898,
       "name": "Grisly Spectacle",
       "number": "73",
@@ -5655,6 +5729,7 @@
         }
       ],
       "manaCost": "{5}{B}",
+      "mciNumber": "74",
       "multiverseid": 425899,
       "name": "Grixis Slavedriver",
       "number": "74",
@@ -5725,6 +5800,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "75",
       "multiverseid": 425900,
       "name": "Inquisition of Kozilek",
       "number": "75",
@@ -5797,6 +5873,7 @@
       ],
       "loyalty": 3,
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "76",
       "multiverseid": 425901,
       "name": "Liliana of the Veil",
       "number": "76",
@@ -5883,6 +5960,7 @@
         }
       ],
       "manaCost": "{X}{B}{B}",
+      "mciNumber": "77",
       "multiverseid": 425902,
       "name": "Mind Shatter",
       "number": "77",
@@ -5949,6 +6027,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "78",
       "multiverseid": 425903,
       "name": "Mortician Beetle",
       "number": "78",
@@ -6028,6 +6107,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "79",
       "multiverseid": 425904,
       "name": "Night Terrors",
       "number": "79",
@@ -6098,6 +6178,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "80",
       "multiverseid": 425905,
       "name": "Ogre Jailbreaker",
       "number": "80",
@@ -6174,6 +6255,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "81",
       "multiverseid": 425906,
       "name": "Pit Keeper",
       "number": "81",
@@ -6244,6 +6326,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "82",
       "multiverseid": 425907,
       "name": "Recover",
       "number": "82",
@@ -6313,6 +6396,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "83",
       "multiverseid": 425908,
       "name": "Seal of Doom",
       "number": "83",
@@ -6378,6 +6462,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "84",
       "multiverseid": 425909,
       "name": "Sever the Bloodline",
       "number": "84",
@@ -6464,6 +6549,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "85",
       "multiverseid": 425910,
       "name": "Unburial Rites",
       "number": "85",
@@ -6524,6 +6610,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "86",
       "multiverseid": 425911,
       "name": "Vampire Aristocrat",
       "number": "86",
@@ -6604,6 +6691,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "87",
       "multiverseid": 425912,
       "name": "Vampire Nighthawk",
       "number": "87",
@@ -6686,6 +6774,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "88",
       "multiverseid": 425913,
       "name": "Ancient Grudge",
       "number": "88",
@@ -6752,6 +6841,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "89",
       "multiverseid": 425914,
       "name": "Battle-Rattle Shaman",
       "number": "89",
@@ -6829,6 +6919,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "90",
       "multiverseid": 425915,
       "name": "Blood Moon",
       "number": "90",
@@ -6915,6 +7006,7 @@
         }
       ],
       "manaCost": "{X}{X}{R}",
+      "mciNumber": "91",
       "multiverseid": 425916,
       "name": "Bonfire of the Damned",
       "number": "91",
@@ -6997,6 +7089,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "92",
       "multiverseid": 425917,
       "name": "Chandra's Outrage",
       "number": "92",
@@ -7075,6 +7168,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "93",
       "multiverseid": 425918,
       "name": "Dragon Fodder",
       "number": "93",
@@ -7144,6 +7238,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "94",
       "multiverseid": 425919,
       "name": "Dynacharge",
       "number": "94",
@@ -7242,6 +7337,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "95",
       "multiverseid": 425920,
       "name": "Goblin Assault",
       "number": "95",
@@ -7312,6 +7408,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "96",
       "multiverseid": 425921,
       "name": "Goblin Guide",
       "number": "96",
@@ -7382,6 +7479,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "97",
       "multiverseid": 425922,
       "name": "Hanweir Lancer",
       "number": "97",
@@ -7452,6 +7550,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "98",
       "multiverseid": 425923,
       "name": "Hellrider",
       "number": "98",
@@ -7536,6 +7635,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "99",
       "multiverseid": 425924,
       "name": "Madcap Skills",
       "number": "99",
@@ -7607,6 +7707,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "100",
       "multiverseid": 425925,
       "name": "Magma Jet",
       "number": "100",
@@ -7693,6 +7794,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "101",
       "multiverseid": 425926,
       "name": "Mizzium Mortars",
       "number": "101",
@@ -7788,6 +7890,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "102",
       "multiverseid": 425927,
       "name": "Mogg Flunkies",
       "number": "102",
@@ -7883,6 +7986,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "103",
       "multiverseid": 425928,
       "name": "Molten Rain",
       "number": "103",
@@ -7947,6 +8051,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "104",
       "multiverseid": 425929,
       "name": "Mudbutton Torchrunner",
       "number": "104",
@@ -8021,6 +8126,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "105",
       "multiverseid": 425930,
       "name": "Past in Flames",
       "number": "105",
@@ -8107,6 +8213,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "106",
       "multiverseid": 425931,
       "name": "Pyrewild Shaman",
       "number": "106",
@@ -8195,6 +8302,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "107",
       "multiverseid": 425932,
       "name": "Pyroclasm",
       "number": "107",
@@ -8269,6 +8377,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "108",
       "multiverseid": 425933,
       "name": "Pyromancer Ascension",
       "number": "108",
@@ -8379,6 +8488,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "109",
       "multiverseid": 425934,
       "name": "Rubblebelt Maaka",
       "number": "109",
@@ -8448,6 +8558,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "110",
       "multiverseid": 425935,
       "name": "Scorched Rusalka",
       "number": "110",
@@ -8517,6 +8628,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "111",
       "multiverseid": 425936,
       "name": "Scourge Devil",
       "number": "111",
@@ -8614,6 +8726,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "112",
       "multiverseid": 425937,
       "name": "Skirsdag Cultist",
       "number": "112",
@@ -8684,6 +8797,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "113",
       "multiverseid": 425938,
       "name": "Thunderous Wrath",
       "number": "113",
@@ -8752,6 +8866,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "114",
       "multiverseid": 425939,
       "name": "Traitorous Instinct",
       "number": "114",
@@ -8822,6 +8937,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "115",
       "multiverseid": 425940,
       "name": "Vithian Stinger",
       "number": "115",
@@ -8914,6 +9030,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "116",
       "multiverseid": 425941,
       "name": "Zealous Conscripts",
       "number": "116",
@@ -8985,6 +9102,7 @@
         }
       ],
       "manaCost": "{5}{G}",
+      "mciNumber": "117",
       "multiverseid": 425942,
       "name": "Arachnus Spinner",
       "number": "117",
@@ -9063,6 +9181,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "118",
       "multiverseid": 425943,
       "name": "Arachnus Web",
       "number": "118",
@@ -9157,6 +9276,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "119",
       "multiverseid": 425944,
       "name": "Avacyn's Pilgrim",
       "number": "119",
@@ -9227,6 +9347,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "120",
       "multiverseid": 425945,
       "name": "Baloth Cage Trap",
       "number": "120",
@@ -9311,6 +9432,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "121",
       "multiverseid": 425946,
       "name": "Call of the Herd",
       "number": "121",
@@ -9377,6 +9499,7 @@
         }
       ],
       "manaCost": "{5}{G}{G}{G}",
+      "mciNumber": "122",
       "multiverseid": 425947,
       "name": "Craterhoof Behemoth",
       "number": "122",
@@ -9456,6 +9579,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "123",
       "multiverseid": 425948,
       "name": "Death-Hood Cobra",
       "number": "123",
@@ -9526,6 +9650,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "124",
       "multiverseid": 425949,
       "name": "Druid's Deliverance",
       "number": "124",
@@ -9628,6 +9753,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "125",
       "multiverseid": 425950,
       "name": "Explore",
       "number": "125",
@@ -9707,6 +9833,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "126",
       "multiverseid": 425951,
       "name": "Fists of Ironwood",
       "number": "126",
@@ -9789,6 +9916,7 @@
         }
       ],
       "manaCost": "{1}{G}{G}",
+      "mciNumber": "127",
       "multiverseid": 425952,
       "name": "Gaea's Anthem",
       "number": "127",
@@ -9859,6 +9987,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "128",
       "multiverseid": 425953,
       "name": "Harmonize",
       "number": "128",
@@ -9939,6 +10068,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "129",
       "multiverseid": 425954,
       "name": "Hungry Spriggan",
       "number": "129",
@@ -10009,6 +10139,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "130",
       "multiverseid": 425955,
       "name": "Might of Old Krosa",
       "number": "130",
@@ -10079,6 +10210,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "131",
       "multiverseid": 425956,
       "name": "Penumbra Spider",
       "number": "131",
@@ -10151,6 +10283,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "132",
       "multiverseid": 425957,
       "name": "Primal Command",
       "number": "132",
@@ -10227,6 +10360,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "133",
       "multiverseid": 425958,
       "name": "Revive",
       "number": "133",
@@ -10289,6 +10423,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "134",
       "multiverseid": 425959,
       "name": "Scavenging Ooze",
       "number": "134",
@@ -10367,6 +10502,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "135",
       "multiverseid": 425960,
       "name": "Seal of Primordium",
       "number": "135",
@@ -10445,6 +10581,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "136",
       "multiverseid": 425961,
       "name": "Slaughterhorn",
       "number": "136",
@@ -10514,6 +10651,7 @@
         }
       ],
       "manaCost": "{X}{G}",
+      "mciNumber": "137",
       "multiverseid": 425962,
       "name": "Slime Molding",
       "number": "137",
@@ -10578,6 +10716,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "138",
       "multiverseid": 425963,
       "name": "Strength in Numbers",
       "number": "138",
@@ -10648,6 +10787,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "139",
       "multiverseid": 425964,
       "name": "Summoning Trap",
       "number": "139",
@@ -10729,6 +10869,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "140",
       "multiverseid": 425965,
       "name": "Sylvan Ranger",
       "number": "140",
@@ -10803,6 +10944,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "141",
       "multiverseid": 425966,
       "name": "Tarmogoyf",
       "number": "141",
@@ -10893,6 +11035,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "142",
       "multiverseid": 425967,
       "name": "Thornscape Battlemage",
       "number": "142",
@@ -10979,6 +11122,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "143",
       "multiverseid": 425968,
       "name": "Thragtusk",
       "number": "143",
@@ -11055,6 +11199,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "144",
       "multiverseid": 425969,
       "name": "Ulvenwald Tracker",
       "number": "144",
@@ -11135,6 +11280,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "145",
       "multiverseid": 425970,
       "name": "Vital Splicer",
       "number": "145",
@@ -11207,6 +11353,7 @@
         }
       ],
       "manaCost": "{B}{G}",
+      "mciNumber": "146",
       "multiverseid": 425971,
       "name": "Abrupt Decay",
       "number": "146",
@@ -11283,6 +11430,7 @@
         }
       ],
       "manaCost": "{1}{G}{G}{W}",
+      "mciNumber": "147",
       "multiverseid": 425972,
       "name": "Advent of the Wurm",
       "number": "147",
@@ -11434,6 +11582,7 @@
         }
       ],
       "manaCost": "{3}{W}{B}",
+      "mciNumber": "149",
       "multiverseid": 425974,
       "name": "Agent of Masks",
       "number": "149",
@@ -11506,6 +11655,7 @@
         }
       ],
       "manaCost": "{U}{B}",
+      "mciNumber": "150",
       "multiverseid": 425975,
       "name": "Agony Warp",
       "number": "150",
@@ -11580,6 +11730,7 @@
         }
       ],
       "manaCost": "{1}{B}{R}",
+      "mciNumber": "151",
       "multiverseid": 425976,
       "name": "Auger Spree",
       "number": "151",
@@ -11646,6 +11797,7 @@
         }
       ],
       "manaCost": "{2}{G}{W}",
+      "mciNumber": "152",
       "multiverseid": 425977,
       "name": "Bronzebeak Moa",
       "number": "152",
@@ -11719,6 +11871,7 @@
         }
       ],
       "manaCost": "{3}{B}{R}{G}",
+      "mciNumber": "153",
       "multiverseid": 425978,
       "name": "Broodmate Dragon",
       "number": "153",
@@ -11791,6 +11944,7 @@
         }
       ],
       "manaCost": "{G}{W}",
+      "mciNumber": "154",
       "multiverseid": 425979,
       "name": "Call of the Conclave",
       "number": "154",
@@ -11858,6 +12012,7 @@
         }
       ],
       "manaCost": "{2}{B}{R}",
+      "mciNumber": "155",
       "multiverseid": 425980,
       "name": "Carnage Gladiator",
       "number": "155",
@@ -11941,6 +12096,7 @@
         }
       ],
       "manaCost": "{1}{G}{W}",
+      "mciNumber": "156",
       "multiverseid": 425981,
       "name": "Centaur Healer",
       "number": "156",
@@ -12013,6 +12169,7 @@
         }
       ],
       "manaCost": "{G}{U}",
+      "mciNumber": "157",
       "multiverseid": 425982,
       "name": "Coiling Oracle",
       "number": "157",
@@ -12093,6 +12250,7 @@
         }
       ],
       "manaCost": "{U}{U}{B}{B}{B}{R}{R}",
+      "mciNumber": "158",
       "multiverseid": 425983,
       "name": "Cruel Ultimatum",
       "number": "158",
@@ -12177,6 +12335,7 @@
         }
       ],
       "manaCost": "{W}{U}",
+      "mciNumber": "159",
       "multiverseid": 425984,
       "name": "Deputy of Acquittals",
       "number": "159",
@@ -12249,6 +12408,7 @@
         }
       ],
       "manaCost": "{4}{U}{B}",
+      "mciNumber": "160",
       "multiverseid": 425985,
       "name": "Dinrova Horror",
       "number": "160",
@@ -12334,6 +12494,7 @@
       ],
       "loyalty": 3,
       "manaCost": "{1}{R}{G}",
+      "mciNumber": "161",
       "multiverseid": 425986,
       "name": "Domri Rade",
       "number": "161",
@@ -12421,6 +12582,7 @@
         }
       ],
       "manaCost": "{2}{U}{B}",
+      "mciNumber": "162",
       "multiverseid": 425987,
       "name": "Evil Twin",
       "number": "162",
@@ -12530,6 +12692,7 @@
         }
       ],
       "manaCost": "{2}{B}{R}",
+      "mciNumber": "163",
       "multiverseid": 425988,
       "name": "Falkenrath Aristocrat",
       "number": "163",
@@ -12621,6 +12784,7 @@
         }
       ],
       "manaCost": "{R}{G}{W}",
+      "mciNumber": "164",
       "multiverseid": 425989,
       "name": "Fiery Justice",
       "number": "164",
@@ -12703,6 +12867,7 @@
         }
       ],
       "manaCost": "{2}{R}{G}",
+      "mciNumber": "165",
       "multiverseid": 425990,
       "name": "Ghor-Clan Rampager",
       "number": "165",
@@ -12775,6 +12940,7 @@
         }
       ],
       "manaCost": "{U}{R}",
+      "mciNumber": "166",
       "multiverseid": 425991,
       "name": "Goblin Electromancer",
       "number": "166",
@@ -12868,6 +13034,7 @@
         }
       ],
       "manaCost": "{1}{B}{G}",
+      "mciNumber": "167",
       "multiverseid": 425992,
       "name": "Golgari Germination",
       "number": "167",
@@ -12935,6 +13102,7 @@
         }
       ],
       "manaCost": "{3}{B}{G}",
+      "mciNumber": "168",
       "multiverseid": 425993,
       "name": "Golgari Rotwurm",
       "number": "168",
@@ -13008,6 +13176,7 @@
         }
       ],
       "manaCost": "{R}{G}",
+      "mciNumber": "169",
       "multiverseid": 425994,
       "name": "Ground Assault",
       "number": "169",
@@ -13074,6 +13243,7 @@
         }
       ],
       "manaCost": "{2}{R}{G}",
+      "mciNumber": "170",
       "multiverseid": 425995,
       "name": "Gruul War Chant",
       "number": "170",
@@ -13140,6 +13310,7 @@
         }
       ],
       "manaCost": "{U}{R}",
+      "mciNumber": "171",
       "multiverseid": 425996,
       "name": "Izzet Charm",
       "number": "171",
@@ -13207,6 +13378,7 @@
         }
       ],
       "manaCost": "{1}{B}{R}",
+      "mciNumber": "172",
       "multiverseid": 425997,
       "name": "Kathari Bomber",
       "number": "172",
@@ -13286,6 +13458,7 @@
         }
       ],
       "manaCost": "{2}{U}{B}",
+      "mciNumber": "173",
       "multiverseid": 425998,
       "name": "Moroii",
       "number": "173",
@@ -13358,6 +13531,7 @@
         }
       ],
       "manaCost": "{2}{G}{U}{U}",
+      "mciNumber": "174",
       "multiverseid": 425999,
       "name": "Mystic Genesis",
       "number": "174",
@@ -13434,6 +13608,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}{R}{R}",
+      "mciNumber": "175",
       "multiverseid": 426000,
       "name": "Niv-Mizzet, Dracogenius",
       "number": "175",
@@ -13508,6 +13683,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}{B}{B}",
+      "mciNumber": "176",
       "multiverseid": 426001,
       "name": "Obzedat, Ghost Council",
       "number": "176",
@@ -13592,6 +13768,7 @@
         }
       ],
       "manaCost": "{2}{B}{R}",
+      "mciNumber": "177",
       "multiverseid": 426002,
       "name": "Olivia Voldaren",
       "number": "177",
@@ -13676,6 +13853,7 @@
         }
       ],
       "manaCost": "{1}{U}{B}",
+      "mciNumber": "178",
       "multiverseid": 426003,
       "name": "Pilfered Plans",
       "number": "178",
@@ -13752,6 +13930,7 @@
         }
       ],
       "manaCost": "{1}{B}{G}",
+      "mciNumber": "179",
       "multiverseid": 426004,
       "name": "Putrefy",
       "number": "179",
@@ -13832,6 +14011,7 @@
         }
       ],
       "manaCost": "{G}{W}{U}",
+      "mciNumber": "180",
       "multiverseid": 426005,
       "name": "Rhox War Monk",
       "number": "180",
@@ -13906,6 +14086,7 @@
         }
       ],
       "manaCost": "{U}{B}{R}",
+      "mciNumber": "181",
       "multiverseid": 426006,
       "name": "Sedraxis Specter",
       "number": "181",
@@ -13999,6 +14180,7 @@
         }
       ],
       "manaCost": "{5}{G}{U}",
+      "mciNumber": "182",
       "multiverseid": 426007,
       "name": "Simic Sky Swallower",
       "number": "182",
@@ -14072,6 +14254,7 @@
         }
       ],
       "manaCost": "{1}{W}{B}",
+      "mciNumber": "183",
       "multiverseid": 426008,
       "name": "Sin Collector",
       "number": "183",
@@ -14155,6 +14338,7 @@
         }
       ],
       "manaCost": "{1}{R}{W}",
+      "mciNumber": "184",
       "multiverseid": 426009,
       "name": "Skyknight Legionnaire",
       "number": "184",
@@ -14229,6 +14413,7 @@
         }
       ],
       "manaCost": "{1}{U}{B}",
+      "mciNumber": "185",
       "multiverseid": 426010,
       "name": "Soul Manipulation",
       "number": "185",
@@ -14305,6 +14490,7 @@
         }
       ],
       "manaCost": "{2}{U}{B}",
+      "mciNumber": "186",
       "multiverseid": 426011,
       "name": "Soul Ransom",
       "number": "186",
@@ -14385,6 +14571,7 @@
         }
       ],
       "manaCost": "{X}{W}{U}{U}",
+      "mciNumber": "187",
       "multiverseid": 426012,
       "name": "Sphinx's Revelation",
       "number": "187",
@@ -14457,6 +14644,7 @@
         }
       ],
       "manaCost": "{B}{R}",
+      "mciNumber": "188",
       "multiverseid": 426013,
       "name": "Spike Jester",
       "number": "188",
@@ -14531,6 +14719,7 @@
         }
       ],
       "manaCost": "{B}{R}{G}",
+      "mciNumber": "189",
       "multiverseid": 426014,
       "name": "Sprouting Thrinax",
       "number": "189",
@@ -14606,6 +14795,7 @@
         }
       ],
       "manaCost": "{1}{G}{W}{U}",
+      "mciNumber": "190",
       "multiverseid": 426015,
       "name": "Stoic Angel",
       "number": "190",
@@ -14686,6 +14876,7 @@
         }
       ],
       "manaCost": "{R}{W}",
+      "mciNumber": "191",
       "multiverseid": 426016,
       "name": "Sunhome Guildmage",
       "number": "191",
@@ -14764,6 +14955,7 @@
         }
       ],
       "manaCost": "{1}{W}{U}",
+      "mciNumber": "192",
       "multiverseid": 426017,
       "name": "Talon Trooper",
       "number": "192",
@@ -14835,6 +15027,7 @@
         }
       ],
       "manaCost": "{U}{R}",
+      "mciNumber": "193",
       "multiverseid": 426018,
       "name": "Teleportal",
       "number": "193",
@@ -14939,6 +15132,7 @@
         }
       ],
       "manaCost": "{B}{R}",
+      "mciNumber": "194",
       "multiverseid": 426019,
       "name": "Terminate",
       "number": "194",
@@ -15013,6 +15207,7 @@
         }
       ],
       "manaCost": "{R}{W}",
+      "mciNumber": "195",
       "multiverseid": 426020,
       "name": "Thundersong Trumpeter",
       "number": "195",
@@ -15087,6 +15282,7 @@
         }
       ],
       "manaCost": "{1}{W}{U}{B}",
+      "mciNumber": "196",
       "multiverseid": 426021,
       "name": "Tower Gargoyle",
       "number": "196",
@@ -15160,6 +15356,7 @@
         }
       ],
       "manaCost": "{1}{G}{W}",
+      "mciNumber": "197",
       "multiverseid": 426022,
       "name": "Unflinching Courage",
       "number": "197",
@@ -15235,6 +15432,7 @@
         }
       ],
       "manaCost": "{3}{G}{U}",
+      "mciNumber": "198",
       "multiverseid": 426023,
       "name": "Urban Evolution",
       "number": "198",
@@ -15316,6 +15514,7 @@
         }
       ],
       "manaCost": "{2}{W}{U}",
+      "mciNumber": "199",
       "multiverseid": 426024,
       "name": "Vanish into Memory",
       "number": "199",
@@ -15396,6 +15595,7 @@
         }
       ],
       "manaCost": "{G}{W}",
+      "mciNumber": "200",
       "multiverseid": 426025,
       "name": "Voice of Resurgence",
       "number": "200",
@@ -15481,6 +15681,7 @@
         }
       ],
       "manaCost": "{1}{W}{U}",
+      "mciNumber": "201",
       "multiverseid": 426026,
       "name": "Wall of Denial",
       "number": "201",
@@ -15553,6 +15754,7 @@
         }
       ],
       "manaCost": "{1}{G}{W}",
+      "mciNumber": "202",
       "multiverseid": 426027,
       "name": "Wayfaring Temple",
       "number": "202",
@@ -15660,6 +15862,7 @@
         }
       ],
       "manaCost": "{R}{G}{W}",
+      "mciNumber": "203",
       "multiverseid": 426028,
       "name": "Woolly Thoctar",
       "number": "203",
@@ -15733,6 +15936,7 @@
         }
       ],
       "manaCost": "{1}{W}{U}{B}",
+      "mciNumber": "204",
       "multiverseid": 426029,
       "name": "Zur the Enchanter",
       "number": "204",
@@ -15879,6 +16083,7 @@
         }
       ],
       "manaCost": "{R/W}{R/W}{R/W}",
+      "mciNumber": "206",
       "multiverseid": 426031,
       "name": "Boros Reckoner",
       "number": "206",
@@ -15965,6 +16170,7 @@
         }
       ],
       "manaCost": "{R/G}{R/G}",
+      "mciNumber": "207",
       "multiverseid": 426032,
       "name": "Burning-Tree Emissary",
       "number": "207",
@@ -16043,6 +16249,7 @@
         }
       ],
       "manaCost": "{2}{R/G}",
+      "mciNumber": "208",
       "multiverseid": 426033,
       "name": "Giantbaiting",
       "number": "208",
@@ -16115,6 +16322,7 @@
         }
       ],
       "manaCost": "{1}{W/B}{W/B}",
+      "mciNumber": "209",
       "multiverseid": 426034,
       "name": "Gift of Orzhova",
       "number": "209",
@@ -16184,6 +16392,7 @@
         }
       ],
       "manaCost": "{1}{W/U}",
+      "mciNumber": "210",
       "multiverseid": 426035,
       "name": "Mistmeadow Witch",
       "number": "210",
@@ -16259,6 +16468,7 @@
         }
       ],
       "manaCost": "{G/W}{G/W}",
+      "mciNumber": "211",
       "multiverseid": 426036,
       "name": "Sundering Growth",
       "number": "211",
@@ -16355,6 +16565,7 @@
         }
       ],
       "manaCost": "{1}{R/G}",
+      "mciNumber": "212",
       "multiverseid": 426037,
       "name": "Tattermunge Witch",
       "number": "212",
@@ -16426,6 +16637,7 @@
         }
       ],
       "manaCost": "{4}{B/R}",
+      "mciNumber": "213",
       "multiverseid": 426038,
       "name": "Torrent of Souls",
       "number": "213",
@@ -16508,6 +16720,7 @@
         }
       ],
       "manaCost": "{4}{R/G}{R/G}",
+      "mciNumber": "214",
       "multiverseid": 426039,
       "name": "Wort, the Raidmother",
       "number": "214",
@@ -16605,6 +16818,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "215",
       "multiverseid": 426040,
       "name": "Azorius Signet",
       "number": "215",
@@ -16664,6 +16878,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "216",
       "multiverseid": 426041,
       "name": "Basilisk Collar",
       "number": "216",
@@ -16729,6 +16944,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "217",
       "multiverseid": 426042,
       "name": "Boros Signet",
       "number": "217",
@@ -16791,6 +17007,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "218",
       "multiverseid": 426043,
       "name": "Damping Matrix",
       "number": "218",
@@ -16867,6 +17084,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "219",
       "multiverseid": 426044,
       "name": "Dimir Signet",
       "number": "219",
@@ -16931,6 +17149,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "220",
       "multiverseid": 426045,
       "name": "Golgari Signet",
       "number": "220",
@@ -16994,6 +17213,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "221",
       "multiverseid": 426046,
       "name": "Grafdigger's Cage",
       "number": "221",
@@ -17078,6 +17298,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "222",
       "multiverseid": 426047,
       "name": "Gruul Signet",
       "number": "222",
@@ -17143,6 +17364,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "223",
       "multiverseid": 426048,
       "name": "Izzet Signet",
       "number": "223",
@@ -17208,6 +17430,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "224",
       "multiverseid": 426049,
       "name": "Orzhov Signet",
       "number": "224",
@@ -17274,6 +17497,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "225",
       "multiverseid": 426050,
       "name": "Rakdos Signet",
       "number": "225",
@@ -17340,6 +17564,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "226",
       "multiverseid": 426051,
       "name": "Selesnya Signet",
       "number": "226",
@@ -17405,6 +17630,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "227",
       "multiverseid": 426052,
       "name": "Simic Signet",
       "number": "227",
@@ -17471,6 +17697,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "228",
       "multiverseid": 426053,
       "name": "Arcane Sanctum",
       "number": "228",
@@ -17528,6 +17755,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "229",
       "multiverseid": 426054,
       "name": "Arid Mesa",
       "number": "229",
@@ -17589,6 +17817,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "230",
       "multiverseid": 426055,
       "name": "Azorius Guildgate",
       "number": "230",
@@ -17665,6 +17894,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "231",
       "multiverseid": 426056,
       "name": "Boros Guildgate",
       "number": "231",
@@ -17737,6 +17967,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "232",
       "multiverseid": 426057,
       "name": "Cavern of Souls",
       "number": "232",
@@ -17808,6 +18039,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "233",
       "multiverseid": 426058,
       "name": "Crumbling Necropolis",
       "number": "233",
@@ -17872,6 +18104,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "234",
       "multiverseid": 426059,
       "name": "Dimir Guildgate",
       "number": "234",
@@ -17947,6 +18180,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "235",
       "multiverseid": 426060,
       "name": "Golgari Guildgate",
       "number": "235",
@@ -18025,6 +18259,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "236",
       "multiverseid": 426061,
       "name": "Gruul Guildgate",
       "number": "236",
@@ -18100,6 +18335,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "237",
       "multiverseid": 426062,
       "name": "Izzet Guildgate",
       "number": "237",
@@ -18177,6 +18413,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "238",
       "multiverseid": 426063,
       "name": "Jungle Shrine",
       "number": "238",
@@ -18235,6 +18472,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "239",
       "multiverseid": 426064,
       "name": "Marsh Flats",
       "number": "239",
@@ -18291,6 +18529,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "240",
       "multiverseid": 426065,
       "name": "Misty Rainforest",
       "number": "240",
@@ -18352,6 +18591,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "241",
       "multiverseid": 426066,
       "name": "Orzhov Guildgate",
       "number": "241",
@@ -18428,6 +18668,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "242",
       "multiverseid": 426067,
       "name": "Rakdos Guildgate",
       "number": "242",
@@ -18504,6 +18745,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "243",
       "multiverseid": 426068,
       "name": "Savage Lands",
       "number": "243",
@@ -18562,6 +18804,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "244",
       "multiverseid": 426069,
       "name": "Scalding Tarn",
       "number": "244",
@@ -18624,6 +18867,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "245",
       "multiverseid": 426070,
       "name": "Seaside Citadel",
       "number": "245",
@@ -18687,6 +18931,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "246",
       "multiverseid": 426071,
       "name": "Selesnya Guildgate",
       "number": "246",
@@ -18763,6 +19008,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "247",
       "multiverseid": 426072,
       "name": "Shimmering Grotto",
       "number": "247",
@@ -18828,6 +19074,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "248",
       "multiverseid": 426073,
       "name": "Simic Guildgate",
       "number": "248",
@@ -18900,6 +19147,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "249",
       "multiverseid": 426074,
       "name": "Verdant Catacombs",
       "number": "249",

--- a/json/MPS_AKH.json
+++ b/json/MPS_AKH.json
@@ -4,6 +4,7 @@
     "Amonkhet Invocations"
   ],
   "code": "MPS_AKH",
+  "magicCardsInfoCode": "mpsakh",
   "releaseDate": "2017-04-28",
   "border": "black",
   "type": "masterpiece",
@@ -43,6 +44,7 @@
         }
       ],
       "manaCost": "{4}{W}{W}",
+      "mciNumber": "1",
       "multiverseid": 429860,
       "name": "Austere Command",
       "number": "1",
@@ -109,6 +111,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "2",
       "multiverseid": 429861,
       "name": "Aven Mindcensor",
       "number": "2",
@@ -177,6 +180,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "3",
       "multiverseid": 429862,
       "name": "Containment Priest",
       "number": "3",
@@ -244,6 +248,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "4",
       "multiverseid": 429863,
       "name": "Loyal Retainers",
       "number": "4",
@@ -313,6 +318,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "5",
       "multiverseid": 429864,
       "name": "Oketra the True",
       "number": "5",
@@ -382,6 +388,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "6",
       "multiverseid": 429865,
       "name": "Worship",
       "number": "6",
@@ -442,6 +449,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}",
+      "mciNumber": "7",
       "multiverseid": 429866,
       "name": "Wrath of God",
       "number": "7",
@@ -511,6 +519,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "8",
       "multiverseid": 429867,
       "name": "Consecrated Sphinx",
       "number": "8",
@@ -581,6 +590,7 @@
         }
       ],
       "manaCost": "{U}{U}",
+      "mciNumber": "9",
       "multiverseid": 429868,
       "name": "Counterbalance",
       "number": "9",
@@ -646,6 +656,7 @@
         }
       ],
       "manaCost": "{U}{U}",
+      "mciNumber": "10",
       "multiverseid": 429869,
       "name": "Counterspell",
       "number": "10",
@@ -723,6 +734,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}{U}",
+      "mciNumber": "11",
       "multiverseid": 429870,
       "name": "Cryptic Command",
       "number": "11",
@@ -783,6 +795,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "12",
       "multiverseid": 429871,
       "name": "Daze",
       "number": "12",
@@ -839,6 +852,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "13",
       "multiverseid": 429872,
       "name": "Divert",
       "number": "13",
@@ -886,6 +900,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "14",
       "multiverseid": 429873,
       "name": "Force of Will",
       "number": "14",
@@ -951,6 +966,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "15",
       "multiverseid": 429874,
       "name": "Kefnet the Mindful",
       "number": "15",
@@ -1020,6 +1036,7 @@
         }
       ],
       "manaCost": "{0}",
+      "mciNumber": "16",
       "multiverseid": 429875,
       "name": "Pact of Negation",
       "number": "16",
@@ -1078,6 +1095,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "17",
       "multiverseid": 429876,
       "name": "Spell Pierce",
       "number": "17",
@@ -1126,6 +1144,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "18",
       "multiverseid": 429877,
       "name": "Stifle",
       "number": "18",
@@ -1189,6 +1208,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "19",
       "multiverseid": 429878,
       "name": "Attrition",
       "number": "19",
@@ -1245,6 +1265,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "20",
       "multiverseid": 429879,
       "name": "Bontu the Glorified",
       "number": "20",
@@ -1334,6 +1355,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "21",
       "multiverseid": 429880,
       "name": "Dark Ritual",
       "number": "21",
@@ -1408,6 +1430,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "22",
       "multiverseid": 429881,
       "name": "Diabolic Intent",
       "number": "22",
@@ -1469,6 +1492,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "23",
       "multiverseid": 429882,
       "name": "Entomb",
       "number": "23",
@@ -1515,6 +1539,7 @@
         }
       ],
       "manaCost": "{X}{B}",
+      "mciNumber": "24",
       "multiverseid": 429883,
       "name": "Mind Twist",
       "number": "24",
@@ -1569,6 +1594,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "25",
       "multiverseid": 429884,
       "name": "Aggravated Assault",
       "number": "25",
@@ -1622,6 +1648,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "26",
       "multiverseid": 429885,
       "name": "Chain Lightning",
       "number": "26",
@@ -1711,6 +1738,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "27",
       "multiverseid": 429886,
       "name": "Hazoret the Fervent",
       "number": "27",
@@ -1784,6 +1812,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "28",
       "multiverseid": 429887,
       "name": "Rhonas the Indomitable",
       "number": "28",
@@ -1855,6 +1884,7 @@
         }
       ],
       "manaCost": "{1}{B}{G}",
+      "mciNumber": "29",
       "multiverseid": 429888,
       "name": "Maelstrom Pulse",
       "number": "29",
@@ -1924,6 +1954,7 @@
         }
       ],
       "manaCost": "{1}{W}{B}",
+      "mciNumber": "30",
       "multiverseid": 429889,
       "name": "Vindicate",
       "number": "30",

--- a/json/PCA.json
+++ b/json/PCA.json
@@ -1,6 +1,7 @@
 {
   "name": "Planechase Anthology",
   "code": "PCA",
+  "magicCardsInfoCode": "pca",
   "releaseDate": "2016-11-25",
   "border": "black",
   "type": "planechase",
@@ -33,6 +34,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "1",
       "multiverseid": 423426,
       "name": "Armored Griffin",
       "number": "1",
@@ -123,6 +125,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "2",
       "multiverseid": 423427,
       "name": "Auramancer",
       "number": "2",
@@ -213,6 +216,7 @@
         }
       ],
       "manaCost": "{5}{W}",
+      "mciNumber": "3",
       "multiverseid": 423428,
       "name": "Auratouched Mage",
       "number": "3",
@@ -324,6 +328,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "4",
       "multiverseid": 423429,
       "name": "Cage of Hands",
       "number": "4",
@@ -402,6 +407,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "5",
       "multiverseid": 423430,
       "name": "Celestial Ancient",
       "number": "5",
@@ -473,6 +479,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "6",
       "multiverseid": 423431,
       "name": "Felidar Umbra",
       "number": "6",
@@ -577,6 +584,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "7",
       "multiverseid": 423432,
       "name": "Ghostly Prison",
       "number": "7",
@@ -678,6 +686,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "8",
       "multiverseid": 423433,
       "name": "Hyena Umbra",
       "number": "8",
@@ -811,6 +820,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "9",
       "multiverseid": 423434,
       "name": "Kor Spiritdancer",
       "number": "9",
@@ -929,6 +939,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "10",
       "multiverseid": 423435,
       "name": "Mammoth Umbra",
       "number": "10",
@@ -1081,6 +1092,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "11",
       "multiverseid": 423436,
       "name": "Sigil of the Empty Throne",
       "number": "11",
@@ -1216,6 +1228,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "12",
       "multiverseid": 423437,
       "name": "Spirit Mantle",
       "number": "12",
@@ -1306,6 +1319,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "13",
       "multiverseid": 423438,
       "name": "Three Dreams",
       "number": "13",
@@ -1384,6 +1398,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "14",
       "multiverseid": 423439,
       "name": "Augury Owl",
       "number": "14",
@@ -1501,6 +1516,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "15",
       "multiverseid": 423440,
       "name": "Cancel",
       "number": "15",
@@ -1641,6 +1657,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "16",
       "multiverseid": 423441,
       "name": "Concentrate",
       "number": "16",
@@ -1726,6 +1743,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "17",
       "multiverseid": 423442,
       "name": "Guard Gomazoa",
       "number": "17",
@@ -1808,6 +1826,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "18",
       "multiverseid": 423443,
       "name": "Higure, the Still Wind",
       "number": "18",
@@ -1938,6 +1957,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "19",
       "multiverseid": 423444,
       "name": "Illusory Angel",
       "number": "19",
@@ -2052,6 +2072,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "20",
       "multiverseid": 423445,
       "name": "Mistblade Shinobi",
       "number": "20",
@@ -2148,6 +2169,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "21",
       "multiverseid": 423446,
       "name": "Ninja of the Deep Hours",
       "number": "21",
@@ -2262,6 +2284,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "22",
       "multiverseid": 423447,
       "name": "Peregrine Drake",
       "number": "22",
@@ -2369,6 +2392,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "23",
       "multiverseid": 423448,
       "name": "Primal Plasma",
       "number": "23",
@@ -2484,6 +2508,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "24",
       "multiverseid": 423449,
       "name": "Sakashima's Student",
       "number": "24",
@@ -2618,6 +2643,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "25",
       "multiverseid": 423450,
       "name": "See Beyond",
       "number": "25",
@@ -2723,6 +2749,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "26",
       "multiverseid": 423451,
       "name": "Sunken Hope",
       "number": "26",
@@ -2810,6 +2837,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "27",
       "multiverseid": 423452,
       "name": "Walker of Secret Ways",
       "number": "27",
@@ -2899,6 +2927,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "28",
       "multiverseid": 423453,
       "name": "Wall of Frost",
       "number": "28",
@@ -2997,6 +3026,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "29",
       "multiverseid": 423454,
       "name": "Whirlpool Warrior",
       "number": "29",
@@ -3138,6 +3168,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "30",
       "multiverseid": 423455,
       "name": "Assassinate",
       "number": "30",
@@ -3237,6 +3268,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "31",
       "multiverseid": 423456,
       "name": "Cadaver Imp",
       "number": "31",
@@ -3330,6 +3362,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "32",
       "multiverseid": 423457,
       "name": "Dark Hatchling",
       "number": "32",
@@ -3439,6 +3472,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "33",
       "multiverseid": 423458,
       "name": "Ink-Eyes, Servant of Oni",
       "number": "33",
@@ -3583,6 +3617,7 @@
         }
       ],
       "manaCost": "{1}{B}{B}",
+      "mciNumber": "34",
       "multiverseid": 423459,
       "name": "Liliana's Specter",
       "number": "34",
@@ -3676,6 +3711,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "35",
       "multiverseid": 423460,
       "name": "Okiba-Gang Shinobi",
       "number": "35",
@@ -3770,6 +3806,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "36",
       "multiverseid": 423461,
       "name": "Skullsnatcher",
       "number": "36",
@@ -3888,6 +3925,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "37",
       "multiverseid": 423462,
       "name": "Throat Slitter",
       "number": "37",
@@ -3966,6 +4004,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "38",
       "multiverseid": 423463,
       "name": "Tormented Soul",
       "number": "38",
@@ -4084,6 +4123,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "39",
       "multiverseid": 423464,
       "name": "Arc Trail",
       "number": "39",
@@ -4200,6 +4240,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "40",
       "multiverseid": 423465,
       "name": "Beetleback Chief",
       "number": "40",
@@ -4335,6 +4376,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "41",
       "multiverseid": 423466,
       "name": "Erratic Explosion",
       "number": "41",
@@ -4428,6 +4470,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "42",
       "multiverseid": 423467,
       "name": "Fiery Conclusion",
       "number": "42",
@@ -4526,6 +4569,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "43",
       "multiverseid": 423468,
       "name": "Fiery Fall",
       "number": "43",
@@ -4657,6 +4701,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "44",
       "multiverseid": 423469,
       "name": "Fling",
       "number": "44",
@@ -4771,6 +4816,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "45",
       "multiverseid": 423470,
       "name": "Hellion Eruption",
       "number": "45",
@@ -4874,6 +4920,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "46",
       "multiverseid": 423471,
       "name": "Hissing Iguanar",
       "number": "46",
@@ -4966,6 +5013,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "47",
       "multiverseid": 423472,
       "name": "Mark of Mutiny",
       "number": "47",
@@ -5068,6 +5116,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "48",
       "multiverseid": 423473,
       "name": "Mass Mutiny",
       "number": "48",
@@ -5184,6 +5233,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "49",
       "multiverseid": 423474,
       "name": "Mudbutton Torchrunner",
       "number": "49",
@@ -5292,6 +5342,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "50",
       "multiverseid": 423475,
       "name": "Preyseizer Dragon",
       "number": "50",
@@ -5405,6 +5456,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "51",
       "multiverseid": 423476,
       "name": "Rivals' Duel",
       "number": "51",
@@ -5495,6 +5547,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "52",
       "multiverseid": 423477,
       "name": "Thorn-Thrash Viashino",
       "number": "52",
@@ -5602,6 +5655,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "53",
       "multiverseid": 423478,
       "name": "Thunder-Thrash Elder",
       "number": "53",
@@ -5721,6 +5775,7 @@
         }
       ],
       "manaCost": "{5}{R}",
+      "mciNumber": "54",
       "multiverseid": 423479,
       "name": "Warstorm Surge",
       "number": "54",
@@ -5828,6 +5883,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "55",
       "multiverseid": 423480,
       "name": "Aura Gnarlid",
       "number": "55",
@@ -5946,6 +6002,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "56",
       "multiverseid": 423481,
       "name": "Awakening Zone",
       "number": "56",
@@ -6030,6 +6087,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "57",
       "multiverseid": 423482,
       "name": "Beast Within",
       "number": "57",
@@ -6126,6 +6184,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "58",
       "multiverseid": 423483,
       "name": "Boar Umbra",
       "number": "58",
@@ -6262,6 +6321,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "59",
       "multiverseid": 423484,
       "name": "Bramble Elemental",
       "number": "59",
@@ -6336,6 +6396,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "60",
       "multiverseid": 423485,
       "name": "Brindle Shoat",
       "number": "60",
@@ -6417,6 +6478,7 @@
         }
       ],
       "manaCost": "{5}{G}",
+      "mciNumber": "61",
       "multiverseid": 423486,
       "name": "Brutalizer Exarch",
       "number": "61",
@@ -6545,6 +6607,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "62",
       "multiverseid": 423487,
       "name": "Cultivate",
       "number": "62",
@@ -6651,6 +6714,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "63",
       "multiverseid": 423488,
       "name": "Dowsing Shaman",
       "number": "63",
@@ -6756,6 +6820,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "64",
       "multiverseid": 423489,
       "name": "Dreampod Druid",
       "number": "64",
@@ -6855,6 +6920,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "65",
       "multiverseid": 423490,
       "name": "Gluttonous Slime",
       "number": "65",
@@ -6951,6 +7017,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "66",
       "multiverseid": 423491,
       "name": "Lumberknot",
       "number": "66",
@@ -7074,6 +7141,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "67",
       "multiverseid": 423492,
       "name": "Mitotic Slime",
       "number": "67",
@@ -7182,6 +7250,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "68",
       "multiverseid": 423493,
       "name": "Mycoloth",
       "number": "68",
@@ -7307,6 +7376,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "69",
       "multiverseid": 423494,
       "name": "Nest Invader",
       "number": "69",
@@ -7405,6 +7475,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "70",
       "multiverseid": 423495,
       "name": "Nullmage Advocate",
       "number": "70",
@@ -7515,6 +7586,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "71",
       "multiverseid": 423496,
       "name": "Ondu Giant",
       "number": "71",
@@ -7633,6 +7705,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}{G}",
+      "mciNumber": "72",
       "multiverseid": 423497,
       "name": "Overrun",
       "number": "72",
@@ -7751,6 +7824,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "73",
       "multiverseid": 423498,
       "name": "Penumbra Spider",
       "number": "73",
@@ -7835,6 +7909,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "74",
       "multiverseid": 423499,
       "name": "Predatory Urge",
       "number": "74",
@@ -7946,6 +8021,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "75",
       "multiverseid": 423500,
       "name": "Quiet Disrepair",
       "number": "75",
@@ -8069,6 +8145,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "76",
       "multiverseid": 423501,
       "name": "Rancor",
       "number": "76",
@@ -8161,6 +8238,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "77",
       "multiverseid": 423502,
       "name": "Silhana Ledgewalker",
       "number": "77",
@@ -8263,6 +8341,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "78",
       "multiverseid": 423503,
       "name": "Snake Umbra",
       "number": "78",
@@ -8415,6 +8494,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "79",
       "multiverseid": 423504,
       "name": "Tukatongue Thallid",
       "number": "79",
@@ -8496,6 +8576,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "80",
       "multiverseid": 423505,
       "name": "Viridian Emissary",
       "number": "80",
@@ -8655,6 +8736,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "81",
       "multiverseid": 423506,
       "name": "Wall of Blossoms",
       "number": "81",
@@ -8738,6 +8820,7 @@
         }
       ],
       "manaCost": "{U}{B}",
+      "mciNumber": "82",
       "multiverseid": 423507,
       "name": "Baleful Strix",
       "number": "82",
@@ -8852,6 +8935,7 @@
         }
       ],
       "manaCost": "{3}{B}{R}",
+      "mciNumber": "83",
       "multiverseid": 423508,
       "name": "Bituminous Blast",
       "number": "83",
@@ -8997,6 +9081,7 @@
         }
       ],
       "manaCost": "{2}{R}{G}",
+      "mciNumber": "84",
       "multiverseid": 423509,
       "name": "Bloodbraid Elf",
       "number": "84",
@@ -9140,6 +9225,7 @@
         }
       ],
       "manaCost": "{3}{U}{B}",
+      "mciNumber": "85",
       "multiverseid": 423510,
       "name": "Deny Reality",
       "number": "85",
@@ -9274,6 +9360,7 @@
         }
       ],
       "manaCost": "{U}{B}",
+      "mciNumber": "86",
       "multiverseid": 423511,
       "name": "Dimir Infiltrator",
       "number": "86",
@@ -9350,6 +9437,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}{G}{G}",
+      "mciNumber": "87",
       "multiverseid": 423512,
       "name": "Dragonlair Spider",
       "number": "87",
@@ -9413,6 +9501,7 @@
         }
       ],
       "manaCost": "{3}{G}{W}",
+      "mciNumber": "88",
       "multiverseid": 423513,
       "name": "Elderwood Scion",
       "number": "88",
@@ -9495,6 +9584,7 @@
         }
       ],
       "manaCost": "{4}{W}{U}{B}",
+      "mciNumber": "89",
       "multiverseid": 423514,
       "name": "Enigma Sphinx",
       "number": "89",
@@ -9598,6 +9688,7 @@
         }
       ],
       "manaCost": "{4}{G}{W}",
+      "mciNumber": "90",
       "multiverseid": 423515,
       "name": "Enlisted Wurm",
       "number": "90",
@@ -9679,6 +9770,7 @@
         }
       ],
       "manaCost": "{4}{U}{R}",
+      "mciNumber": "91",
       "multiverseid": 423516,
       "name": "Etherium-Horn Sorcerer",
       "number": "91",
@@ -9743,6 +9835,7 @@
         }
       ],
       "manaCost": "{1}{R}{G}",
+      "mciNumber": "92",
       "multiverseid": 423517,
       "name": "Fires of Yavimaya",
       "number": "92",
@@ -9810,6 +9903,7 @@
         }
       ],
       "manaCost": "{W}{U}{B}{R}{G}",
+      "mciNumber": "93",
       "multiverseid": 423518,
       "name": "Fusion Elemental",
       "number": "93",
@@ -9868,6 +9962,7 @@
         }
       ],
       "manaCost": "{1}{U/B}{U/B}{U/B}",
+      "mciNumber": "94",
       "multiverseid": 423519,
       "name": "Glen Elendra Liege",
       "number": "94",
@@ -9935,6 +10030,7 @@
         }
       ],
       "manaCost": "{2}{R}{G}",
+      "mciNumber": "95",
       "multiverseid": 423520,
       "name": "Hellkite Hatchling",
       "number": "95",
@@ -9996,6 +10092,7 @@
         }
       ],
       "manaCost": "{4}{G}{W}",
+      "mciNumber": "96",
       "multiverseid": 423521,
       "name": "Indrik Umbra",
       "number": "96",
@@ -10063,6 +10160,7 @@
         }
       ],
       "manaCost": "{1}{U/B}",
+      "mciNumber": "97",
       "multiverseid": 423522,
       "name": "Inkfathom Witch",
       "number": "97",
@@ -10145,6 +10243,7 @@
         }
       ],
       "manaCost": "{2}{U}{B}",
+      "mciNumber": "98",
       "multiverseid": 423523,
       "name": "Kathari Remnant",
       "number": "98",
@@ -10228,6 +10327,7 @@
         }
       ],
       "manaCost": "{G}{G}{G}{W}{W}{W}",
+      "mciNumber": "99",
       "multiverseid": 423524,
       "name": "Krond the Dawn-Clad",
       "number": "99",
@@ -10297,6 +10397,7 @@
         }
       ],
       "manaCost": "{W}{U}{B}{R}{G}",
+      "mciNumber": "100",
       "multiverseid": 423525,
       "name": "Last Stand",
       "number": "100",
@@ -10345,6 +10446,7 @@
         }
       ],
       "manaCost": "{5}{U}{R}{G}",
+      "mciNumber": "101",
       "multiverseid": 423526,
       "name": "Maelstrom Wanderer",
       "number": "101",
@@ -10423,6 +10525,7 @@
         }
       ],
       "manaCost": "{2}{U/R}",
+      "mciNumber": "102",
       "multiverseid": 423527,
       "name": "Noggle Ransacker",
       "number": "102",
@@ -10489,6 +10592,7 @@
         }
       ],
       "manaCost": "{4}{G}{W}",
+      "mciNumber": "103",
       "multiverseid": 423528,
       "name": "Pollenbright Wings",
       "number": "103",
@@ -10538,6 +10642,7 @@
         }
       ],
       "manaCost": "{1}{G}{U}",
+      "mciNumber": "104",
       "multiverseid": 423529,
       "name": "Shardless Agent",
       "number": "104",
@@ -10591,6 +10696,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}{B}{B}",
+      "mciNumber": "105",
       "multiverseid": 423530,
       "name": "Silent-Blade Oni",
       "number": "105",
@@ -10656,6 +10762,7 @@
         }
       ],
       "manaCost": "{3}{R}{G}",
+      "mciNumber": "106",
       "multiverseid": 423531,
       "name": "Thromok the Insatiable",
       "number": "106",
@@ -10716,6 +10823,7 @@
         }
       ],
       "manaCost": "{4}{U}{B}",
+      "mciNumber": "107",
       "multiverseid": 423532,
       "name": "Vela the Night-Clad",
       "number": "107",
@@ -10778,6 +10886,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "108",
       "multiverseid": 423533,
       "name": "Armillary Sphere",
       "number": "108",
@@ -10830,6 +10939,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "109",
       "multiverseid": 423534,
       "name": "Farsight Mask",
       "number": "109",
@@ -10894,6 +11004,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "110",
       "multiverseid": 423535,
       "name": "Flayer Husk",
       "number": "110",
@@ -10937,6 +11048,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "111",
       "multiverseid": 423536,
       "name": "Fractured Powerstone",
       "number": "111",
@@ -10992,6 +11104,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "112",
       "multiverseid": 423537,
       "name": "Quietus Spike",
       "number": "112",
@@ -11048,6 +11161,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "113",
       "multiverseid": 423538,
       "name": "Sai of the Shinobi",
       "number": "113",
@@ -11103,6 +11217,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "114",
       "multiverseid": 423539,
       "name": "Thran Golem",
       "number": "114",
@@ -11158,6 +11273,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "115",
       "multiverseid": 423540,
       "name": "Whispersilk Cloak",
       "number": "115",
@@ -11214,6 +11330,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "116",
       "multiverseid": 423541,
       "name": "Dimir Aqueduct",
       "number": "116",
@@ -11268,6 +11385,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "117",
       "multiverseid": 423542,
       "name": "Exotic Orchard",
       "number": "117",
@@ -11340,6 +11458,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "118",
       "multiverseid": 423543,
       "name": "Graypelt Refuge",
       "number": "118",
@@ -11391,6 +11510,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "119",
       "multiverseid": 423544,
       "name": "Gruul Turf",
       "number": "119",
@@ -11449,6 +11569,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "120",
       "multiverseid": 423545,
       "name": "Jwar Isle Refuge",
       "number": "120",
@@ -11499,6 +11620,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "121",
       "multiverseid": 423546,
       "name": "Kazandu Refuge",
       "number": "121",
@@ -11551,6 +11673,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "122",
       "multiverseid": 423547,
       "name": "Khalni Garden",
       "number": "122",
@@ -11594,6 +11717,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "123",
       "multiverseid": 423548,
       "name": "Krosan Verge",
       "number": "123",
@@ -11640,6 +11764,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "124",
       "multiverseid": 423549,
       "name": "Rupture Spire",
       "number": "124",
@@ -11694,6 +11819,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "125",
       "multiverseid": 423550,
       "name": "Selesnya Sanctuary",
       "number": "125",
@@ -11755,6 +11881,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "126",
       "multiverseid": 423551,
       "name": "Shimmering Grotto",
       "number": "126",
@@ -11808,6 +11935,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "127",
       "multiverseid": 423552,
       "name": "Skarrg, the Rage Pits",
       "number": "127",
@@ -11853,6 +11981,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "128",
       "multiverseid": 423553,
       "name": "Tainted Isle",
       "number": "128",
@@ -11897,6 +12026,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "129",
       "multiverseid": 423554,
       "name": "Terramorphic Expanse",
       "number": "129",
@@ -11962,6 +12092,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "130",
       "multiverseid": 423555,
       "name": "Vitu-Ghazi, the City-Tree",
       "number": "130",
@@ -12012,6 +12143,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "131",
       "multiverseid": 423556,
       "name": "Vivid Creek",
       "number": "131",

--- a/json/SOI.json
+++ b/json/SOI.json
@@ -1,6 +1,7 @@
 {
   "name": "Shadows over Innistrad",
   "code": "SOI",
+  "magicCardsInfoCode": "soi",
   "releaseDate": "2016-04-08",
   "border": "black",
   "type": "expansion",
@@ -140,6 +141,7 @@
         }
       ],
       "manaCost": "{1}{W}{W}",
+      "mciNumber": "1",
       "multiverseid": 409737,
       "name": "Always Watching",
       "number": "1",
@@ -246,6 +248,7 @@
         }
       ],
       "manaCost": "{6}{W}{W}",
+      "mciNumber": "2",
       "multiverseid": 409738,
       "name": "Angel of Deliverance",
       "number": "2",
@@ -396,6 +399,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "3",
       "multiverseid": 409739,
       "name": "Angelic Purge",
       "number": "3",
@@ -503,6 +507,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "4",
       "multiverseid": 409740,
       "name": "Apothecary Geist",
       "number": "4",
@@ -615,6 +620,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "5a",
       "multiverseid": 409741,
       "name": "Archangel Avacyn",
       "names": [
@@ -748,6 +754,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "5b",
       "multiverseid": 409742,
       "name": "Avacyn, the Purifier",
       "names": [
@@ -867,6 +874,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "6a",
       "multiverseid": 409743,
       "name": "Avacynian Missionaries",
       "names": [
@@ -989,6 +997,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "6b",
       "multiverseid": 409744,
       "name": "Lunarch Inquisitors",
       "names": [
@@ -1131,6 +1140,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "7",
       "multiverseid": 409745,
       "name": "Bound by Moonsilver",
       "number": "7",
@@ -1250,6 +1260,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "8",
       "multiverseid": 409746,
       "name": "Bygone Bishop",
       "number": "8",
@@ -1381,6 +1392,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "9",
       "multiverseid": 409747,
       "name": "Cathar's Companion",
       "number": "9",
@@ -1499,6 +1511,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "10",
       "multiverseid": 409748,
       "name": "Chaplain's Blessing",
       "number": "10",
@@ -1606,6 +1619,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "11",
       "multiverseid": 409749,
       "name": "Dauntless Cathar",
       "number": "11",
@@ -1719,6 +1733,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "12",
       "multiverseid": 409750,
       "name": "Declaration in Stone",
       "number": "12",
@@ -1860,6 +1875,7 @@
         }
       ],
       "manaCost": "{4}{W}{W}",
+      "mciNumber": "13",
       "multiverseid": 409751,
       "name": "Descend upon the Sinful",
       "number": "13",
@@ -1993,6 +2009,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "14",
       "multiverseid": 409752,
       "name": "Devilthorn Fox",
       "number": "14",
@@ -2102,6 +2119,7 @@
         }
       ],
       "manaCost": "{5}{W}{W}",
+      "mciNumber": "15",
       "multiverseid": 409753,
       "name": "Drogskol Cavalry",
       "number": "15",
@@ -2221,6 +2239,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "16",
       "multiverseid": 409754,
       "name": "Eerie Interlude",
       "number": "16",
@@ -2342,6 +2361,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "17",
       "multiverseid": 409755,
       "name": "Emissary of the Sleepless",
       "number": "17",
@@ -2468,6 +2488,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "18",
       "multiverseid": 409756,
       "name": "Ethereal Guidance",
       "number": "18",
@@ -2581,6 +2602,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "19",
       "multiverseid": 409757,
       "name": "Expose Evil",
       "number": "19",
@@ -2709,6 +2731,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "20",
       "multiverseid": 409758,
       "name": "Gryff's Boon",
       "number": "20",
@@ -2825,6 +2848,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "21a",
       "multiverseid": 409759,
       "name": "Hanweir Militia Captain",
       "names": [
@@ -2958,6 +2982,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "21b",
       "multiverseid": 409760,
       "name": "Westvale Cult Leader",
       "names": [
@@ -3085,6 +3110,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "22",
       "multiverseid": 409761,
       "name": "Hope Against Hope",
       "number": "22",
@@ -3201,6 +3227,7 @@
         }
       ],
       "manaCost": "{4}{W}",
+      "mciNumber": "23",
       "multiverseid": 409762,
       "name": "Humble the Brute",
       "number": "23",
@@ -3326,6 +3353,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "24",
       "multiverseid": 409763,
       "name": "Inquisitor's Ox",
       "number": "24",
@@ -3460,6 +3488,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "25",
       "multiverseid": 409764,
       "name": "Inspiring Captain",
       "number": "25",
@@ -3579,6 +3608,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "26",
       "multiverseid": 409765,
       "name": "Militant Inquisitor",
       "number": "26",
@@ -3702,6 +3732,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "27",
       "multiverseid": 409766,
       "name": "Moorland Drifter",
       "number": "27",
@@ -3837,6 +3868,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "28",
       "multiverseid": 409767,
       "name": "Nahiri's Machinations",
       "number": "28",
@@ -3953,6 +3985,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "29",
       "multiverseid": 409768,
       "name": "Nearheath Chaplain",
       "number": "29",
@@ -4066,6 +4099,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "30",
       "multiverseid": 409769,
       "name": "Not Forgotten",
       "number": "30",
@@ -4182,6 +4216,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "31",
       "multiverseid": 409770,
       "name": "Odric, Lunarch Marshal",
       "number": "31",
@@ -4312,6 +4347,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "32",
       "multiverseid": 409771,
       "name": "Open the Armory",
       "number": "32",
@@ -4419,6 +4455,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "33",
       "multiverseid": 409772,
       "name": "Paranoid Parish-Blade",
       "number": "33",
@@ -4555,6 +4592,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "34a",
       "multiverseid": 409773,
       "name": "Pious Evangel",
       "names": [
@@ -4682,6 +4720,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "34b",
       "multiverseid": 409774,
       "name": "Wayward Disciple",
       "names": [
@@ -4809,6 +4848,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "35",
       "multiverseid": 409775,
       "name": "Puncturing Light",
       "number": "35",
@@ -4930,6 +4970,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "36",
       "multiverseid": 409776,
       "name": "Reaper of Flight Moonsilver",
       "number": "36",
@@ -5064,6 +5105,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "37",
       "multiverseid": 409777,
       "name": "Silverstrike",
       "number": "37",
@@ -5172,6 +5214,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "38",
       "multiverseid": 409778,
       "name": "Spectral Shepherd",
       "number": "38",
@@ -5284,6 +5327,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "39",
       "multiverseid": 409779,
       "name": "Stern Constable",
       "number": "39",
@@ -5397,6 +5441,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "40",
       "multiverseid": 409780,
       "name": "Strength of Arms",
       "number": "40",
@@ -5510,6 +5555,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "41",
       "multiverseid": 409781,
       "name": "Survive the Night",
       "number": "41",
@@ -5635,6 +5681,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "42",
       "multiverseid": 409782,
       "name": "Tenacity",
       "number": "42",
@@ -5751,6 +5798,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "43",
       "multiverseid": 409783,
       "name": "Thalia's Lieutenant",
       "number": "43",
@@ -5870,6 +5918,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "44",
       "multiverseid": 409784,
       "name": "Thraben Inspector",
       "number": "44",
@@ -5996,6 +6045,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "45",
       "multiverseid": 409785,
       "name": "Topplegeist",
       "number": "45",
@@ -6132,6 +6182,7 @@
         }
       ],
       "manaCost": "{W}",
+      "mciNumber": "46a",
       "multiverseid": 409786,
       "name": "Town Gossipmonger",
       "names": [
@@ -6258,6 +6309,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "46b",
       "multiverseid": 409787,
       "name": "Incited Rabble",
       "names": [
@@ -6388,6 +6440,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "47",
       "multiverseid": 409788,
       "name": "Unruly Mob",
       "number": "47",
@@ -6507,6 +6560,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "48",
       "multiverseid": 409789,
       "name": "Vessel of Ephemera",
       "number": "48",
@@ -6614,6 +6668,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "49a",
       "multiverseid": 409790,
       "name": "Aberrant Researcher",
       "names": [
@@ -6744,6 +6799,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "49b",
       "multiverseid": 409791,
       "name": "Perfected Form",
       "names": [
@@ -6861,6 +6917,7 @@
         }
       ],
       "manaCost": "{1}{U}{U}",
+      "mciNumber": "50",
       "multiverseid": 409792,
       "name": "Broken Concentration",
       "number": "50",
@@ -7010,6 +7067,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "51",
       "multiverseid": 409793,
       "name": "Catalog",
       "number": "51",
@@ -7119,6 +7177,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "52",
       "multiverseid": 409794,
       "name": "Compelling Deterrence",
       "number": "52",
@@ -7241,6 +7300,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "53",
       "multiverseid": 409795,
       "name": "Confirm Suspicions",
       "number": "53",
@@ -7366,6 +7426,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "54a",
       "multiverseid": 409796,
       "name": "Daring Sleuth",
       "names": [
@@ -7491,6 +7552,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "54b",
       "multiverseid": 409797,
       "name": "Bearer of Overwhelming Truths",
       "names": [
@@ -7622,6 +7684,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "55",
       "multiverseid": 409798,
       "name": "Deny Existence",
       "number": "55",
@@ -7729,6 +7792,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "56",
       "multiverseid": 409799,
       "name": "Drownyard Explorers",
       "number": "56",
@@ -7857,6 +7921,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "57",
       "multiverseid": 409800,
       "name": "Drunau Corpse Trawler",
       "number": "57",
@@ -7969,6 +8034,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "58",
       "multiverseid": 409801,
       "name": "Engulf the Shore",
       "number": "58",
@@ -8076,6 +8142,7 @@
         }
       ],
       "manaCost": "{X}{U}",
+      "mciNumber": "59",
       "multiverseid": 409802,
       "name": "Epiphany at the Drownyard",
       "number": "59",
@@ -8189,6 +8256,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "60",
       "multiverseid": 409803,
       "name": "Erdwal Illuminator",
       "number": "60",
@@ -8301,6 +8369,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "61",
       "multiverseid": 409804,
       "name": "Essence Flux",
       "number": "61",
@@ -8425,6 +8494,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "62",
       "multiverseid": 409805,
       "name": "Fleeting Memories",
       "number": "62",
@@ -8550,6 +8620,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "63",
       "multiverseid": 409806,
       "name": "Forgotten Creation",
       "number": "63",
@@ -8677,6 +8748,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "64",
       "multiverseid": 409807,
       "name": "Furtive Homunculus",
       "number": "64",
@@ -8798,6 +8870,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "65",
       "multiverseid": 409808,
       "name": "Geralf's Masterpiece",
       "number": "65",
@@ -8924,6 +8997,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "66",
       "multiverseid": 409809,
       "name": "Ghostly Wings",
       "number": "66",
@@ -9053,6 +9127,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "67",
       "multiverseid": 409810,
       "name": "Gone Missing",
       "number": "67",
@@ -9177,6 +9252,7 @@
         }
       ],
       "manaCost": "{U}",
+      "mciNumber": "68",
       "multiverseid": 409811,
       "name": "Invasive Surgery",
       "number": "68",
@@ -9306,6 +9382,7 @@
       ],
       "loyalty": 5,
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "69",
       "multiverseid": 409812,
       "name": "Jace, Unraveler of Secrets",
       "number": "69",
@@ -9430,6 +9507,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "70",
       "multiverseid": 409813,
       "name": "Jace's Scrutiny",
       "number": "70",
@@ -9555,6 +9633,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "71",
       "multiverseid": 409814,
       "name": "Just the Wind",
       "number": "71",
@@ -9700,6 +9779,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "72",
       "multiverseid": 409815,
       "name": "Lamplighter of Selhoff",
       "number": "72",
@@ -9812,6 +9892,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "73",
       "multiverseid": 409816,
       "name": "Manic Scribe",
       "number": "73",
@@ -9950,6 +10031,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "74",
       "multiverseid": 409817,
       "name": "Nagging Thoughts",
       "number": "74",
@@ -10098,6 +10180,7 @@
         }
       ],
       "manaCost": "{5}{U}{U}",
+      "mciNumber": "75",
       "multiverseid": 409818,
       "name": "Nephalia Moondrakes",
       "number": "75",
@@ -10210,6 +10293,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "76",
       "multiverseid": 409819,
       "name": "Niblis of Dusk",
       "number": "76",
@@ -10322,6 +10406,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "77",
       "multiverseid": 409820,
       "name": "Ongoing Investigation",
       "number": "77",
@@ -10447,6 +10532,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "78",
       "multiverseid": 409821,
       "name": "Pieces of the Puzzle",
       "number": "78",
@@ -10554,6 +10640,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "79",
       "multiverseid": 409822,
       "name": "Pore Over the Pages",
       "number": "79",
@@ -10667,6 +10754,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "80",
       "multiverseid": 409823,
       "name": "Press for Answers",
       "number": "80",
@@ -10791,6 +10879,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "81",
       "multiverseid": 409824,
       "name": "Rattlechains",
       "number": "81",
@@ -10907,6 +10996,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "82",
       "multiverseid": 409825,
       "name": "Reckless Scholar",
       "number": "82",
@@ -11023,6 +11113,7 @@
         }
       ],
       "manaCost": "{5}{U}",
+      "mciNumber": "83",
       "multiverseid": 409826,
       "name": "Rise from the Tides",
       "number": "83",
@@ -11136,6 +11227,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "84",
       "multiverseid": 409827,
       "name": "Seagraf Skaab",
       "number": "84",
@@ -11246,6 +11338,7 @@
         }
       ],
       "manaCost": "{5}{U}",
+      "mciNumber": "85",
       "multiverseid": 409828,
       "name": "Silburlind Snapper",
       "number": "85",
@@ -11364,6 +11457,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "86",
       "multiverseid": 409829,
       "name": "Silent Observer",
       "number": "86",
@@ -11476,6 +11570,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "87",
       "multiverseid": 409830,
       "name": "Sleep Paralysis",
       "number": "87",
@@ -11586,6 +11681,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "88a",
       "multiverseid": 409831,
       "name": "Startled Awake",
       "names": [
@@ -11702,6 +11798,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "88b",
       "multiverseid": 409832,
       "name": "Persistent Nightmare",
       "names": [
@@ -11831,6 +11928,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "89",
       "multiverseid": 409833,
       "name": "Stitched Mangler",
       "number": "89",
@@ -11944,6 +12042,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "90",
       "multiverseid": 409834,
       "name": "Stitchwing Skaab",
       "number": "90",
@@ -12063,6 +12162,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "91",
       "multiverseid": 409835,
       "name": "Stormrider Spirit",
       "number": "91",
@@ -12174,6 +12274,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "92a",
       "multiverseid": 409836,
       "name": "Thing in the Ice",
       "names": [
@@ -12303,6 +12404,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "92b",
       "multiverseid": 409837,
       "name": "Awoken Horror",
       "names": [
@@ -12420,6 +12522,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "93",
       "multiverseid": 409838,
       "name": "Trail of Evidence",
       "number": "93",
@@ -12541,6 +12644,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "94a",
       "multiverseid": 409839,
       "name": "Uninvited Geist",
       "names": [
@@ -12670,6 +12774,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "94b",
       "multiverseid": 409840,
       "name": "Unimpeded Trespasser",
       "names": [
@@ -12786,6 +12891,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "95",
       "multiverseid": 409841,
       "name": "Vessel of Paramnesia",
       "number": "95",
@@ -12892,6 +12998,7 @@
         }
       ],
       "manaCost": "{2}{U}{U}",
+      "mciNumber": "96",
       "multiverseid": 409842,
       "name": "Welcome to the Fold",
       "number": "96",
@@ -13040,6 +13147,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "97a",
       "multiverseid": 409843,
       "name": "Accursed Witch",
       "names": [
@@ -13169,6 +13277,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "97b",
       "multiverseid": 409844,
       "name": "Infectious Curse",
       "names": [
@@ -13293,6 +13402,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "98",
       "multiverseid": 409845,
       "name": "Alms of the Vein",
       "number": "98",
@@ -13438,6 +13548,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "99",
       "multiverseid": 409846,
       "name": "Asylum Visitor",
       "number": "99",
@@ -13602,6 +13713,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "100",
       "multiverseid": 409847,
       "name": "Behind the Scenes",
       "number": "100",
@@ -13719,6 +13831,7 @@
         }
       ],
       "manaCost": "{5}{B}{B}",
+      "mciNumber": "101",
       "multiverseid": 409848,
       "name": "Behold the Beyond",
       "number": "101",
@@ -13826,6 +13939,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "102",
       "multiverseid": 409849,
       "name": "Biting Rain",
       "number": "102",
@@ -13975,6 +14089,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "103",
       "multiverseid": 409850,
       "name": "Call the Bloodline",
       "number": "103",
@@ -14087,6 +14202,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "104",
       "multiverseid": 409851,
       "name": "Creeping Dread",
       "number": "104",
@@ -14215,6 +14331,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "105",
       "multiverseid": 409852,
       "name": "Crow of Dark Tidings",
       "number": "105",
@@ -14338,6 +14455,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "106",
       "multiverseid": 409853,
       "name": "Dead Weight",
       "number": "106",
@@ -14448,6 +14566,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "107",
       "multiverseid": 409854,
       "name": "Diregraf Colossus",
       "number": "107",
@@ -14572,6 +14691,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "108a",
       "multiverseid": 409855,
       "name": "Elusive Tormentor",
       "names": [
@@ -14706,6 +14826,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "108b",
       "multiverseid": 409856,
       "name": "Insidious Mist",
       "names": [
@@ -14821,6 +14942,7 @@
         }
       ],
       "manaCost": "{4}{B}{B}",
+      "mciNumber": "109",
       "multiverseid": 409857,
       "name": "Ever After",
       "number": "109",
@@ -14934,6 +15056,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "110",
       "multiverseid": 409858,
       "name": "Farbog Revenant",
       "number": "110",
@@ -15055,6 +15178,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "111",
       "multiverseid": 409859,
       "name": "From Under the Floorboards",
       "number": "111",
@@ -15200,6 +15324,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "112",
       "multiverseid": 409860,
       "name": "Ghoulcaller's Accomplice",
       "number": "112",
@@ -15313,6 +15438,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "113",
       "multiverseid": 409861,
       "name": "Ghoulsteed",
       "number": "113",
@@ -15432,6 +15558,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "114",
       "multiverseid": 409862,
       "name": "Gisa's Bidding",
       "number": "114",
@@ -15576,6 +15703,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "115",
       "multiverseid": 409863,
       "name": "Grotesque Mutation",
       "number": "115",
@@ -15689,6 +15817,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "116a",
       "multiverseid": 409864,
       "name": "Heir of Falkenrath",
       "names": [
@@ -15810,6 +15939,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "116b",
       "multiverseid": 409865,
       "name": "Heir to the Night",
       "names": [
@@ -15927,6 +16057,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "117",
       "multiverseid": 409866,
       "name": "Hound of the Farbogs",
       "number": "117",
@@ -16062,6 +16193,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "118",
       "multiverseid": 409867,
       "name": "Indulgent Aristocrat",
       "number": "118",
@@ -16180,6 +16312,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "119a",
       "multiverseid": 409868,
       "name": "Kindly Stranger",
       "names": [
@@ -16325,6 +16458,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "119b",
       "multiverseid": 409869,
       "name": "Demon-Possessed Witch",
       "names": [
@@ -16442,6 +16576,7 @@
         }
       ],
       "manaCost": "{X}{B}",
+      "mciNumber": "120",
       "multiverseid": 409870,
       "name": "Liliana's Indignation",
       "number": "120",
@@ -16559,6 +16694,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "121",
       "multiverseid": 409871,
       "name": "Macabre Waltz",
       "number": "121",
@@ -16678,6 +16814,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "122",
       "multiverseid": 409872,
       "name": "Markov Dreadknight",
       "number": "122",
@@ -16791,6 +16928,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "123",
       "multiverseid": 409873,
       "name": "Merciless Resolve",
       "number": "123",
@@ -16907,6 +17045,7 @@
         }
       ],
       "manaCost": "{2}{B}{B}",
+      "mciNumber": "124",
       "multiverseid": 409874,
       "name": "Mindwrack Demon",
       "number": "124",
@@ -17042,6 +17181,7 @@
         }
       ],
       "manaCost": "{5}{B}",
+      "mciNumber": "125",
       "multiverseid": 409875,
       "name": "Morkrut Necropod",
       "number": "125",
@@ -17165,6 +17305,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "126",
       "multiverseid": 409876,
       "name": "Murderous Compulsion",
       "number": "126",
@@ -17311,6 +17452,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "127",
       "multiverseid": 409877,
       "name": "Olivia's Bloodsworn",
       "number": "127",
@@ -17424,6 +17566,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "128",
       "multiverseid": 409878,
       "name": "Pale Rider of Trostad",
       "number": "128",
@@ -17549,6 +17692,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "129",
       "multiverseid": 409879,
       "name": "Pick the Brain",
       "number": "129",
@@ -17678,6 +17822,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "130",
       "multiverseid": 409880,
       "name": "Rancid Rats",
       "number": "130",
@@ -17800,6 +17945,7 @@
         }
       ],
       "manaCost": "{B}{B}",
+      "mciNumber": "131",
       "multiverseid": 409881,
       "name": "Relentless Dead",
       "number": "131",
@@ -17922,6 +18068,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "132",
       "multiverseid": 409882,
       "name": "Rottenheart Ghoul",
       "number": "132",
@@ -18034,6 +18181,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "133",
       "multiverseid": 409883,
       "name": "Sanitarium Skeleton",
       "number": "133",
@@ -18146,6 +18294,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "134",
       "multiverseid": 409884,
       "name": "Shamble Back",
       "number": "134",
@@ -18259,6 +18408,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "135",
       "multiverseid": 409885,
       "name": "Sinister Concoction",
       "number": "135",
@@ -18372,6 +18522,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "136",
       "multiverseid": 409886,
       "name": "Stallion of Ashmouth",
       "number": "136",
@@ -18507,6 +18658,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "137",
       "multiverseid": 409887,
       "name": "Stromkirk Mentor",
       "number": "137",
@@ -18624,6 +18776,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "138",
       "multiverseid": 409888,
       "name": "Throttle",
       "number": "138",
@@ -18732,6 +18885,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "139",
       "multiverseid": 409889,
       "name": "To the Slaughter",
       "number": "139",
@@ -18864,6 +19018,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "140",
       "multiverseid": 409890,
       "name": "Tooth Collector",
       "number": "140",
@@ -18999,6 +19154,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "141",
       "multiverseid": 409891,
       "name": "Triskaidekaphobia",
       "number": "141",
@@ -19124,6 +19280,7 @@
         }
       ],
       "manaCost": "{4}{B}",
+      "mciNumber": "142",
       "multiverseid": 409892,
       "name": "Twins of Maurer Estate",
       "number": "142",
@@ -19274,6 +19431,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "143",
       "multiverseid": 409893,
       "name": "Vampire Noble",
       "number": "143",
@@ -19384,6 +19542,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "144",
       "multiverseid": 409894,
       "name": "Vessel of Malignity",
       "number": "144",
@@ -19496,6 +19655,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "145",
       "multiverseid": 409895,
       "name": "Avacyn's Judgment",
       "number": "145",
@@ -19652,6 +19812,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "146",
       "multiverseid": 409896,
       "name": "Bloodmad Vampire",
       "number": "146",
@@ -19803,6 +19964,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "147a",
       "multiverseid": 409897,
       "name": "Breakneck Rider",
       "names": [
@@ -19930,6 +20092,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "147b",
       "multiverseid": 409898,
       "name": "Neck Breaker",
       "names": [
@@ -20055,6 +20218,7 @@
         }
       ],
       "manaCost": "{X}{R}",
+      "mciNumber": "148",
       "multiverseid": 409899,
       "name": "Burn from Within",
       "number": "148",
@@ -20176,6 +20340,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "149a",
       "multiverseid": 409900,
       "name": "Convicted Killer",
       "names": [
@@ -20302,6 +20467,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "149b",
       "multiverseid": 409901,
       "name": "Branded Howler",
       "names": [
@@ -20428,6 +20594,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "150",
       "multiverseid": 409902,
       "name": "Dance with Devils",
       "number": "150",
@@ -20535,6 +20702,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "151",
       "multiverseid": 409903,
       "name": "Devils' Playground",
       "number": "151",
@@ -20642,6 +20810,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "152",
       "multiverseid": 409904,
       "name": "Dissension in the Ranks",
       "number": "152",
@@ -20755,6 +20924,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "153",
       "multiverseid": 409905,
       "name": "Dual Shot",
       "number": "153",
@@ -20868,6 +21038,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "154",
       "multiverseid": 409906,
       "name": "Ember-Eye Wolf",
       "number": "154",
@@ -20979,6 +21150,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "155",
       "multiverseid": 409907,
       "name": "Falkenrath Gorger",
       "number": "155",
@@ -21150,6 +21322,7 @@
         }
       ],
       "manaCost": "{1}{R}{R}",
+      "mciNumber": "156",
       "multiverseid": 409908,
       "name": "Fiery Temper",
       "number": "156",
@@ -21298,6 +21471,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "157",
       "multiverseid": 409909,
       "name": "Flameblade Angel",
       "number": "157",
@@ -21420,6 +21594,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "158a",
       "multiverseid": 409910,
       "name": "Gatstaf Arsonists",
       "names": [
@@ -21545,6 +21720,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "158b",
       "multiverseid": 409911,
       "name": "Gatstaf Ravagers",
       "names": [
@@ -21671,6 +21847,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "159a",
       "multiverseid": 409912,
       "name": "Geier Reach Bandit",
       "names": [
@@ -21797,6 +21974,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "159b",
       "multiverseid": 409913,
       "name": "Vildin-Pack Alpha",
       "names": [
@@ -21931,6 +22109,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "160",
       "multiverseid": 409914,
       "name": "Geistblast",
       "number": "160",
@@ -22067,6 +22246,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "161",
       "multiverseid": 409915,
       "name": "Gibbering Fiend",
       "number": "161",
@@ -22200,6 +22380,7 @@
         }
       ],
       "manaCost": "{2}{R}{R}",
+      "mciNumber": "162",
       "multiverseid": 409916,
       "name": "Goldnight Castigator",
       "number": "162",
@@ -22322,6 +22503,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "163",
       "multiverseid": 409917,
       "name": "Harness the Storm",
       "number": "163",
@@ -22455,6 +22637,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "164",
       "multiverseid": 409918,
       "name": "Howlpack Wolf",
       "number": "164",
@@ -22573,6 +22756,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "165",
       "multiverseid": 409919,
       "name": "Hulking Devil",
       "number": "165",
@@ -22683,6 +22867,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "166",
       "multiverseid": 409920,
       "name": "Incorrigible Youths",
       "number": "166",
@@ -22833,6 +23018,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "167",
       "multiverseid": 409921,
       "name": "Inner Struggle",
       "number": "167",
@@ -22940,6 +23126,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "168",
       "multiverseid": 409922,
       "name": "Insolent Neonate",
       "number": "168",
@@ -23051,6 +23238,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "169a",
       "multiverseid": 409923,
       "name": "Kessig Forgemaster",
       "names": [
@@ -23181,6 +23369,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "169b",
       "multiverseid": 409924,
       "name": "Flameheart Werewolf",
       "names": [
@@ -23315,6 +23504,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "170",
       "multiverseid": 409925,
       "name": "Lightning Axe",
       "number": "170",
@@ -23437,6 +23627,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "171",
       "multiverseid": 409926,
       "name": "Mad Prophet",
       "number": "171",
@@ -23562,6 +23753,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "172",
       "multiverseid": 409927,
       "name": "Magmatic Chasm",
       "number": "172",
@@ -23675,6 +23867,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "173",
       "multiverseid": 409928,
       "name": "Malevolent Whispers",
       "number": "173",
@@ -23828,6 +24021,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "174",
       "multiverseid": 409929,
       "name": "Pyre Hound",
       "number": "174",
@@ -23947,6 +24141,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "175",
       "multiverseid": 409930,
       "name": "Ravenous Bloodseeker",
       "number": "175",
@@ -24066,6 +24261,7 @@
         }
       ],
       "manaCost": "{4}{R}",
+      "mciNumber": "176",
       "multiverseid": 409931,
       "name": "Reduce to Ashes",
       "number": "176",
@@ -24179,6 +24375,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "177",
       "multiverseid": 409932,
       "name": "Rush of Adrenaline",
       "number": "177",
@@ -24286,6 +24483,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "178",
       "multiverseid": 409933,
       "name": "Sanguinary Mage",
       "number": "178",
@@ -24398,6 +24596,7 @@
         }
       ],
       "manaCost": "{R}{R}",
+      "mciNumber": "179",
       "multiverseid": 409934,
       "name": "Scourge Wolf",
       "number": "179",
@@ -24528,6 +24727,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "180",
       "multiverseid": 409935,
       "name": "Senseless Rage",
       "number": "180",
@@ -24675,6 +24875,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "181",
       "multiverseid": 409936,
       "name": "Sin Prodder",
       "number": "181",
@@ -24792,6 +24993,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "182a",
       "multiverseid": 409937,
       "name": "Skin Invasion",
       "names": [
@@ -24923,6 +25125,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "182b",
       "multiverseid": 409938,
       "name": "Skin Shedder",
       "names": [
@@ -25038,6 +25241,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "183",
       "multiverseid": 409939,
       "name": "Spiteful Motives",
       "number": "183",
@@ -25147,6 +25351,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "184",
       "multiverseid": 409940,
       "name": "Stensia Masquerade",
       "number": "184",
@@ -25296,6 +25501,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "185",
       "multiverseid": 409941,
       "name": "Structural Distortion",
       "number": "185",
@@ -25411,6 +25617,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "186",
       "multiverseid": 409942,
       "name": "Tormenting Voice",
       "number": "186",
@@ -25529,6 +25736,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "187",
       "multiverseid": 409943,
       "name": "Ulrich's Kindred",
       "number": "187",
@@ -25641,6 +25849,7 @@
         }
       ],
       "manaCost": "{2}{R}",
+      "mciNumber": "188",
       "multiverseid": 409944,
       "name": "Uncaged Fury",
       "number": "188",
@@ -25748,6 +25957,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "189",
       "multiverseid": 409945,
       "name": "Vessel of Volatility",
       "number": "189",
@@ -25855,6 +26065,7 @@
         }
       ],
       "manaCost": "{R}",
+      "mciNumber": "190a",
       "multiverseid": 409946,
       "name": "Village Messenger",
       "names": [
@@ -25980,6 +26191,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "190b",
       "multiverseid": 409947,
       "name": "Moonrise Intruder",
       "names": [
@@ -26106,6 +26318,7 @@
         }
       ],
       "manaCost": "{3}{R}",
+      "mciNumber": "191",
       "multiverseid": 409948,
       "name": "Voldaren Duelist",
       "number": "191",
@@ -26219,6 +26432,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "192",
       "multiverseid": 409949,
       "name": "Wolf of Devil's Breach",
       "number": "192",
@@ -26346,6 +26560,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "193",
       "multiverseid": 409950,
       "name": "Aim High",
       "number": "193",
@@ -26463,6 +26678,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "194a",
       "multiverseid": 409951,
       "name": "Autumnal Gloom",
       "names": [
@@ -26600,6 +26816,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "194b",
       "multiverseid": 409952,
       "name": "Ancient of the Equinox",
       "names": [
@@ -26715,6 +26932,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "195",
       "multiverseid": 409953,
       "name": "Briarbridge Patrol",
       "number": "195",
@@ -26850,6 +27068,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "196",
       "multiverseid": 409954,
       "name": "Byway Courier",
       "number": "196",
@@ -26977,6 +27196,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "197",
       "multiverseid": 409955,
       "name": "Clip Wings",
       "number": "197",
@@ -27090,6 +27310,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "198",
       "multiverseid": 409956,
       "name": "Confront the Unknown",
       "number": "198",
@@ -27218,6 +27439,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "199",
       "multiverseid": 409957,
       "name": "Crawling Sensation",
       "number": "199",
@@ -27331,6 +27553,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "200",
       "multiverseid": 409958,
       "name": "Cryptolith Rite",
       "number": "200",
@@ -27444,6 +27667,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "201",
       "multiverseid": 409959,
       "name": "Cult of the Waxing Moon",
       "number": "201",
@@ -27568,6 +27792,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "202",
       "multiverseid": 409960,
       "name": "Deathcap Cultivator",
       "number": "202",
@@ -27702,6 +27927,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "203a",
       "multiverseid": 409961,
       "name": "Duskwatch Recruiter",
       "names": [
@@ -27832,6 +28058,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "203b",
       "multiverseid": 409962,
       "name": "Krallenhorde Howler",
       "names": [
@@ -27966,6 +28193,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "204",
       "multiverseid": 409963,
       "name": "Equestrian Skill",
       "number": "204",
@@ -28076,6 +28304,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "205",
       "multiverseid": 409964,
       "name": "Fork in the Road",
       "number": "205",
@@ -28191,6 +28420,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "206",
       "multiverseid": 409965,
       "name": "Gloomwidow",
       "number": "206",
@@ -28305,6 +28535,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "207",
       "multiverseid": 409966,
       "name": "Graf Mole",
       "number": "207",
@@ -28422,6 +28653,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "208",
       "multiverseid": 409967,
       "name": "Groundskeeper",
       "number": "208",
@@ -28537,6 +28769,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "209a",
       "multiverseid": 409968,
       "name": "Hermit of the Natterknolls",
       "names": [
@@ -28671,6 +28904,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "209b",
       "multiverseid": 409969,
       "name": "Lone Wolf of the Natterknolls",
       "names": [
@@ -28805,6 +29039,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "210a",
       "multiverseid": 409970,
       "name": "Hinterland Logger",
       "names": [
@@ -28931,6 +29166,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "210b",
       "multiverseid": 409971,
       "name": "Timber Shredder",
       "names": [
@@ -29057,6 +29293,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "211",
       "multiverseid": 409972,
       "name": "Howlpack Resurgence",
       "number": "211",
@@ -29163,6 +29400,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "212",
       "multiverseid": 409973,
       "name": "Inexorable Blob",
       "number": "212",
@@ -29309,6 +29547,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "213",
       "multiverseid": 409974,
       "name": "Intrepid Provisioner",
       "number": "213",
@@ -29422,6 +29661,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "214",
       "multiverseid": 409975,
       "name": "Kessig Dire Swine",
       "number": "214",
@@ -29556,6 +29796,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "215a",
       "multiverseid": 409976,
       "name": "Lambholt Pacifist",
       "names": [
@@ -29687,6 +29928,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "215b",
       "multiverseid": 409977,
       "name": "Lambholt Butcher",
       "names": [
@@ -29813,6 +30055,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "216",
       "multiverseid": 409978,
       "name": "Loam Dryad",
       "number": "216",
@@ -29931,6 +30174,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "217",
       "multiverseid": 409979,
       "name": "Might Beyond Reason",
       "number": "217",
@@ -30060,6 +30304,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "218",
       "multiverseid": 409980,
       "name": "Moldgraf Scavenger",
       "number": "218",
@@ -30190,6 +30435,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "219",
       "multiverseid": 409981,
       "name": "Moonlight Hunt",
       "number": "219",
@@ -30296,6 +30542,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "220",
       "multiverseid": 409982,
       "name": "Obsessive Skinner",
       "number": "220",
@@ -30434,6 +30681,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "221",
       "multiverseid": 409983,
       "name": "Pack Guardian",
       "number": "221",
@@ -30547,6 +30795,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "222",
       "multiverseid": 409984,
       "name": "Quilled Wolf",
       "number": "222",
@@ -30659,6 +30908,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "223",
       "multiverseid": 409985,
       "name": "Rabid Bite",
       "number": "223",
@@ -30772,6 +31022,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "224",
       "multiverseid": 409986,
       "name": "Root Out",
       "number": "224",
@@ -30896,6 +31147,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "225a",
       "multiverseid": 409987,
       "name": "Sage of Ancient Lore",
       "names": [
@@ -31026,6 +31278,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "225b",
       "multiverseid": 409988,
       "name": "Werewolf of Ancient Hunger",
       "names": [
@@ -31152,6 +31405,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "226",
       "multiverseid": 409989,
       "name": "Seasons Past",
       "number": "226",
@@ -31277,6 +31531,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "227",
       "multiverseid": 409990,
       "name": "Second Harvest",
       "number": "227",
@@ -31394,6 +31649,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "228",
       "multiverseid": 409991,
       "name": "Silverfur Partisan",
       "number": "228",
@@ -31507,6 +31763,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "229a",
       "multiverseid": 409992,
       "name": "Solitary Hunter",
       "names": [
@@ -31634,6 +31891,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "229b",
       "multiverseid": 409993,
       "name": "One of the Pack",
       "names": [
@@ -31760,6 +32018,7 @@
         }
       ],
       "manaCost": "{2}{G}{G}",
+      "mciNumber": "230",
       "multiverseid": 409994,
       "name": "Soul Swallower",
       "number": "230",
@@ -31894,6 +32153,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "231",
       "multiverseid": 409995,
       "name": "Stoic Builder",
       "number": "231",
@@ -32006,6 +32266,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "232",
       "multiverseid": 409996,
       "name": "Thornhide Wolves",
       "number": "232",
@@ -32115,6 +32376,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "233",
       "multiverseid": 409997,
       "name": "Tireless Tracker",
       "number": "233",
@@ -32241,6 +32503,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "234",
       "multiverseid": 409998,
       "name": "Traverse the Ulvenwald",
       "number": "234",
@@ -32373,6 +32636,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "235",
       "multiverseid": 409999,
       "name": "Ulvenwald Hydra",
       "number": "235",
@@ -32484,6 +32748,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "236",
       "multiverseid": 410000,
       "name": "Ulvenwald Mysteries",
       "number": "236",
@@ -32604,6 +32869,7 @@
         }
       ],
       "manaCost": "{G}",
+      "mciNumber": "237",
       "multiverseid": 410001,
       "name": "Vessel of Nascency",
       "number": "237",
@@ -32712,6 +32978,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "238",
       "multiverseid": 410002,
       "name": "Veteran Cathar",
       "number": "238",
@@ -32825,6 +33092,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "239",
       "multiverseid": 410003,
       "name": "Watcher in the Web",
       "number": "239",
@@ -32936,6 +33204,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "240",
       "multiverseid": 410004,
       "name": "Weirding Wood",
       "number": "240",
@@ -33061,6 +33330,7 @@
         }
       ],
       "manaCost": "{X}{2}{G}{U}",
+      "mciNumber": "241",
       "multiverseid": 410005,
       "name": "Altered Ego",
       "number": "241",
@@ -33213,6 +33483,7 @@
         }
       ],
       "manaCost": "{1}{W}{B}",
+      "mciNumber": "242",
       "multiverseid": 410006,
       "name": "Anguished Unmaking",
       "number": "242",
@@ -33328,6 +33599,7 @@
       ],
       "loyalty": 3,
       "manaCost": "{2}{R}{G}",
+      "mciNumber": "243a",
       "multiverseid": 410007,
       "name": "Arlinn Kord",
       "names": [
@@ -33468,6 +33740,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "243b",
       "multiverseid": 410008,
       "name": "Arlinn, Embraced by the Moon",
       "names": [
@@ -33610,6 +33883,7 @@
         }
       ],
       "manaCost": "{1}{U}{R}",
+      "mciNumber": "244",
       "multiverseid": 410009,
       "name": "Fevered Visions",
       "number": "244",
@@ -33724,6 +33998,7 @@
         }
       ],
       "manaCost": "{3}{B}{G}",
+      "mciNumber": "245",
       "multiverseid": 410010,
       "name": "The Gitrog Monster",
       "number": "245",
@@ -33847,6 +34122,7 @@
         }
       ],
       "manaCost": "{1}{W}{U}",
+      "mciNumber": "246",
       "multiverseid": 410011,
       "name": "Invocation of Saint Traft",
       "number": "246",
@@ -33977,6 +34253,7 @@
       ],
       "loyalty": 4,
       "manaCost": "{2}{R}{W}",
+      "mciNumber": "247",
       "multiverseid": 410012,
       "name": "Nahiri, the Harbinger",
       "number": "247",
@@ -34102,6 +34379,7 @@
         }
       ],
       "manaCost": "{1}{B}{R}",
+      "mciNumber": "248",
       "multiverseid": 410013,
       "name": "Olivia, Mobilized for War",
       "number": "248",
@@ -34234,6 +34512,7 @@
         }
       ],
       "manaCost": "{1}{U}{B}",
+      "mciNumber": "249",
       "multiverseid": 410014,
       "name": "Prized Amalgam",
       "number": "249",
@@ -34357,6 +34636,7 @@
         }
       ],
       "manaCost": "{3}{G}{W}",
+      "mciNumber": "250",
       "multiverseid": 410015,
       "name": "Sigarda, Heron's Grace",
       "number": "250",
@@ -34480,6 +34760,7 @@
       ],
       "loyalty": 6,
       "manaCost": "{4}{W}{B}",
+      "mciNumber": "251",
       "multiverseid": 410016,
       "name": "Sorin, Grim Nemesis",
       "number": "251",
@@ -34593,6 +34874,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "252",
       "multiverseid": 410017,
       "name": "Brain in a Jar",
       "number": "252",
@@ -34712,6 +34994,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "253",
       "multiverseid": 410018,
       "name": "Corrupted Grafstone",
       "number": "253",
@@ -34823,6 +35106,7 @@
         }
       ],
       "manaCost": "{5}",
+      "mciNumber": "254",
       "multiverseid": 410019,
       "name": "Epitaph Golem",
       "number": "254",
@@ -34930,6 +35214,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "255",
       "multiverseid": 410020,
       "name": "Explosive Apparatus",
       "number": "255",
@@ -35031,6 +35316,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "256a",
       "multiverseid": 410021,
       "name": "Harvest Hand",
       "names": [
@@ -35146,6 +35432,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "256b",
       "multiverseid": 410022,
       "name": "Scrounged Scythe",
       "names": [
@@ -35254,6 +35541,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "257",
       "multiverseid": 410023,
       "name": "Haunted Cloak",
       "number": "257",
@@ -35364,6 +35652,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "258",
       "multiverseid": 410024,
       "name": "Magnifying Glass",
       "number": "258",
@@ -35479,6 +35768,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "259",
       "multiverseid": 410025,
       "name": "Murderer's Axe",
       "number": "259",
@@ -35583,6 +35873,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "260a",
       "multiverseid": 410026,
       "name": "Neglected Heirloom",
       "names": [
@@ -35700,6 +35991,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "260b",
       "multiverseid": 410027,
       "name": "Ashmouth Blade",
       "names": [
@@ -35808,6 +36100,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "261",
       "multiverseid": 410028,
       "name": "Runaway Carriage",
       "number": "261",
@@ -35914,6 +36207,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "262",
       "multiverseid": 410029,
       "name": "Shard of Broken Glass",
       "number": "262",
@@ -36017,6 +36311,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "263",
       "multiverseid": 410030,
       "name": "Skeleton Key",
       "number": "263",
@@ -36130,6 +36425,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "264",
       "multiverseid": 410031,
       "name": "Slayer's Plate",
       "number": "264",
@@ -36352,6 +36648,7 @@
         }
       ],
       "manaCost": "{1}",
+      "mciNumber": "266a",
       "multiverseid": 410033,
       "name": "Thraben Gargoyle",
       "names": [
@@ -36468,6 +36765,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "266b",
       "multiverseid": 410034,
       "name": "Stonewing Antagonizer",
       "names": [
@@ -36579,6 +36877,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "267",
       "multiverseid": 410035,
       "name": "True-Faith Censer",
       "number": "267",
@@ -36683,6 +36982,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "268",
       "multiverseid": 410036,
       "name": "Wicker Witch",
       "number": "268",
@@ -36787,6 +37087,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "269",
       "multiverseid": 410037,
       "name": "Wild-Field Scarecrow",
       "number": "269",
@@ -36895,6 +37196,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "270",
       "multiverseid": 410038,
       "name": "Choked Estuary",
       "number": "270",
@@ -37012,6 +37314,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "271",
       "multiverseid": 410039,
       "name": "Drownyard Temple",
       "number": "271",
@@ -37115,6 +37418,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "272",
       "multiverseid": 410040,
       "name": "Foreboding Ruins",
       "number": "272",
@@ -37222,6 +37526,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "273",
       "multiverseid": 410041,
       "name": "Forsaken Sanctuary",
       "number": "273",
@@ -37325,6 +37630,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "274",
       "multiverseid": 410042,
       "name": "Fortified Village",
       "number": "274",
@@ -37450,6 +37756,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "275",
       "multiverseid": 410043,
       "name": "Foul Orchard",
       "number": "275",
@@ -37553,6 +37860,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "276",
       "multiverseid": 410044,
       "name": "Game Trail",
       "number": "276",
@@ -37678,6 +37986,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "277",
       "multiverseid": 410045,
       "name": "Highland Lake",
       "number": "277",
@@ -37782,6 +38091,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "278",
       "multiverseid": 410046,
       "name": "Port Town",
       "number": "278",
@@ -37911,6 +38221,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "279",
       "multiverseid": 410047,
       "name": "Stone Quarry",
       "number": "279",
@@ -38012,6 +38323,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "280",
       "multiverseid": 410048,
       "name": "Warped Landscape",
       "number": "280",
@@ -38113,6 +38425,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "281a",
       "multiverseid": 410049,
       "name": "Westvale Abbey",
       "names": [
@@ -38228,6 +38541,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "281b",
       "multiverseid": 410050,
       "name": "Ormendahl, Profane Prince",
       "names": [
@@ -38351,6 +38665,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "282",
       "multiverseid": 410051,
       "name": "Woodland Stream",
       "number": "282",

--- a/json/V16.json
+++ b/json/V16.json
@@ -1,6 +1,7 @@
 {
   "name": "From the Vault: Lore",
   "code": "V16",
+  "magicCardsInfoCode": "v16",
   "releaseDate": "2016-08-19",
   "border": "black",
   "type": "from the vault",
@@ -41,6 +42,7 @@
         }
       ],
       "manaCost": "{2/B}{2/B}{2/B}",
+      "mciNumber": "1",
       "multiverseid": 416743,
       "name": "Beseech the Queen",
       "number": "1",
@@ -108,6 +110,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "2",
       "multiverseid": 416744,
       "name": "Cabal Ritual",
       "number": "2",
@@ -169,6 +172,7 @@
         }
       ],
       "manaCost": "{3}{W}{U}{B}{R}{G}",
+      "mciNumber": "3",
       "multiverseid": 416745,
       "name": "Conflux",
       "number": "3",
@@ -222,6 +226,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "4",
       "multiverseid": 416746,
       "name": "Dark Depths",
       "number": "4",
@@ -290,6 +295,7 @@
         }
       ],
       "manaCost": "{B}{G}{G}",
+      "mciNumber": "5",
       "multiverseid": 416747,
       "name": "Glissa, the Traitor",
       "number": "5",
@@ -352,6 +358,7 @@
         }
       ],
       "manaCost": "{3}",
+      "mciNumber": "6",
       "multiverseid": 416748,
       "name": "Helvault",
       "number": "6",
@@ -410,6 +417,7 @@
         }
       ],
       "manaCost": "{7}",
+      "mciNumber": "7",
       "multiverseid": 416749,
       "name": "Memnarch",
       "number": "7",
@@ -477,6 +485,7 @@
         }
       ],
       "manaCost": "{4}{U}{U}",
+      "mciNumber": "8",
       "multiverseid": 416750,
       "name": "Mind's Desire",
       "number": "8",
@@ -559,6 +568,7 @@
         }
       ],
       "manaCost": "{3}{G}{U}",
+      "mciNumber": "9",
       "multiverseid": 416751,
       "name": "Momir Vig, Simic Visionary",
       "number": "9",
@@ -627,6 +637,7 @@
         }
       ],
       "manaCost": "{2}{W}{W}{W}",
+      "mciNumber": "10",
       "multiverseid": 416752,
       "name": "Near-Death Experience",
       "number": "10",
@@ -689,6 +700,7 @@
         }
       ],
       "manaCost": "{6}{R}{R}",
+      "mciNumber": "11",
       "multiverseid": 416753,
       "name": "Obliterate",
       "number": "11",
@@ -737,6 +749,7 @@
         }
       ],
       "manaCost": "{4}",
+      "mciNumber": "12",
       "multiverseid": 416754,
       "name": "Phyrexian Processor",
       "number": "12",
@@ -791,6 +804,7 @@
           "legality": "Legal"
         }
       ],
+      "mciNumber": "13",
       "multiverseid": 416755,
       "name": "Tolaria West",
       "number": "13",
@@ -842,6 +856,7 @@
         }
       ],
       "manaCost": "{2}",
+      "mciNumber": "14",
       "multiverseid": 416756,
       "name": "Umezawa's Jitte",
       "number": "14",
@@ -918,6 +933,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "15",
       "multiverseid": 416757,
       "name": "Unmask",
       "number": "15",

--- a/json/W16.json
+++ b/json/W16.json
@@ -1,6 +1,7 @@
 {
   "name": "Welcome Deck 2016",
   "code": "W16",
+  "magicCardsInfoCode": "w16",
   "releaseDate": "2016-04-08",
   "border": "black",
   "type": "starter",
@@ -93,6 +94,7 @@
         }
       ],
       "manaCost": "{4}{W}{W}",
+      "mciNumber": "1",
       "multiverseid": 413367,
       "name": "Aegis Angel",
       "number": "1",
@@ -219,6 +221,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "2",
       "multiverseid": 413368,
       "name": "Marked by Honor",
       "number": "2",
@@ -326,6 +329,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "3",
       "multiverseid": 413369,
       "name": "Serra Angel",
       "number": "3",
@@ -462,6 +466,7 @@
         }
       ],
       "manaCost": "{4}{U}",
+      "mciNumber": "4",
       "multiverseid": 413370,
       "name": "Air Servant",
       "number": "4",
@@ -582,6 +587,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "5",
       "multiverseid": 413371,
       "name": "Disperse",
       "number": "5",
@@ -693,6 +699,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}{U}",
+      "mciNumber": "6",
       "multiverseid": 413372,
       "name": "Sphinx of Magosi",
       "number": "6",
@@ -817,6 +824,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "7",
       "multiverseid": 413373,
       "name": "Mind Rot",
       "number": "7",
@@ -938,6 +946,7 @@
         }
       ],
       "manaCost": "{5}{B}",
+      "mciNumber": "8",
       "multiverseid": 413374,
       "name": "Nightmare",
       "number": "8",
@@ -1087,6 +1096,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "9",
       "multiverseid": 413375,
       "name": "Sengir Vampire",
       "number": "9",
@@ -1233,6 +1243,7 @@
         }
       ],
       "manaCost": "{1}{B}",
+      "mciNumber": "10",
       "multiverseid": 413376,
       "name": "Walking Corpse",
       "number": "10",
@@ -1342,6 +1353,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "11",
       "multiverseid": 413377,
       "name": "Borderland Marauder",
       "number": "11",
@@ -1456,6 +1468,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "12",
       "multiverseid": 413378,
       "name": "Cone of Flame",
       "number": "12",
@@ -1576,6 +1589,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "13",
       "multiverseid": 413379,
       "name": "Shivan Dragon",
       "number": "13",
@@ -1714,6 +1728,7 @@
         }
       ],
       "manaCost": "{3}{G}{G}",
+      "mciNumber": "14",
       "multiverseid": 413380,
       "name": "Incremental Growth",
       "number": "14",
@@ -1830,6 +1845,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "15",
       "multiverseid": 413381,
       "name": "Oakenform",
       "number": "15",
@@ -1941,6 +1957,7 @@
         }
       ],
       "manaCost": "{4}{G}{G}",
+      "mciNumber": "16",
       "multiverseid": 413382,
       "name": "Soul of the Harvest",
       "number": "16",

--- a/json/W17.json
+++ b/json/W17.json
@@ -1,6 +1,7 @@
 {
   "name": "Welcome Deck 2017",
   "code": "W17",
+  "magicCardsInfoCode": "w17",
   "releaseDate": "2017-04-15",
   "border": "black",
   "type": "starter",
@@ -94,6 +95,7 @@
         }
       ],
       "manaCost": "{3}{W}",
+      "mciNumber": "1",
       "multiverseid": 429890,
       "name": "Divine Verdict",
       "number": "1",
@@ -220,6 +222,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "2",
       "multiverseid": 429891,
       "name": "Glory Seeker",
       "number": "2",
@@ -332,6 +335,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}",
+      "mciNumber": "3",
       "multiverseid": 429892,
       "name": "Serra Angel",
       "number": "3",
@@ -468,6 +472,7 @@
         }
       ],
       "manaCost": "{2}{W}",
+      "mciNumber": "4",
       "multiverseid": 429893,
       "name": "Standing Troops",
       "number": "4",
@@ -579,6 +584,7 @@
         }
       ],
       "manaCost": "{1}{W}",
+      "mciNumber": "5",
       "multiverseid": 429894,
       "name": "Stormfront Pegasus",
       "number": "5",
@@ -689,6 +695,7 @@
         }
       ],
       "manaCost": "{3}{W}{W}{W}",
+      "mciNumber": "6",
       "multiverseid": 429895,
       "name": "Victory's Herald",
       "number": "6",
@@ -805,6 +812,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}",
+      "mciNumber": "7",
       "multiverseid": 429896,
       "name": "Air Elemental",
       "number": "7",
@@ -935,6 +943,7 @@
         }
       ],
       "manaCost": "{1}{U}",
+      "mciNumber": "8",
       "multiverseid": 429897,
       "name": "Coral Merfolk",
       "number": "8",
@@ -1050,6 +1059,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "9",
       "multiverseid": 429898,
       "name": "Drag Under",
       "number": "9",
@@ -1164,6 +1174,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "10",
       "multiverseid": 429899,
       "name": "Inspiration",
       "number": "10",
@@ -1276,6 +1287,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "11",
       "multiverseid": 429900,
       "name": "Sleep Paralysis",
       "number": "11",
@@ -1387,6 +1399,7 @@
         }
       ],
       "manaCost": "{3}{U}{U}{U}",
+      "mciNumber": "12",
       "multiverseid": 429901,
       "name": "Sphinx of Magosi",
       "number": "12",
@@ -1499,6 +1512,7 @@
         }
       ],
       "manaCost": "{2}{U}",
+      "mciNumber": "13",
       "multiverseid": 429902,
       "name": "Stealer of Secrets",
       "number": "13",
@@ -1607,6 +1621,7 @@
         }
       ],
       "manaCost": "{3}{U}",
+      "mciNumber": "14",
       "multiverseid": 429903,
       "name": "Tricks of the Trade",
       "number": "14",
@@ -1710,6 +1725,7 @@
         }
       ],
       "manaCost": "{3}{B}",
+      "mciNumber": "15",
       "multiverseid": 429904,
       "name": "Bloodhunter Bat",
       "number": "15",
@@ -1823,6 +1839,7 @@
         }
       ],
       "manaCost": "{5}{B}",
+      "mciNumber": "16",
       "multiverseid": 429905,
       "name": "Certain Death",
       "number": "16",
@@ -1937,6 +1954,7 @@
         }
       ],
       "manaCost": "{5}{B}",
+      "mciNumber": "17",
       "multiverseid": 429906,
       "name": "Nightmare",
       "number": "17",
@@ -2078,6 +2096,7 @@
         }
       ],
       "manaCost": "{B}",
+      "mciNumber": "18",
       "multiverseid": 429907,
       "name": "Raise Dead",
       "number": "18",
@@ -2217,6 +2236,7 @@
         }
       ],
       "manaCost": "{3}{B}{B}",
+      "mciNumber": "19",
       "multiverseid": 429908,
       "name": "Sengir Vampire",
       "number": "19",
@@ -2363,6 +2383,7 @@
         }
       ],
       "manaCost": "{2}{B}",
+      "mciNumber": "20",
       "multiverseid": 429909,
       "name": "Untamed Hunger",
       "number": "20",
@@ -2474,6 +2495,7 @@
         }
       ],
       "manaCost": "{1}{R}",
+      "mciNumber": "21",
       "multiverseid": 429910,
       "name": "Falkenrath Reaver",
       "number": "21",
@@ -2581,6 +2603,7 @@
         }
       ],
       "manaCost": "{4}{R}{R}",
+      "mciNumber": "22",
       "multiverseid": 429911,
       "name": "Shivan Dragon",
       "number": "22",
@@ -2711,6 +2734,7 @@
         }
       ],
       "manaCost": "{3}{R}{R}",
+      "mciNumber": "23",
       "multiverseid": 429912,
       "name": "Thundering Giant",
       "number": "23",
@@ -2819,6 +2843,7 @@
         }
       ],
       "manaCost": "{5}{G}{G}",
+      "mciNumber": "24",
       "multiverseid": 429913,
       "name": "Garruk's Horde",
       "number": "24",
@@ -2956,6 +2981,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "25",
       "multiverseid": 429914,
       "name": "Oakenform",
       "number": "25",
@@ -3068,6 +3094,7 @@
         }
       ],
       "manaCost": "{1}{G}",
+      "mciNumber": "26",
       "multiverseid": 429915,
       "name": "Rabid Bite",
       "number": "26",
@@ -3178,6 +3205,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "27",
       "multiverseid": 429916,
       "name": "Rootwalla",
       "number": "27",
@@ -3297,6 +3325,7 @@
         }
       ],
       "manaCost": "{3}{G}",
+      "mciNumber": "28",
       "multiverseid": 429917,
       "name": "Stalking Tiger",
       "number": "28",
@@ -3406,6 +3435,7 @@
         }
       ],
       "manaCost": "{4}{G}",
+      "mciNumber": "29",
       "multiverseid": 429918,
       "name": "Stampeding Rhino",
       "number": "29",
@@ -3516,6 +3546,7 @@
         }
       ],
       "manaCost": "{2}{G}",
+      "mciNumber": "30",
       "multiverseid": 429919,
       "name": "Wing Snare",
       "number": "30",

--- a/shared/set_configs/AER.json
+++ b/shared/set_configs/AER.json
@@ -2,6 +2,7 @@
   "SET": {
     "name": "Aether Revolt",
     "code": "AER",
+    "magicCardsInfoCode": "aer",
     "releaseDate": "2017-01-20",
     "border": "black",
     "block": "Kaladesh",

--- a/shared/set_configs/AKH.json
+++ b/shared/set_configs/AKH.json
@@ -2,6 +2,7 @@
   "SET": {
     "name": "Amonkhet",
     "code": "AKH",
+    "magicCardsInfoCode": "akh",
     "releaseDate": "2017-04-28",
     "border": "black",
     "block": "Amonkhet",

--- a/shared/set_configs/ATH.json
+++ b/shared/set_configs/ATH.json
@@ -3,6 +3,7 @@
     "name": "Anthologies",
     "code": "ATH",
     "magicCardsInfoCode": "at",
+    "isMCISet": true,
     "releaseDate": "1998-11-01",
     "border": "white",
     "type": "box",

--- a/shared/set_configs/HOU.json
+++ b/shared/set_configs/HOU.json
@@ -2,6 +2,7 @@
   "SET": {
     "name": "Hour of Devastation",
     "code": "HOU",
+    "magicCardsInfoCode": "hou",
     "releaseDate": "2017-07-14",
     "border": "black",
     "block": "Amonkhet",

--- a/shared/set_configs/KLD.json
+++ b/shared/set_configs/KLD.json
@@ -3,6 +3,7 @@
   "SET": {
     "name": "Kaladesh",
     "code": "KLD",
+    "magicCardsInfoCode": "kld",
     "releaseDate": "2016-09-30",
     "border": "black",
     "type": "expansion",

--- a/shared/set_configs/SOI.json
+++ b/shared/set_configs/SOI.json
@@ -2,6 +2,7 @@
   "SET": {
     "name": "Shadows over Innistrad",
     "code": "SOI",
+    "magicCardsInfoCode": "soi",
     "releaseDate": "2016-04-08",
     "border": "black",
     "type": "expansion",

--- a/shared/set_configs/W16.json
+++ b/shared/set_configs/W16.json
@@ -2,6 +2,7 @@
   "SET": {
     "name": "Welcome Deck 2016",
     "code": "W16",
+    "magicCardsInfoCode": "w16",
     "releaseDate": "2016-04-08",
     "border": "black",
     "type": "starter",

--- a/shared/set_configs/W17.json
+++ b/shared/set_configs/W17.json
@@ -2,6 +2,7 @@
   "SET": {
     "name": "Welcome Deck 2017",
     "code": "W17",
+    "magicCardsInfoCode": "w17",
     "releaseDate": "2017-04-15",
     "border": "black",
     "type": "starter",

--- a/shared/set_configs/commander/C16.json
+++ b/shared/set_configs/commander/C16.json
@@ -2,6 +2,7 @@
   "SET": {
     "name": "Commander 2016",
     "code": "C16",
+    "magicCardsInfoCode": "c16",
     "releaseDate": "2016-11-11",
     "border": "black",
     "type": "commander",

--- a/shared/set_configs/conspiracy/CN2.json
+++ b/shared/set_configs/conspiracy/CN2.json
@@ -3,6 +3,7 @@
   "SET": {
     "name": "Conspiracy: Take the Crown",
     "code": "CN2",
+    "magicCardsInfoCode": "cn2",
     "releaseDate": "2016-08-26",
     "border": "black",
     "type": "conspiracy",

--- a/shared/set_configs/duel_decks/DDQ.json
+++ b/shared/set_configs/duel_decks/DDQ.json
@@ -2,6 +2,7 @@
   "SET": {
     "name": "Duel Decks: Blessed vs. Cursed",
     "code": "DDQ",
+    "magicCardsInfoCode": "ddq",
     "releaseDate": "2016-02-26",
     "border": "black",
     "type": "duel deck",

--- a/shared/set_configs/duel_decks/DDR.json
+++ b/shared/set_configs/duel_decks/DDR.json
@@ -3,6 +3,7 @@
   "SET": {
     "name": "Duel Decks: Nissa vs. Ob Nixilis",
     "code": "DDR",
+    "magicCardsInfoCode": "ddr",
     "releaseDate": "2016-09-02",
     "type": "duel deck",
     "border": "black"

--- a/shared/set_configs/duel_decks/DDS.json
+++ b/shared/set_configs/duel_decks/DDS.json
@@ -3,6 +3,7 @@
   "SET": {
     "name": "Duel Decks: Mind vs. Might",
     "code": "DDS",
+    "magicCardsInfoCode": "dds",
     "releaseDate": "2017-03-31",
     "type": "duel deck",
     "border": "black"

--- a/shared/set_configs/ftv/V16.json
+++ b/shared/set_configs/ftv/V16.json
@@ -3,6 +3,7 @@
   "SET": {
     "name": "From the Vault: Lore",
     "code": "V16",
+    "magicCardsInfoCode": "v16",
     "releaseDate": "2016-08-19",
     "border": "black",
     "type": "from the vault"

--- a/shared/set_configs/masterpiece/MPS_AKH.json
+++ b/shared/set_configs/masterpiece/MPS_AKH.json
@@ -3,6 +3,7 @@
     "name": "Masterpiece Series: Amonkhet Invocations",
     "alternativeNames": [ "Amonkhet Invocations" ],
     "code": "MPS_AKH",
+    "magicCardsInfoCode": "mpsakh",
     "releaseDate": "2017-04-28",
     "border": "black",
     "type": "masterpiece"

--- a/shared/set_configs/masters/EMA.json
+++ b/shared/set_configs/masters/EMA.json
@@ -2,6 +2,7 @@
   "SET": {
     "name": "Eternal Masters",
     "code": "EMA",
+    "magicCardsInfoCode": "ema",
     "releaseDate": "2016-06-10",
     "border": "black",
     "type": "reprint",

--- a/shared/set_configs/masters/MM3.json
+++ b/shared/set_configs/masters/MM3.json
@@ -2,6 +2,7 @@
   "SET": {
     "name": "Modern Masters 2017 Edition",
     "code": "MM3",
+    "magicCardsInfoCode": "mm3",
     "releaseDate": "2017-03-17",
     "border": "black",
     "type": "reprint",

--- a/shared/set_configs/planechase/PCA.json
+++ b/shared/set_configs/planechase/PCA.json
@@ -2,6 +2,7 @@
   "SET": {
     "name": "Planechase Anthology",
     "code": "PCA",
+    "magicCardsInfoCode": "pca",
     "releaseDate": "2016-11-25",
     "border": "black",
     "type": "planechase"

--- a/web/changelog.json
+++ b/web/changelog.json
@@ -1,5 +1,33 @@
 [
   {
+    "version": "3.10.1",
+    "when": "2017-07-23",
+    "changes": [
+      "Add magiccards.info code to a number of sets",
+      "Fix some mciNumber bugs"
+    ],
+    "updatedSetFiles": [
+      "AER", "AER-x",
+      "AKH", "AKH-x",
+      "ATH", "ATH-x",
+      "C16", "C16-x",
+      "CN2", "CN2-x",
+      "DDQ", "DDQ-x",
+      "DDR", "DDR-x",
+      "DDS", "DDS-x",
+      "EMA", "EMA-x",
+      "HOU", "HOU-x",
+      "KLD", "KLD-x",
+      "MM3", "MM3-x",
+      "MPS_AKH", "MPS_AKH-x",
+      "PCA", "PCA-x",
+      "SOI", "SOI-x",
+      "V16", "V16-x",
+      "W16", "W16-x",
+      "W17", "W17-x"
+    ]
+  },
+  {
     "version": "3.10.0",
     "when": "2017-07-20",
     "changes": [


### PR DESCRIPTION
- Add magicCardsInfoCode to a number of sets
- Set ATH as `isMCISet: true`
- Fix some bugs in mciNumber processing
- Rebuild a bunch of sets

Issues:
- fixes #252 
- fixes #273 
- fixes #211 
- fixes #260