### PR TITLE
update language map

### DIFF
--- a/mtgjson4/mtg_global.py
+++ b/mtgjson4/mtg_global.py
@@ -757,15 +757,17 @@ SYMBOL_MAP: Dict[str, str] = {
 }
 
 LANGUAGE_MAP: Dict[str, str] = {
-    'cn': 'Chinese Traditional',
     'de': 'German',
     'en': 'English',
     'es': 'Spanish',
     'fr': 'French',
     'it': 'Italian',
     'jp': 'Japanese',
+    'ko': 'Korean',
     'pt': 'Portuguese (Brazil)',
-    'ru': 'Russian'
+    'ru': 'Russian',
+    'zh-Hans': 'Chinese Simplified',
+    'zh-Hant': 'Chinese Traditional'
 }
 
 # These file names cannot be used on WindowsOS

--- a/mtgjson4/mtg_global.py
+++ b/mtgjson4/mtg_global.py
@@ -766,8 +766,8 @@ LANGUAGE_MAP: Dict[str, str] = {
     'ko': 'Korean',
     'pt': 'Portuguese (Brazil)',
     'ru': 'Russian',
-    'zh-Hans': 'Chinese Simplified',
-    'zh-Hant': 'Chinese Traditional'
+    'zh-hans': 'Chinese Simplified',
+    'zh-hant': 'Chinese Traditional'
 }
 
 # These file names cannot be used on WindowsOS


### PR DESCRIPTION
<!-- Thanks for submitting this change to help improve upon MTGJSONv4! If you have any questions, please don't hesitate to ask. -->

Fixes #19

This might break languages on other places.

There is no 2 digit code to distinguish between simplified and traditional chinese:
https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

So I went with what others use for those two as well.
**Edit: we use it at other places already: https://github.com/mtgjson/mtgjson-python/blob/master/mtgjson4/set_configs/normal/OGW.json#L13-L23**

Actually, Brazilian Portuguese (if they really print that) could be `pt_BR` or something.