### PR TITLE
Added updatedSetFiles section for C17

### DIFF
--- a/web/changelog.json
+++ b/web/changelog.json
@@ -12,6 +12,9 @@
     "when": "2017-08-16",
     "changes": [
       "Commander 2017"
+    ],
+    "updatedSetFiles": [
+      "C17", "C17-x"
     ]
   },
   {


### PR DESCRIPTION
Just noticed the updatedSetFiles section for C17 was missing in the changelog.json.