### PR TITLE
Do not add tokens to the NAMES field

### DIFF
--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -388,7 +388,10 @@ def build_mtgjson_card(  # pylint: disable=too-many-branches
             if "//" in a_part.get("name"):
                 mtgjson_card["names"] = a_part.get("name").split(" // ")
                 break
-            mtgjson_card["names"].append(a_part.get("name"))
+
+            # If the card is a token, we are to ignore it. Only real card parts are added.
+            if "/t{}/".format(sf_card.get("set").lower()) not in a_part.get("uri"):
+                mtgjson_card["names"].append(a_part.get("name"))
 
     # Characteristics that we cannot get from Scryfall
     # Characteristics we have to do further API calls for

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -390,7 +390,7 @@ def build_mtgjson_card(  # pylint: disable=too-many-branches
                 break
 
             # If the card is a token, we are to ignore it. Only real card parts are added.
-            if "/t{}/".format(sf_card.get("set").lower()) not in a_part.get("uri"):
+            if "/t{}/".format(sf_card["set"].lower()) not in a_part.get("uri"):
                 mtgjson_card["names"].append(a_part.get("name"))
 
     # Characteristics that we cannot get from Scryfall


### PR DESCRIPTION
Fix #112 

In 4.0.2, tokens were (mistakenly) added to the `names` field for cards. This fixes that.



Examples
___
Before: [SOI.old.json.txt](https://github.com/mtgjson/mtgjson4/files/2557741/SOI.old.json.txt)
Now: [SOI.json.txt](https://github.com/mtgjson/mtgjson4/files/2557740/SOI.json.txt)

Before: [XLN.old.json.txt](https://github.com/mtgjson/mtgjson4/files/2557743/XLN.old.json.txt)
Now: [XLN.json.txt](https://github.com/mtgjson/mtgjson4/files/2557742/XLN.json.txt)

