### PR TITLE
Ignore "exploded the internet" pages

### DIFF
--- a/shared/shared.js
+++ b/shared/shared.js
@@ -663,7 +663,8 @@ exports.getURLAsDoc = function(targetURL, getCb) {
                 err = new Error('Server responded with statusCode: ' + response.statusCode);
             if (!err && (!body || body.length === 0))
                 err = new Error('No page contents');
-            if (!err && body.indexOf('Server Error') !== -1)
+            if (!err && (body.indexOf('Server Error') !== -1) ||
+                         body.indexOf('You Just Exploded the Internet.') !== -1 )
                 err = new Error('Gatherer Server Error despite statusCode: ' + response.statusCode);
             if (err) {
                 base.error('Error downloading: %s', targetURL);


### PR DESCRIPTION
Sometimes gatherer has server errors but decides to use http return code 200 (success) instead of 500 (server error). To catch these cases, we match against error messages in the body of the response. This PR adds handling for another error message: "You Just Exploded the Internet."

This should decrease the occurrence of #482 (but probably doesn't solve all of them).