### PR TITLE
Add TCGPlayer API information & Fix Sessions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -25,7 +25,8 @@ disable=
     too-few-public-methods,
     too-many-statements,
     wrong-import-order,
-    too-many-branches
+    too-many-branches,
+    import-error
 
 
 [REPORTS]

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -1,4 +1,6 @@
 """Compile incoming data into the target output format."""
+
+import contextvars
 import copy
 import json
 import logging
@@ -8,10 +10,12 @@ import re
 from typing import Any, Dict, List, Tuple
 
 import mtgjson4
-from mtgjson4.provider import gatherer, scryfall
+from mtgjson4.provider import gatherer, scryfall, tcgplayer
 from mtgjson4.util import is_number
 
 LOGGER = logging.getLogger(__name__)
+
+SESSION: contextvars.ContextVar = contextvars.ContextVar("SESSION")
 
 
 def build_output_file(sf_cards: List[Dict[str, Any]], set_code: str) -> Dict[str, Any]:
@@ -67,6 +71,10 @@ def build_output_file(sf_cards: List[Dict[str, Any]], set_code: str) -> Dict[str
 
     card_holder = uniquify_duplicates_in_set(card_holder)
 
+    # Add TCGPlayer information
+    output_file["tcgplayerGroupId"] = tcgplayer.get_group_id(set_code.upper())
+    card_holder = add_tcgplayer_ids(output_file["tcgplayerGroupId"], card_holder)
+
     output_file["totalSetSize"] = len(sf_cards)
     output_file["baseSetSize"] = output_file["totalSetSize"] - non_booster_cards
     output_file["cards"] = card_holder
@@ -79,6 +87,26 @@ def build_output_file(sf_cards: List[Dict[str, Any]], set_code: str) -> Dict[str
     LOGGER.info("Finished tokens for {}".format(set_code))
 
     return output_file
+
+
+def add_tcgplayer_ids(
+    group_id: int, cards: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """
+    For each card in the set, we will find its tcgplayer ID
+    and add it to the card if found
+    :param group_id: group to search for the cards
+    :param cards: Cards list to add information to
+    :return: Cards list with new information added
+    """
+    tcg_card_objs = tcgplayer.get_group_id_cards(group_id)
+
+    for card in cards:
+        prod_id = tcgplayer.get_card_id(card["name"], tcg_card_objs)
+        if prod_id > 0:
+            card["tcgplayerProductId"] = prod_id
+
+    return cards
 
 
 def uniquify_duplicates_in_set(cards: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -219,6 +247,9 @@ def convert_to_mtgjson(sf_cards: List[Dict[str, Any]]) -> List[Any]:
     :param sf_cards: cards to build
     :return: list of cards built
     """
+    # Clear sessions before the fork() to prevent awk issues with urllib3
+    SESSION.set(None)
+
     with multiprocessing.Pool(processes=8) as pool:
         results: List[Any] = pool.map(build_mtgjson_card, sf_cards)
 

--- a/mtgjson4/provider/gatherer.py
+++ b/mtgjson4/provider/gatherer.py
@@ -1,5 +1,4 @@
 """Card information provider for WotC Gatherer."""
-
 import contextvars
 import copy
 import logging
@@ -73,7 +72,6 @@ def get_cards(multiverse_id: str) -> List[GathererCard]:
     )
     LOGGER.info("Retrieved: %s", response.url)
 
-    session.close()
     return parse_cards(response.text)
 
 

--- a/mtgjson4/provider/scryfall.py
+++ b/mtgjson4/provider/scryfall.py
@@ -52,7 +52,6 @@ def download(scryfall_url: str) -> Dict[str, Any]:
 
     LOGGER.info("Downloaded URL: {0}".format(scryfall_url))
 
-    session.close()
     return request_api_json
 
 

--- a/mtgjson4/provider/tcgplayer.py
+++ b/mtgjson4/provider/tcgplayer.py
@@ -1,0 +1,181 @@
+"""TCGPlayer retrieval and processing."""
+
+import configparser
+import contextvars
+import json
+import logging
+import pathlib
+from typing import Any, Dict, List, Optional
+
+import mtgjson4
+from mtgjson4 import util
+import requests
+
+LOGGER = logging.getLogger(__name__)
+SESSION: contextvars.ContextVar = contextvars.ContextVar("SESSION")
+TCGPLAYER_API_VERSION: contextvars.ContextVar = contextvars.ContextVar("API_TCGPLAYER")
+
+
+def __get_session() -> requests.Session:
+    """Get or create a requests session for TCGPlayer."""
+    session: Optional[requests.Session] = SESSION.get(None)
+    if session is None:
+        session = requests.Session()
+        header_auth = {"Authorization": "Bearer " + _request_tcgplayer_bearer()}
+        session.headers.update(header_auth)
+        session = util.retryable_session(session)
+        SESSION.set(session)
+    return session
+
+
+def _request_tcgplayer_bearer() -> str:
+    """
+    Attempt to get the latest TCGPlayer Bearer token for
+    API access. Use the credentials found in the local
+    config to contact the server.
+    :return: Empty string or current Bearer token
+    """
+    if not pathlib.Path(mtgjson4.CONFIG_PATH).is_file():
+        LOGGER.error(
+            "Unable to import TCGPlayer keys. Config at {} not found".format(
+                mtgjson4.CONFIG_PATH
+            )
+        )
+        return ""
+
+    config = configparser.RawConfigParser()
+    config.read(mtgjson4.CONFIG_PATH)
+
+    tcg_post = requests.post(
+        "https://api.tcgplayer.com/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": config.get("TCGPlayer", "client_id"),
+            "client_secret": config.get("TCGPlayer", "client_secret"),
+        },
+    )
+
+    if tcg_post.status_code != 200:
+        LOGGER.error("Unable to contact TCGPlayer. Reason: {}".format(tcg_post.reason))
+        return ""
+
+    TCGPLAYER_API_VERSION.set(config.get("TCGPlayer", "api_version"))
+    request_as_json = json.loads(tcg_post.text)
+    return str(request_as_json.get("access_token", ""))
+
+
+def download(tcgplayer_url: str, params_str: Dict[str, Any] = None) -> str:
+    """
+    Download content from TCGPlayer with a given URL that
+    can include a wildcard for default API version, as well
+    as a way to pass in custom params to the URL
+    :param tcgplayer_url: URL to get information from
+    :param params_str: Additional params to pass to TCGPlayer call
+    :return: Data from TCGPlayer API Call
+    """
+    if params_str is None:
+        params_str = {}
+
+    session = __get_session()
+
+    response = session.get(
+        url=tcgplayer_url.replace("[API_VERSION]", TCGPLAYER_API_VERSION.get("")),
+        params=params_str,
+        timeout=5.0,
+    )
+
+    LOGGER.info("Downloaded URL: {0}".format(tcgplayer_url))
+
+    if response.status_code != 200:
+        LOGGER.warning(
+            "Status Code: {} Failed to download from TCGPlayer with URL: {}, Params: {}".format(
+                response.status_code, tcgplayer_url, params_str
+            )
+        )
+        return ""
+
+    return response.text
+
+
+def get_group_id(set_code: str) -> int:
+    """
+    Find the TCGPlayer group ID for a specific set
+    :param set_code: Set to find group ID for
+    :return: Group ID or Not found (-1)
+    """
+    offset = 0
+    # TCGPlayer will only send 100 results at a time, so we need to
+    # page through the data to find the appropriate set
+    while True:
+        tcg_data = json.loads(
+            download(
+                "http://api.tcgplayer.com/[API_VERSION]/catalog/categories/1/groups",
+                {"limit": "100", "offset": offset},
+            )
+        )
+
+        if not tcg_data["results"]:
+            break
+
+        for set_content in tcg_data["results"]:
+            if set_content["abbreviation"] == set_code.upper():
+                return int(set_content.get("groupId", -1))
+
+        offset += len(tcg_data["results"])
+    return -1
+
+
+def get_group_id_cards(group_id: int) -> List[Dict[str, Any]]:
+    """
+    Given a group_id, get all the cards within that set.
+    :param group_id: Set to get all cards from
+    :return: List of card objects
+    """
+    if group_id < 0:
+        LOGGER.error(
+            "Unable to get cards from a negative group_id: {}".format(group_id)
+        )
+        return []
+
+    cards: List[Dict[str, Any]] = []
+    offset = 0
+
+    while True:
+        response = download(
+            "http://api.tcgplayer.com/[API_VERSION]/catalog/products",
+            {
+                "categoryId": "1",  # MTG
+                "groupId": group_id,
+                "productTypes": "Cards",  # Cards only
+                "limit": 100,
+                "offset": offset,
+            },
+        )
+
+        if not response:
+            break
+
+        tcg_data = json.loads(response)
+
+        if not tcg_data["results"]:
+            break
+
+        cards += tcg_data["results"]
+        offset += len(tcg_data["results"])
+
+    return cards
+
+
+def get_card_id(card_name: str, card_list: List[Dict[str, Any]]) -> int:
+    """
+    Go through the passed in card object list to find the matching
+    card from the set and get its ID.
+    :param card_name: Card to find in the list
+    :param card_list: List of card objects from TCGPlayer
+    :return: Card ID or Default (-1)
+    """
+    for card in card_list:
+        if card_name.lower() == card["name"].lower():
+            return card.get("productId", -1)
+
+    return -1

--- a/mtgjson4/provider/wizards.py
+++ b/mtgjson4/provider/wizards.py
@@ -1,4 +1,5 @@
 """File information provider for WotC Website."""
+
 import contextvars
 import logging
 import re
@@ -12,7 +13,7 @@ import unidecode
 LOGGER = logging.getLogger(__name__)
 SESSION: contextvars.ContextVar = contextvars.ContextVar("SESSION")
 
-COMP_RULES = "https://magic.wizards.com/en/game-info/gameplay/rules-and-formats/rules"
+COMP_RULES: str = "https://magic.wizards.com/en/game-info/gameplay/rules-and-formats/rules"
 
 
 def download_from_wizards(url: str) -> str:
@@ -23,10 +24,9 @@ def download_from_wizards(url: str) -> str:
     """
     session = util.get_generic_session()
     response = session.get(url=url, timeout=5.0)
-    response.encoding = "windows-1252"  # WHYYYY
+    response.encoding = "windows-1252"  # WHY DO THEY DO THIS
 
     LOGGER.info("Retrieved: %s", response.url)
-    session.close()
 
     return response.text
 


### PR DESCRIPTION
Fix #56 

Add TCGPlayer information for sets and cards for better integration with TCGPlayer API network. 
Also fix sessions not working correctly because of the fork() 

Adds `tcgplayerGroupId` to each set to indicate what the TCGPlayer set ID is
Adds `tcgplayerProductId` to each card in each set that has a `tcgplayerGroupId`

You can combine `1:tcgplayerGroupId:tcgplayerProductId` to get all the information about a specific card that you'll need via TCGPlayer API (the 1 = MagicTCG and it's a firm constant, so it's hard coded).

----

Also fixes sessions for the fork() as they were holding some stuff back here