### PR TITLE
Add set cards count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+venv3.7/
 
 # Spyder project settings
 .spyderproject

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,3 +2,4 @@ black
 isort
 mypy
 pylint
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,14 @@
 [tox]
-envlist = yapf-inplace, mypy, lint
+envlist = black-inplace, mypy, lint
 
 [testenv]
 basepython = python3.7
+
+[testenv:black-inplace]
+description = Run black and edit all files in place
+skip_install = True
+deps = black
+commands = black mtgjson4/
 
 # Active Tests
 [testenv:yapf-inplace]


### PR DESCRIPTION
Fix #48 

This will add two top-level pairs to the JSON; `totalSetSize` and `baseSetSize`. baseSetSize will be the total # of cards printed in the set that can appear in boosters (Think X/297; will be 297 here). totalSetSize will be the total # of cards printed that have the set symbol (Say X/297 had 11 cards printed in planeswalker decks or what have you, then this would be 308)

Example can be found here: [DOM.json.txt](https://github.com/mtgjson/mtgjson4/files/2531673/DOM.json.txt)

Also adds tox as requirement and adds a tox test.

( I modified the old function to return a tuple as there's no reason to re-poll the scryfall API to get this data if we already have it downloaded )