### PR TITLE
Add letters to appending numbers for SPLIT-type cards, excluding meld

### DIFF
--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -347,8 +347,14 @@ def build_mtgjson_card(  # pylint: disable=too-many-branches
     mtgjson_card["isOnlineOnly"] = sf_card.get("digital")  # bool
     mtgjson_card["isOversized"] = sf_card.get("oversized")  # bool
     mtgjson_card["layout"] = sf_card.get("layout")  # str
-    mtgjson_card["number"] = sf_card.get("collector_number")  # str
     mtgjson_card["isReserved"] = sf_card.get("reserved")  # bool
+
+    # Append a lower-case letter to the number if it's a "split" type card
+    # Will only work for two faced cards (not meld, as they don't need this)
+    mtgjson_num = sf_card.get("collector_number")
+    if "names" in mtgjson_card and len(mtgjson_card["names"]) == 2:
+        mtgjson_num += chr(mtgjson_card["names"].index(mtgjson_card["name"]) + 97)
+    mtgjson_card["number"] = mtgjson_num
 
     if "uuid" not in mtgjson_card:
         mtgjson_card["uuid"] = sf_card.get("id")  # str

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -351,8 +351,9 @@ def build_mtgjson_card(  # pylint: disable=too-many-branches
 
     # Append a lower-case letter to the number if it's a "split" type card
     # Will only work for two faced cards (not meld, as they don't need this)
-    mtgjson_num = sf_card.get("collector_number")
+    mtgjson_num: str = sf_card["collector_number"]
     if "names" in mtgjson_card and len(mtgjson_card["names"]) == 2:
+        # chr(97) = 'a', chr(98) = 'b', ...
         mtgjson_num += chr(mtgjson_card["names"].index(mtgjson_card["name"]) + 97)
     mtgjson_card["number"] = mtgjson_num
 

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -347,8 +347,8 @@ def build_mtgjson_card(  # pylint: disable=too-many-branches
     mtgjson_card["isOnlineOnly"] = sf_card.get("digital")  # bool
     mtgjson_card["isOversized"] = sf_card.get("oversized")  # bool
     mtgjson_card["layout"] = sf_card.get("layout")  # str
+    mtgjson_card["number"] = sf_card.get("collector_number")
     mtgjson_card["isReserved"] = sf_card.get("reserved")  # bool
-    mtgjson_card["number"] = sf_card["collector_number"]
 
     # Add a "side" entry for split cards
     # Will only work for two faced cards (not meld, as they don't need this)

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -348,14 +348,15 @@ def build_mtgjson_card(  # pylint: disable=too-many-branches
     mtgjson_card["isOversized"] = sf_card.get("oversized")  # bool
     mtgjson_card["layout"] = sf_card.get("layout")  # str
     mtgjson_card["isReserved"] = sf_card.get("reserved")  # bool
+    mtgjson_card["number"] = sf_card["collector_number"]
 
-    # Append a lower-case letter to the number if it's a "split" type card
+    # Add a "side" entry for split cards
     # Will only work for two faced cards (not meld, as they don't need this)
-    mtgjson_num: str = sf_card["collector_number"]
     if "names" in mtgjson_card and len(mtgjson_card["names"]) == 2:
         # chr(97) = 'a', chr(98) = 'b', ...
-        mtgjson_num += chr(mtgjson_card["names"].index(mtgjson_card["name"]) + 97)
-    mtgjson_card["number"] = mtgjson_num
+        mtgjson_card["side"] = chr(
+            mtgjson_card["names"].index(mtgjson_card["name"]) + 97
+        )
 
     if "uuid" not in mtgjson_card:
         mtgjson_card["uuid"] = sf_card.get("id")  # str

--- a/mtgjson4/provider/gatherer.py
+++ b/mtgjson4/provider/gatherer.py
@@ -6,7 +6,6 @@ import logging
 from typing import List, NamedTuple, Optional
 
 import bs4
-
 from mtgjson4 import util
 
 LOGGER = logging.getLogger(__name__)

--- a/mtgjson4/provider/scryfall.py
+++ b/mtgjson4/provider/scryfall.py
@@ -6,11 +6,10 @@ import logging
 import pathlib
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-import requests
-import requests.adapters
-
 import mtgjson4
 from mtgjson4 import util
+import requests
+import requests.adapters
 
 LOGGER = logging.getLogger(__name__)
 SESSION: contextvars.ContextVar = contextvars.ContextVar("SESSION")


### PR DESCRIPTION
Fix #110 

~~This adds a letter to split cards' number field to help distinguish them better. Follows V3 formats. Will NOT append letters to meld cards.~~

~~Example: [DGM.json.txt](https://github.com/mtgjson/mtgjson4/files/2550406/DGM.json.txt)~~

This will add a "side" key with value "a", "b", ... for the side/face of the split card. Does NOT affect number
