### PR TITLE
Add SetCodes.json to the build process

### DIFF
--- a/mtgjson4/__main__.py
+++ b/mtgjson4/__main__.py
@@ -6,7 +6,7 @@ import json
 import logging
 import pathlib
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import mtgjson4
 from mtgjson4 import compile_mtg
@@ -70,7 +70,9 @@ def win_os_fix(set_name: str) -> str:
 
 
 def write_to_file(
-    set_name: str, file_contents: Dict[str, Any], do_cleanup: bool = False
+    set_name: str,
+    file_contents: Union[Dict[str, Any], List[str]],
+    do_cleanup: bool = False,
 ) -> None:
     """
     Write the compiled data to a file with the set's code
@@ -80,7 +82,7 @@ def write_to_file(
     with pathlib.Path(
         mtgjson4.COMPILED_OUTPUT_DIR, win_os_fix(set_name) + ".json"
     ).open("w", encoding="utf-8") as f:
-        if do_cleanup:
+        if do_cleanup and isinstance(file_contents, dict):
             if "cards" in file_contents:
                 file_contents["cards"] = compile_mtg.remove_unnecessary_fields(
                     file_contents["cards"]

--- a/mtgjson4/__main__.py
+++ b/mtgjson4/__main__.py
@@ -134,7 +134,12 @@ def compile_and_write_outputs() -> None:
     of AllSets.json and AllCards.json
     """
     # Files that should not be combined into compiled outputs
-    files_to_ignore: List[str] = ["AllSets.json", "AllCards.json", "SetCodes.json", "SetList.json"]
+    files_to_ignore: List[str] = [
+        "AllSets.json",
+        "AllCards.json",
+        "SetCodes.json",
+        "SetList.json",
+    ]
 
     # Actual compilation process of the method
     all_sets = create_all_sets(files_to_ignore)
@@ -252,7 +257,13 @@ def get_all_set_list(files_to_ignore: List[str]) -> List[Dict[str, str]]:
 
         with set_file.open("r", encoding="utf-8") as f:
             file_content = json.load(f)
-            all_sets_data.append({"name": file_content["name"], "code": file_content["code"], "releaseDate": file_content["releaseDate"]})
+            all_sets_data.append(
+                {
+                    "name": file_content["name"],
+                    "code": file_content["code"],
+                    "releaseDate": file_content["releaseDate"],
+                }
+            )
 
     return sorted(all_sets_data)
 

--- a/mtgjson4/__main__.py
+++ b/mtgjson4/__main__.py
@@ -134,7 +134,7 @@ def compile_and_write_outputs() -> None:
     of AllSets.json and AllCards.json
     """
     # Files that should not be combined into compiled outputs
-    files_to_ignore: List[str] = ["AllSets.json", "AllCards.json", "SetCodes.json"]
+    files_to_ignore: List[str] = ["AllSets.json", "AllCards.json", "SetCodes.json", "SetList.json"]
 
     # Actual compilation process of the method
     all_sets = create_all_sets(files_to_ignore)
@@ -145,6 +145,9 @@ def compile_and_write_outputs() -> None:
 
     all_set_names = get_all_set_names(files_to_ignore)
     write_to_file("SetCodes", all_set_names)
+
+    compiled_set_info = get_all_set_list(files_to_ignore)
+    write_to_file("SetList", compiled_set_info)
 
 
 def create_all_sets(files_to_ignore: List[str]) -> Dict[str, Any]:
@@ -228,6 +231,28 @@ def get_all_set_names(files_to_ignore: List[str]) -> List[str]:
         if set_file.name in files_to_ignore:
             continue
         all_sets_data.append(set_file.name.split(".")[0].upper())
+
+    return sorted(all_sets_data)
+
+
+def get_all_set_list(files_to_ignore: List[str]) -> List[Dict[str, str]]:
+    """
+    This will create the SetList.json file
+    by getting the info from all the files in
+    the set_outputs folder and combining
+    them into the old v3 structure.
+    :param files_to_ignore: Files to ignore in set_outputs folder
+    :return: List of all set dicts
+    """
+    all_sets_data: List[Dict[str, str]] = []
+
+    for set_file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.json"):
+        if set_file.name in files_to_ignore:
+            continue
+
+        with set_file.open("r", encoding="utf-8") as f:
+            file_content = json.load(f)
+            all_sets_data.append({"name": file_content["name"], "code": file_content["code"], "releaseDate": file_content["releaseDate"]})
 
     return sorted(all_sets_data)
 

--- a/mtgjson4/__main__.py
+++ b/mtgjson4/__main__.py
@@ -6,7 +6,7 @@ import json
 import logging
 import pathlib
 import sys
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 import mtgjson4
 from mtgjson4 import compile_mtg
@@ -69,11 +69,7 @@ def win_os_fix(set_name: str) -> str:
     return set_name
 
 
-def write_to_file(
-    set_name: str,
-    file_contents: Union[Dict[str, Any], List[str]],
-    do_cleanup: bool = False,
-) -> None:
+def write_to_file(set_name: str, file_contents: Any, do_cleanup: bool = False) -> None:
     """
     Write the compiled data to a file with the set's code
     Will ensure the output directory exists first
@@ -259,9 +255,9 @@ def get_all_set_list(files_to_ignore: List[str]) -> List[Dict[str, str]]:
             file_content = json.load(f)
             all_sets_data.append(
                 {
-                    "name": file_content["name"],
-                    "code": file_content["code"],
-                    "releaseDate": file_content["releaseDate"],
+                    "name": file_content.get("name", None),
+                    "code": file_content.get("code", None),
+                    "releaseDate": file_content.get("releaseDate", None),
                 }
             )
 
@@ -326,7 +322,7 @@ def main() -> None:
                 write_to_file(set_code.upper(), compiled, do_cleanup=True)
 
     if args.compiled_outputs:
-        LOGGER.info("Compiling AllSets, AllCards, and SetCodes")
+        LOGGER.info("Compiling AllSets, AllCards, SetCodes, and SetList")
         compile_and_write_outputs()
 
 


### PR DESCRIPTION
Fix #60 

Follows similar methods to gen AllCards/AllSets. 
Small Example: [SetCodes.json.txt](https://github.com/mtgjson/mtgjson4/files/2531752/SetCodes.json.txt)
