### PR TITLE
Address split/meld card issues

### DIFF
--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -370,11 +370,10 @@ def build_mtgjson_card(  # pylint: disable=too-many-branches
     # Handle meld issues
     if "all_parts" in sf_card:
         mtgjson_card["names"] = []
-        for a_part in sf_card["all_parts"]:
-            if "//" in a_part.get("name"):
-                mtgjson_card["names"] = a_part.get("name").split(" // ")
-                break
-            mtgjson_card["names"].append(a_part.get("name"))
+        for card_part in sf_card["all_parts"]:
+            mtgjson_card["names"].extend(
+                name.strip() for name in card_part.get("name", "").split("//")
+            )
 
     # Characteristics that we cannot get from Scryfall
     # Characteristics we have to do further API calls for

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -370,6 +370,9 @@ def build_mtgjson_card(  # pylint: disable=too-many-branches
     if "all_parts" in sf_card:
         mtgjson_card["names"] = []
         for a_part in sf_card["all_parts"]:
+            if "//" in a_part.get("name"):
+                mtgjson_card["names"] = a_part.get("name").split(" // ")
+                break
             mtgjson_card["names"].append(a_part.get("name"))
 
     # Characteristics that we cannot get from Scryfall

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -370,10 +370,11 @@ def build_mtgjson_card(  # pylint: disable=too-many-branches
     # Handle meld issues
     if "all_parts" in sf_card:
         mtgjson_card["names"] = []
-        for card_part in sf_card["all_parts"]:
-            mtgjson_card["names"].extend(
-                name.strip() for name in card_part.get("name", "").split("//")
-            )
+        for a_part in sf_card["all_parts"]:
+            if "//" in a_part.get("name"):
+                mtgjson_card["names"] = a_part.get("name").split(" // ")
+                break
+            mtgjson_card["names"].append(a_part.get("name"))
 
     # Characteristics that we cannot get from Scryfall
     # Characteristics we have to do further API calls for

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -228,7 +228,8 @@ def get_cmc(mana_cost: str) -> float:
 
     symbol: List[str] = re.findall(r"{([\s\S]*?)}", mana_cost)
     for element in symbol:
-        element = element.split("/")[0]  # Address 2/W, G/W, etc as "higher" cost always first
+        # Address 2/W, G/W, etc as "higher" cost always first
+        element = element.split("/")[0]
         if isinstance(element, (int, float)):
             total += float(element)
         elif element in ["X", "Y", "Z"]:  # Placeholder mana
@@ -388,7 +389,9 @@ def build_mtgjson_card(  # pylint: disable=too-many-branches
             mtgjson_card["originalType"] = gatherer_card.original_types
             mtgjson_card["originalText"] = gatherer_card.original_text
         except IndexError:
-            LOGGER.warning("Unable to parse originals for {}".format(mtgjson_card["name"]))
+            LOGGER.warning(
+                "Unable to parse originals for {}".format(mtgjson_card["name"])
+            )
 
     mtgjson_cards.append(mtgjson_card)
     return mtgjson_cards

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-contextvars
-bs4
+beautifulsoup4
 requests
 urllib3


### PR DESCRIPTION
Fix #91 
Fix #90 

This fixes the split card issues with weird values in the "names" field. The issue with Meld card is also somewhat addressed here, given the following structure:
```
Card A
Combined Card
Card B
```

This format seems to hold consistent with all EMN meld cards that I looked at. You can view the compiled file at [EMN.json.txt](https://github.com/mtgjson/mtgjson4/files/2531012/EMN.json.txt)

Two other files I was testing with: [AKH.json.txt](https://github.com/mtgjson/mtgjson4/files/2531018/AKH.json.txt) and [C18.json.txt](https://github.com/mtgjson/mtgjson4/files/2531019/C18.json.txt)