### PR TITLE
Move the duplication checking code to the individual sets

### DIFF
--- a/mtgjson4/__main__.py
+++ b/mtgjson4/__main__.py
@@ -182,26 +182,7 @@ def create_all_cards(files_to_ignore: List[str]) -> Dict[str, Any]:
         with set_file.open("r", encoding="utf-8") as f:
             file_content = json.load(f)
 
-            duplicate_cards: Dict[str, int] = {}
-
             for card in file_content["cards"]:
-                # Only if a card is duplicated in a set will it get the (a), (b) appended
-                if (
-                    card["name"] in duplicate_cards
-                    or file_content["cards"].count(card["name"]) > 1
-                ):
-                    if card["name"] in mtgjson4.BASIC_LANDS:
-                        pass
-                    elif card["name"] in duplicate_cards:
-                        duplicate_cards[card["name"]] += 1
-                    else:
-                        duplicate_cards[card["name"]] = 98  # 'b'
-                        # Replace "Original" => "Original (a)"
-                        all_cards_data[
-                            "{0} ({1})".format(card["name"], "a")
-                        ] = all_cards_data[card["name"]]
-                        del all_cards_data[card["name"]]
-
                 # Since these can vary from printing to printing, we do not include them in the output
                 card.pop("artist", None)
                 card.pop("borderColor", None)
@@ -225,11 +206,7 @@ def create_all_cards(files_to_ignore: List[str]) -> Dict[str, Any]:
                 for foreign in card["foreignData"]:
                     foreign.pop("multiverseId", None)
 
-                key = card["name"]
-                if duplicate_cards.get(card["name"], 0) > 0:
-                    key += " ({0})".format(chr(duplicate_cards[card["name"]]))
-
-                all_cards_data[key] = card
+                all_cards_data[card["name"]] = card
 
     return all_cards_data
 

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -92,16 +92,20 @@ def uniquify_duplicates_in_set(cards: List[Dict[str, Any]]) -> List[Dict[str, An
     duplicate_cards: Dict[str, int] = {}
     for card in cards:
         # Only if a card is duplicated in a set will it get the (a), (b) appended
-        total_same_name_cards = len([item for item in cards if item["name"] == card["name"]])
+        total_same_name_cards = len(
+            [item for item in cards if item["name"] == card["name"]]
+        )
 
-        new_card = copy.deepcopy(card)
-        if (new_card["name"] not in mtgjson4.BASIC_LANDS) and (new_card["name"] in duplicate_cards or total_same_name_cards > 1):
-            if new_card["name"] in duplicate_cards:
-                duplicate_cards[new_card["name"]] += 1
+        if (card["name"] not in mtgjson4.BASIC_LANDS) and (
+            card["name"] in duplicate_cards or total_same_name_cards > 1
+        ):
+            if card["name"] in duplicate_cards:
+                duplicate_cards[card["name"]] += 1
             else:
-                duplicate_cards[new_card["name"]] = ord('a')
+                duplicate_cards[card["name"]] = ord("a")
 
             # Update the name of the card, and remove its names field (as it's not correct here)
+            new_card = copy.deepcopy(card)
             new_card["name"] += " ({0})".format(chr(duplicate_cards[new_card["name"]]))
             new_card.pop("names", None)
             unique_list.append(new_card)

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -1,4 +1,5 @@
 """Compile incoming data into the target output format."""
+import copy
 import json
 import logging
 import multiprocessing
@@ -63,6 +64,8 @@ def build_output_file(sf_cards: List[Dict[str, Any]], set_code: str) -> Dict[str
         set_code, set_config["search_uri"], card_holder
     )
 
+    card_holder = uniquify_duplicates_in_set(card_holder)
+
     output_file["totalSetSize"] = len(sf_cards)
     output_file["baseSetSize"] = output_file["totalSetSize"] - non_booster_cards
     output_file["cards"] = card_holder
@@ -75,6 +78,37 @@ def build_output_file(sf_cards: List[Dict[str, Any]], set_code: str) -> Dict[str
     LOGGER.info("Finished tokens for {}".format(set_code))
 
     return output_file
+
+
+def uniquify_duplicates_in_set(cards: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    For cards with multiple printings in a set, we need to identify
+    them against each other. We will add (a), (b), ... to the end
+    of the card name to do so.
+    :param cards: Cards to check and update for repeats
+    :return: updated cards list
+    """
+    unique_list = []
+    duplicate_cards: Dict[str, int] = {}
+    for card in cards:
+        # Only if a card is duplicated in a set will it get the (a), (b) appended
+        total_same_name_cards = len([item for item in cards if item["name"] == card["name"]])
+
+        new_card = copy.deepcopy(card)
+        if (new_card["name"] not in mtgjson4.BASIC_LANDS) and (new_card["name"] in duplicate_cards or total_same_name_cards > 1):
+            if new_card["name"] in duplicate_cards:
+                duplicate_cards[new_card["name"]] += 1
+            else:
+                duplicate_cards[new_card["name"]] = ord('a')
+
+            # Update the name of the card, and remove its names field (as it's not correct here)
+            new_card["name"] += " ({0})".format(chr(duplicate_cards[new_card["name"]]))
+            new_card.pop("names", None)
+            unique_list.append(new_card)
+        else:
+            unique_list.append(card)
+
+    return unique_list
 
 
 def add_start_flag_and_count_modified(


### PR DESCRIPTION
Before this PR, I was running the duplication checker in the AllCards file, which isn't necessarily correct. I have propagated it down to the set level. In addition, the "names" field on all cards that would be hit by this are just wrong, and they should be empty. As such, I empty them out.

[UST.json.txt](https://github.com/mtgjson/mtgjson4/files/2606596/UST.json.txt)
