### PR TITLE
update translations in rix set info

### DIFF
--- a/shared/set_configs/RIX.json
+++ b/shared/set_configs/RIX.json
@@ -11,12 +11,12 @@
       ["rare", "mythic rare"], "uncommon", "uncommon", "uncommon", "common", "common", "common", "common", "common", "common", "common", "common", "common", "common", "land", "marketing"
     ],
     "translations": {
-      "de": "Ixalan",
-      "fr": "Ixalan",
-      "it": "Ixalan",
-      "es": "Ixalan",
-      "pt": "Ixalan",
-      "ru": "Ixalan"
+      "de": "Rivalen von Ixalan",
+      "fr": "Les combattants d'Ixalan",
+      "it": "Rivali di Ixalan",
+      "es": "Rivales de Ixalan",
+      "pt": "Rivais de Ixalan",
+      "ru": "Борьба за Иксалан"
     },
     "mkm_name": "Ixalan",
     "mkm_id": 114

--- a/web/changelog.json
+++ b/web/changelog.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "3.12.8",
+    "when": "2018-01-10",
+    "changes": [
+      "RIX: fix translated set names"
+    ]
+  },
+  {
     "version": "3.12.7",
     "when": "2018-01-10",
     "changes": [


### PR DESCRIPTION
follow up to https://github.com/mtgjson/mtgjson/pull/526
cc @DanielHeath: you missed that :)

i don't know about mkm name and id. :(

also missing at all in the files are translations for chinese.

RIX:
- zh-hans (simplified chinese): 决胜依夏兰
- zh-hant (traditional chinese): 決勝依夏蘭