### PR TITLE
webpage: adjust utf8 text hint

### DIFF
--- a/web/index.pug
+++ b/web/index.pug
@@ -71,7 +71,7 @@ block contents
 		p
 			| Data is available in AllSets, AllCards or by 
 			a(href="sets.html") individual sets
-		p All files are UTF8 encoded. There are UTF8 characters (such as Æther Adept) in many of the files.
+		p All files are UTF8 encoded. There are UTF8 characters (such as "El-Hajjâj" or em dashes "—") in many of the files.
 		p 
 			| JSONP support (
 			a(href="/documentation.html#jsonp") docs


### PR DESCRIPTION
fix #448

no more "Æ"
use other examples instead