### PR TITLE
Create PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,1 @@
+<!-- Make sure to update the changelog.json file in the "web" folder with your PR! -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,5 @@
-<!-- Make sure to update the changelog.json file in the "web" folder with your PR! -->
+<!--
+Make sure to update the "changelog.json" file in the "/web" folder as well!
+Use version style X.Y.Z (X = incompatible/breaking change | Y = new set | Z = fix)
+Don't forget to add "updatedSetFiles" once you touch any set.json files in "/json".
+-->


### PR DESCRIPTION
Add a very first simple template to remind contributors to update the changelog, too.

Text is commented out that it doesn't appear in the pr text if you don't remove it. Will be shown in create pr window, though:
```
<!--
Make sure to update the "changelog.json" file in the "/web" folder as well!
Use version style X.Y.Z (X = incompatible/breaking change | Y = new set | Z = fix)
Don't forget to add "updatedSetFiles" once you touch any set.json files in "/json".
-->
```

I don't intent to change the changelog for this one, since i feel the changelog is only for output related changes.