### PR TITLE
Fixes for some cards with outdated/missing oracle text.

### DIFF
--- a/build/rip.js
+++ b/build/rip.js
@@ -116,7 +116,8 @@ var SYMBOL_CONVERSION_MAP = {
     "500"                : "500",
     "1000000"            : "1000000",
     "infinite"           : "∞",
-    "half a red"         : "hr"
+    "half a red"         : "hr",
+    "half a white"       : "hw"
 };
 
 var TEXT_TO_SYMBOL_MAP = {

--- a/shared/C.js
+++ b/shared/C.js
@@ -54,7 +54,7 @@
     [
       "recalculateStandard",
       { match : {name : "Draco"}, replace : {text : "Domain — Draco costs {2} less to cast for each basic land type among lands you control.\nFlying\nDomain — At the beginning of your upkeep, sacrifice Draco unless you pay {10}. This cost is reduced by {2} for each basic land type among lands you control."}},
-      { match : {name : "Spawnsire of Ulamog"}, replace : {text : "Annihilator 1 (Whenever this creature attacks, defending player sacrifices a permanent.)\n{4}: Create two 0/1 colorless Eldrazi Spawn creature tokens. They have \"Sacrifice this creature: Add {C} to your mana pool.\"\n{20}: Cast any number of Eldrazi cards you own from outside the game without paying their mana costs."}},
+      { match : {name : "Spawnsire of Ulamog"}, replace : {text : "Annihilator 1 (Whenever this creature attacks, defending player sacrifices a permanent.)\n{4}: Create two 0/1 colorless Eldrazi Spawn creature tokens. They have \"Sacrifice this creature: Add {C}.\"\n{20}: Cast any number of Eldrazi cards you own from outside the game without paying their mana costs."}},
       { match : {name : "Jade Statue"}, remove : ["power", "toughness"] },
       { match : {name : "Ghostfire"}, remove : ["colors"] },
       { match : {name : "Will-O'-The-Wisp"}, replace : {name : "Will-o'-the-Wisp"}},

--- a/shared/set_configs/promo/pHHO.json
+++ b/shared/set_configs/promo/pHHO.json
@@ -39,8 +39,8 @@
         "printings": ["pHHO"]
       }
     },
-    {"match": {"name": "Mishra's Toy Workshop"}, "replace": {"artist": "Jung Park"}},
-    {"match": {"name": "Gifts Given"}, "replace": {"text": "Search target opponent's library for four cards with different names and reveal them. That player chooses two of those cards. Put the chosen cards into the player's graveyard and the rest into your hand. Then that player shuffles his or her library."}},
+    {"match": {"name": "Mishra's Toy Workshop"}, "replace": {"text": "{T}: Add {3}. Spend this mana only on spells and abilities that create tokens. Use toys to represent the tokens.", "artist": "Jung Park"}},
+    {"match": {"name": "Gifts Given"}, "replace": {"text": "Search target opponent's library for four cards with different names and reveal them. That player chooses two of those cards. Put the chosen cards into the player's graveyard and the rest into your hand. Then that player shuffles their library."}},
     {"match": {"name": "Evil Presents"}, "replace": {"flavor": "'Tis better to give than to receive."}},
     {"match": {"name": "Gifts Given"}, "replace": {"flavor": "\"Thanks! You shouldn't have.\""}},
     {"match": {"name": "Season's Beatings"}, "replace": {"flavor": "Arriving home, he suddenly longed for the bloodsoaked battlefields behind him."}}

--- a/shared/set_configs/un/UGL.json
+++ b/shared/set_configs/un/UGL.json
@@ -14,15 +14,18 @@
   "SET_CORRECTIONS": [{
     "match": {
       "name": "B.F.M. (Big Furry Monster)",
-      "number": "28b"
+      "number": "28a"
     },
     "replace": {
+      "type": "Creature -- The Biggest, Baddest, Nastiest,",
       "imageName": "b.f.m. 1",
-      "number": "28"
-    }
+      "number": "28",
+      "text": "You must cast both B.F.M. cards to put\nleaves the battlefield, sacrifice the other.\nB.F.M. can't be blocked except by three or"
+    },
+    "remove" : ["power","toughness","manaCost"]
   }, {
     "match": {
-      "name": "B.F.M. (Big Furry Monster)",
+      "name": "B.F.M. (Big Furry Monster, Right Side)",
       "number": "29b"
     },
     "replace": {

--- a/shared/set_configs/un/UNH.json
+++ b/shared/set_configs/un/UNH.json
@@ -170,11 +170,28 @@
       }
     }
   }, {
+    "copyCard": "Curse of the Fire Penguin Creature",
+    "replace": {
+      "name": "Curse of the Fire Penguin",
+      "type": "Enchantment -- Aura",
+      "text": "Enchant creature\nCurse of the Fire Penguin consumes and confuses enchanted creature.",
+      "originalText": "Curse of the Fire Penguin consumes and confuses enchanted creature.",
+      "originalType": "Enchant creature"
+    },
+    "remove": ["power","toughness"]
+  }, {
     "match": {
       "name": "Yet Another Æther Vortex"
     },
     "replace": {
       "name": "Yet Another Aether Vortex"
+    }
+  }, {
+    "match": {
+      "name": "Mox Lotus"
+    },
+    "replace": {
+      "text": "{T}: Add {∞}.\n{100}: Add one mana of any color."
     }
   }]
 }


### PR DESCRIPTION
These commits fix the following cards:
* Spawnsire of Ulamog
* Curese of the Fire Penguin
* Gifts Given
* Mishra’s Toy Workshop
* Little Girl
* B.F.M. (Big Furry Monster)
* Mox Lotus

<!--
Make sure to update the "changelog.json" file in the "/web" folder as well!
Use version style X.Y.Z (X = incompatible/breaking change | Y = new set | Z = fix)
Don't forget to add "updatedSetFiles" once you touch any set.json files in "/json".
-->