### PR TITLE
Re-implement variations field

### DIFF
--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -118,20 +118,25 @@ def uniquify_duplicates_in_set(cards: List[Dict[str, Any]]) -> List[Dict[str, An
                 unique_list.append(new_card)
             else:
                 unique_list.append(card)
+
         return unique_list
-    else:
-        for card in cards:
-            repeats_in_set = [
-                item
-                for item in cards
-                if item["name"] == card["name"] and item["uuid"] != card["uuid"]
-            ]
-            variations = []
-            for repeat in repeats_in_set:
-                variations.append(repeat["uuid"])
-            if len(variations) > 0:
-                card["variations"] = variations
-        return cards
+
+    # Non-silver border sets use "variations"
+    for card in cards:
+        repeats_in_set = [
+            item
+            for item in cards
+            if item["name"] == card["name"] and item["uuid"] != card["uuid"]
+        ]
+
+        variations = []
+        for repeat in repeats_in_set:
+            variations.append(repeat["uuid"])
+
+        if variations:
+            card["variations"] = variations
+
+    return cards
 
 
 def add_start_flag_and_count_modified(

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -97,10 +97,11 @@ def uniquify_duplicates_in_set(cards: List[Dict[str, Any]]) -> List[Dict[str, An
         duplicate_cards: Dict[str, int] = {}
         for card in cards:
             # Only if a card is duplicated in a set will it get the (a), (b) appended
-            total_same_name_cards = len(
-                [item for item in cards if item["name"] == card["name"]]
+            total_same_name_cards = sum(
+                1 for item in cards if item["name"] == card["name"]
             )
 
+            # Ignore basic lands
             if (card["name"] not in mtgjson4.BASIC_LANDS) and (
                 card["name"] in duplicate_cards or total_same_name_cards > 1
             ):
@@ -117,6 +118,7 @@ def uniquify_duplicates_in_set(cards: List[Dict[str, Any]]) -> List[Dict[str, An
                 new_card.pop("names", None)
                 unique_list.append(new_card)
             else:
+                # Not a duplicate, just put the normal card into the list
                 unique_list.append(card)
 
         return unique_list
@@ -129,10 +131,7 @@ def uniquify_duplicates_in_set(cards: List[Dict[str, Any]]) -> List[Dict[str, An
             if item["name"] == card["name"] and item["uuid"] != card["uuid"]
         ]
 
-        variations = []
-        for repeat in repeats_in_set:
-            variations.append(repeat["uuid"])
-
+        variations = [r["uuid"] for r in repeats_in_set]
         if variations:
             card["variations"] = variations
 


### PR DESCRIPTION
Fix #145 

Change the (a), (b), ... implementation for non un-sets to be a variations field instead since they're the same card in every other printing, even if multiple times in a set.

Attached is the un-set that's affected (only one) and a set that exemplifies the variations field.
[UST.json.txt](https://github.com/mtgjson/mtgjson4/files/2632157/UST.json.txt)
[WC99.json.txt](https://github.com/mtgjson/mtgjson4/files/2632158/WC99.json.txt)
