### PR TITLE
Fix release date

### DIFF
--- a/json/V17.json
+++ b/json/V17.json
@@ -2,7 +2,7 @@
   "name": "From the Vault: Transform",
   "code": "V17",
   "magicCardsInfoCode": "v17",
-  "releaseDate": "2015-11-24",
+  "releaseDate": "2017-11-24",
   "border": "black",
   "type": "from the vault",
   "mkm_name": "From the Vault: Transform",

--- a/web/changelog.json
+++ b/web/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "3.13.2",
+    "when": "2018-02-27",
+    "changes": [
+      "Fix release date of From the Vault: Transform"
+    ],
+    "updatedSetFiles": [
+      "V17.json"
+    ]
+  },
+  {
     "verison": "3.13.1",
     "when": "2018-01-21",
     "changes": [


### PR DESCRIPTION
Year of release date was incorrect, see: https://magic.wizards.com/en/products/vault-transform

fixes #550 