### PR TITLE
C18 metadata

### DIFF
--- a/mtgjson4/set_configs/commander/C18.json
+++ b/mtgjson4/set_configs/commander/C18.json
@@ -1,0 +1,9 @@
+{
+  "SET": {
+    "name": "Commander 2018",
+    "code": "C18",
+    "releaseDate": "2018-08-10",
+    "border": "black",
+    "type": "commander"
+  }
+}


### PR DESCRIPTION
[Commander 2018](https://magic.wizards.com/en/products/Commander-2018) is coming out.

It seems that some but not all sets have extra fields like translations etc., just added same fields as C17 had.