### PR TITLE
Fix Names and AllCards

### DIFF
--- a/mtgjson4/__main__.py
+++ b/mtgjson4/__main__.py
@@ -176,9 +176,10 @@ def create_all_cards(files_to_ignore: List[str]) -> Dict[str, Any]:
             duplicate_cards: Dict[str, int] = {}
 
             for card in file_content["cards"]:
+                # Only if a card is duplicated in a set will it get the (a), (b) appended
                 if (
-                    card["name"] in all_cards_data.keys()
-                    or card["name"] in duplicate_cards
+                    card["name"] in duplicate_cards
+                    or file_content["cards"].count(card["name"]) > 1
                 ):
                     if card["name"] in mtgjson4.BASIC_LANDS:
                         pass

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -402,7 +402,10 @@ def build_mtgjson_card(  # pylint: disable=too-many-branches
                 mtgjson_card["names"].append(a_part.get("name"))
 
         # If the only entry is the original card, empty the names array
-        if len(mtgjson_card["names"]) == 1 and mtgjson_card["name"] in mtgjson_card["names"]:
+        if (
+            len(mtgjson_card["names"]) == 1
+            and mtgjson_card["name"] in mtgjson_card["names"]
+        ):
             del mtgjson_card["names"]
 
     # Characteristics that we cannot get from Scryfall

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -389,17 +389,21 @@ def build_mtgjson_card(  # pylint: disable=too-many-branches
     mtgjson_card["types"] = card_types[1]  # List[str]
     mtgjson_card["subtypes"] = card_types[2]  # List[str]
 
-    # Handle meld issues
+    # Handle meld and all parts tokens issues
     if "all_parts" in sf_card:
         mtgjson_card["names"] = []
         for a_part in sf_card["all_parts"]:
-            if "//" in a_part.get("name"):
-                mtgjson_card["names"] = a_part.get("name").split(" // ")
-                break
-
             # If the card is a token, we are to ignore it. Only real card parts are added.
             if "/t{}/".format(sf_card["set"].lower()) not in a_part.get("uri"):
+                if "//" in a_part.get("name"):
+                    mtgjson_card["names"] = a_part.get("name").split(" // ")
+                    break
+
                 mtgjson_card["names"].append(a_part.get("name"))
+
+        # If the only entry is the original card, empty the names array
+        if len(mtgjson_card["names"]) == 1 and mtgjson_card["name"] in mtgjson_card["names"]:
+            del mtgjson_card["names"]
 
     # Characteristics that we cannot get from Scryfall
     # Characteristics we have to do further API calls for


### PR DESCRIPTION
Fix #119 
Fix #116 

Fixes two PRs in one issue. Will no longer create erroneous entries into the AllCards output, as well as address the "names" still having tokens.