### PR TITLE
Address colors for front/back of awk cards better

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,4 +11,4 @@ trim_trailing_whitespace = true
 indent_size = 2
 
 [LICENSE.txt]
-indent_size = 2
+indent_size = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ trim_trailing_whitespace = true
 
 [*.{yml,yaml,json}]
 indent_size = 2
+
+[LICENSE.txt]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,3 @@ trim_trailing_whitespace = true
 
 [*.{yml,yaml,json}]
 indent_size = 2
-
-[LICENSE.txt]
-indent_size = none

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -346,7 +346,10 @@ def build_mtgjson_card(
         mtgjson_card["manaCost"] = face_data.get("mana_cost")
 
     if "colors" not in mtgjson_card:
-        mtgjson_card["colors"] = face_data.get("colors")
+        if "colors" in face_data:
+            mtgjson_card["colors"] = face_data.get("colors")
+        else:
+            mtgjson_card["colors"] = sf_card.get("colors")
 
     mtgjson_card["name"] = face_data.get("name")
     mtgjson_card["type"] = face_data.get("type_line")


### PR DESCRIPTION
Fix #138 

Address colors not appearing for split cards that hold same identity on front/back. Will impact cards like Budoka Gardener, but not Archangel Avacyn.


[C18.json.old.txt](https://github.com/mtgjson/mtgjson4/files/2612093/C18.json.old.txt)
[C18.json.txt](https://github.com/mtgjson/mtgjson4/files/2612094/C18.json.txt)

[SOI.json.old.txt](https://github.com/mtgjson/mtgjson4/files/2612095/SOI.json.old.txt)
[SOI.json.txt](https://github.com/mtgjson/mtgjson4/files/2612096/SOI.json.txt)
