### PR TITLE
New Compiled Outputs, Token Array Fixes, Meld Sides

### DIFF
--- a/mtgjson4/__init__.py
+++ b/mtgjson4/__init__.py
@@ -24,9 +24,12 @@ RESOURCE_PATH: pathlib.Path = TOP_LEVEL_DIR.joinpath("mtgjson4").joinpath("resou
 ALL_SETS_OUTPUT: str = "AllSets"
 ALL_CARDS_OUTPUT: str = "AllCards"
 SET_CODES_OUTPUT: str = "SetCodes"
-SET_LIST_OUTPUT: str = "SetList"
 KEY_WORDS_OUTPUT: str = "Keywords"
 VERSION_OUTPUT: str = "version"
+STANDARD_OUTPUT: str = "Standard"
+MODERN_OUTPUT: str = "Modern"
+ALL_CARDS_NO_FUN_OUTPUT: str = "AllCardsNoUn"
+ALL_SETS_NO_FUN_OUTPUT: str = "AllSetsNoUn"
 
 LANGUAGE_MAP: Dict[str, str] = {
     "en": "English",

--- a/mtgjson4/__main__.py
+++ b/mtgjson4/__main__.py
@@ -114,7 +114,7 @@ def main() -> None:
             compiled: Dict[str, Any] = compile_mtg.build_output_file(sf_set, set_code)
 
             # If we have at least 1 card, dump to file SET.json
-            if compiled["cards"]:
+            if compiled["cards"] or compiled["tokens"]:
                 mtgjson4.outputter.write_to_file(
                     set_code.upper(), compiled, do_cleanup=True
                 )

--- a/mtgjson4/__main__.py
+++ b/mtgjson4/__main__.py
@@ -2,15 +2,14 @@
 # pylint: disable=too-many-lines
 
 import argparse
-import json
 import logging
 import pathlib
 import sys
 from typing import Any, Dict, List, Optional
 
-import mtgjson4
 from mtgjson4 import compile_mtg
-from mtgjson4.provider import scryfall, wizards
+import mtgjson4.outputter
+from mtgjson4.provider import scryfall
 
 LOGGER = logging.getLogger(__name__)
 
@@ -28,49 +27,13 @@ def find_file(name: str, path: pathlib.Path) -> Optional[pathlib.Path]:
     return None
 
 
-def win_os_fix(set_name: str) -> str:
-    """
-    In the Windows OS, there are certain file names that are not allowed.
-    In case we have a set with such a name, we will add a _ to the end to allow its existence
-    on Windows.
-    :param set_name: Set name
-    :return: Set name with a _ if necessary
-    """
-    if set_name in mtgjson4.BANNED_FILE_NAMES:
-        return set_name + "_"
-
-    return set_name
-
-
-def write_to_file(set_name: str, file_contents: Any, do_cleanup: bool = False) -> None:
-    """
-    Write the compiled data to a file with the set's code
-    Will ensure the output directory exists first
-    """
-    mtgjson4.COMPILED_OUTPUT_DIR.mkdir(exist_ok=True)
-    with pathlib.Path(
-        mtgjson4.COMPILED_OUTPUT_DIR, win_os_fix(set_name) + ".json"
-    ).open("w", encoding="utf-8") as f:
-        if do_cleanup and isinstance(file_contents, dict):
-            if "cards" in file_contents:
-                file_contents["cards"] = compile_mtg.remove_unnecessary_fields(
-                    file_contents["cards"]
-                )
-            if "tokens" in file_contents:
-                file_contents["tokens"] = compile_mtg.remove_unnecessary_fields(
-                    file_contents["tokens"]
-                )
-        json.dump(file_contents, f, indent=4, sort_keys=True, ensure_ascii=False)
-        return
-
-
 def get_all_sets() -> List[str]:
     """
     Grab the set codes (~3 letters) for all sets found
     in the config database.
     :return: List of all set codes found, sorted
     """
-    downloaded = scryfall.download(scryfall.SCRYFALL_API_SETS)
+    downloaded = mtgjson4.provider.scryfall.download(scryfall.SCRYFALL_API_SETS)
     if downloaded["object"] == "error":
         LOGGER.error("Downloading Scryfall data failed: {}".format(downloaded))
         return []
@@ -101,175 +64,6 @@ def get_compiled_sets() -> List[str]:
     ]
 
     return all_sets_found
-
-
-def compile_and_write_outputs() -> None:
-    """
-    This method class will create the combined output files
-    of AllSets.json and AllCards.json
-    """
-    # Files that should not be combined into compiled outputs
-    files_to_ignore: List[str] = [
-        mtgjson4.ALL_SETS_OUTPUT,
-        mtgjson4.ALL_CARDS_OUTPUT,
-        mtgjson4.SET_CODES_OUTPUT,
-        mtgjson4.SET_LIST_OUTPUT,
-        mtgjson4.KEY_WORDS_OUTPUT,
-        mtgjson4.VERSION_OUTPUT,
-    ]
-
-    # Actual compilation process of the method
-    # The ordering _shouldn't necessarily_ matter
-    # but it works as is, so no need to tweak it
-    all_sets = create_all_sets(files_to_ignore)
-    write_to_file(mtgjson4.ALL_SETS_OUTPUT, all_sets)
-
-    all_cards = create_all_cards(files_to_ignore)
-    write_to_file(mtgjson4.ALL_CARDS_OUTPUT, all_cards)
-
-    all_set_codes = get_all_set_names(files_to_ignore)
-    write_to_file(mtgjson4.SET_CODES_OUTPUT, all_set_codes)
-
-    set_list_info = get_all_set_list(files_to_ignore)
-    write_to_file(mtgjson4.SET_LIST_OUTPUT, set_list_info)
-
-    key_words = wizards.compile_comp_output()
-    write_to_file(mtgjson4.KEY_WORDS_OUTPUT, key_words)
-
-    version_info = {"version": mtgjson4.__VERSION__, "date": mtgjson4.__VERSION_DATE__}
-    write_to_file(mtgjson4.VERSION_OUTPUT, version_info)
-
-
-def create_all_sets(files_to_ignore: List[str]) -> Dict[str, Any]:
-    """
-    This will create the AllSets.json file
-    by pulling the compile data from the
-    compiled sets and combining them into
-    one conglomerate file.
-    """
-    all_sets_data: Dict[str, Any] = {}
-
-    for set_file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.json"):
-        if set_file.name[:-5] in files_to_ignore:
-            continue
-
-        with set_file.open("r", encoding="utf-8") as f:
-            file_content = json.load(f)
-            set_name = get_set_name_from_file_name(set_file.name.split(".")[0])
-            all_sets_data[set_name] = file_content
-
-    return all_sets_data
-
-
-def get_set_name_from_file_name(set_name: str) -> str:
-    """
-    Some files on Windows break down, such as CON. This is our reverse mapping.
-    :param set_name: File name to convert to MTG format
-    :return: Real MTG set code
-    """
-    return set_name[:-1] if set_name[:-1] in mtgjson4.BANNED_FILE_NAMES else set_name
-
-
-def create_all_cards(files_to_ignore: List[str]) -> Dict[str, Any]:
-    """
-    This will create the AllCards.json file
-    by pulling the compile data from the
-    compiled sets and combining them into
-    one conglomerate file.
-    """
-    all_cards_data: Dict[str, Any] = {}
-
-    for set_file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.json"):
-        if set_file.name[:-5] in files_to_ignore:
-            continue
-
-        with set_file.open("r", encoding="utf-8") as f:
-            file_content = json.load(f)
-
-            for card in file_content["cards"]:
-                # Since these can vary from printing to printing, we do not include them in the output
-                card.pop("artist", None)
-                card.pop("borderColor", None)
-                card.pop("cardHash", None)
-                card.pop("flavorText", None)
-                card.pop("frameVersion", None)
-                card.pop("hasFoil", None)
-                card.pop("hasNonFoil", None)
-                card.pop("isOnlineOnly", None)
-                card.pop("isOversized", None)
-                card.pop("multiverseId", None)
-                card.pop("number", None)
-                card.pop("originalText", None)
-                card.pop("originalType", None)
-                card.pop("rarity", None)
-                card.pop("reserved", None)
-                card.pop("isTimeshifted", None)
-                card.pop("variations", None)
-                card.pop("watermark", None)
-
-                for foreign in card["foreignData"]:
-                    foreign.pop("multiverseId", None)
-
-                all_cards_data[card["name"]] = card
-
-    return all_cards_data
-
-
-def get_all_set_names(files_to_ignore: List[str]) -> List[str]:
-    """
-    This will create the SetCodes.json file
-    by getting the name of all the files in
-    the set_outputs folder and combining
-    them into a list.
-    :param files_to_ignore: Files to ignore in set_outputs folder
-    :return: List of all set names
-    """
-    all_sets_data: List[str] = []
-
-    for set_file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.json"):
-        if set_file.name[:-5] in files_to_ignore:
-            continue
-        all_sets_data.append(
-            get_set_name_from_file_name(set_file.name.split(".")[0].upper())
-        )
-
-    return sorted(all_sets_data)
-
-
-def get_all_set_list(files_to_ignore: List[str]) -> List[Dict[str, str]]:
-    """
-    This will create the SetList.json file
-    by getting the info from all the files in
-    the set_outputs folder and combining
-    them into the old v3 structure.
-    :param files_to_ignore: Files to ignore in set_outputs folder
-    :return: List of all set dicts
-    """
-    all_sets_data: List[Dict[str, str]] = []
-
-    for set_file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.json"):
-        if set_file.name[:-5] in files_to_ignore:
-            continue
-
-        with set_file.open("r", encoding="utf-8") as f:
-            file_content = json.load(f)
-            all_sets_data.append(
-                {
-                    "name": file_content.get("name", None),
-                    "code": file_content.get("code", None),
-                    "releaseDate": file_content.get("releaseDate", None),
-                }
-            )
-
-    return sorted(all_sets_data, key=lambda set_info: set_info["name"])
-
-
-def create_version_file() -> None:
-    """
-    :return: nothing
-    """
-    # TODO
-    return
 
 
 def main() -> None:
@@ -317,15 +111,15 @@ def main() -> None:
 
         for set_code in set_list:
             sf_set: List[Dict[str, Any]] = scryfall.get_set(set_code)
-            compiled: Dict[str, Any] = compile_mtg.build_output_file(sf_set, set_code)
+            compiled: Dict[str, Any] = mtgjson4.compile_mtg.build_output_file(sf_set, set_code)
 
-            # If we have at least 1 card, print out to file
+            # If we have at least 1 card, dump to file SET.json
             if compiled["cards"]:
-                write_to_file(set_code.upper(), compiled, do_cleanup=True)
+                mtgjson4.outputter.write_to_file(set_code.upper(), compiled, do_cleanup=True)
 
     if args.compiled_outputs:
-        LOGGER.info("Compiling AllSets, AllCards, SetCodes, and SetList")
-        compile_and_write_outputs()
+        LOGGER.info("Compiling Additional Outputs")
+        mtgjson4.outputter.create_and_write_compiled_outputs()
 
 
 if __name__ == "__main__":

--- a/mtgjson4/__main__.py
+++ b/mtgjson4/__main__.py
@@ -111,11 +111,13 @@ def main() -> None:
 
         for set_code in set_list:
             sf_set: List[Dict[str, Any]] = scryfall.get_set(set_code)
-            compiled: Dict[str, Any] = mtgjson4.compile_mtg.build_output_file(sf_set, set_code)
+            compiled: Dict[str, Any] = compile_mtg.build_output_file(sf_set, set_code)
 
             # If we have at least 1 card, dump to file SET.json
             if compiled["cards"]:
-                mtgjson4.outputter.write_to_file(set_code.upper(), compiled, do_cleanup=True)
+                mtgjson4.outputter.write_to_file(
+                    set_code.upper(), compiled, do_cleanup=True
+                )
 
     if args.compiled_outputs:
         LOGGER.info("Compiling Additional Outputs")

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -250,6 +250,7 @@ def build_mtgjson_tokens(
     """
     Convert Scryfall tokens to MTGJSON tokens
     :param sf_tokens: All tokens in a set
+    :param sf_card_face: Faces of the token index
     :return: List of MTGJSON tokens
     """
     token_cards: List[Dict[str, Any]] = []
@@ -584,6 +585,15 @@ def build_mtgjson_card(
             and mtgjson_card["name"] in mtgjson_card["names"]
         ):
             del mtgjson_card["names"]
+
+    # Since we built meld cards later, we will add the "side" attribute now
+    if len(mtgjson_card.get("names", [])) == 3:  # MELD
+        if mtgjson_card["name"] == mtgjson_card["names"][0]:
+            mtgjson_card["side"] = "a"
+        elif mtgjson_card["name"] == mtgjson_card["names"][2]:
+            mtgjson_card["side"] = "b"
+        else:
+            mtgjson_card["side"] = "c"
 
     # Characteristics that we cannot get from Scryfall
     # Characteristics we have to do further API calls for

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -7,7 +7,7 @@ import logging
 import multiprocessing
 import pathlib
 import re
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 import mtgjson4
 from mtgjson4.provider import gatherer, scryfall, tcgplayer
@@ -105,13 +105,30 @@ def transpose_tokens(
     """
     # Order matters with these, as if you do cards first
     # it will shadow the tokens lookup
+
+    # Single faced tokens are easy
     tokens = [
         scryfall.download(scryfall.SCRYFALL_API_CARD + card["uuid"])
         for card in cards
         if card["layout"] == "token"
     ]
 
-    cards = [card for card in cards if card["layout"] != "token"]
+    # Do not duplicate double faced tokens
+    done_tokens: Set[str] = set()
+    for card in cards:
+        if (
+            card["layout"] == "double_faced_token"
+            and card["uuid"][:-1] not in done_tokens
+        ):
+            tokens.append(
+                scryfall.download(scryfall.SCRYFALL_API_CARD + card["uuid"][:-1])
+            )
+            done_tokens.add(card["uuid"][:-1])
+
+    # Remaining cards, without any kind of token
+    cards = [
+        card for card in cards if card["layout"] not in ["token", "double_faced_token"]
+    ]
 
     return cards, tokens
 
@@ -227,7 +244,9 @@ def add_start_flag_and_count_modified(
     return mtgjson_cards, len(starter_cards["data"])
 
 
-def build_mtgjson_tokens(sf_tokens: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def build_mtgjson_tokens(
+    sf_tokens: List[Dict[str, Any]], sf_card_face: int = 0
+) -> List[Dict[str, Any]]:
     """
     Convert Scryfall tokens to MTGJSON tokens
     :param sf_tokens: All tokens in a set
@@ -236,6 +255,28 @@ def build_mtgjson_tokens(sf_tokens: List[Dict[str, Any]]) -> List[Dict[str, Any]
     token_cards: List[Dict[str, Any]] = []
 
     for sf_token in sf_tokens:
+        mtgjson_card = {}
+        if "card_faces" in sf_token:
+            mtgjson_card["names"] = sf_token["name"].split(" // ")  # List[str]
+            face_data = sf_token["card_faces"][sf_card_face]
+
+            # Prevent duplicate UUIDs for split card halves
+            # Remove the last character and replace with the id of the card face
+            mtgjson_card["uuid"] = sf_token["id"] + str(sf_card_face)
+
+            # Recursively parse the other cards within this card too
+            # Only call recursive if it is the first time we see this card object
+            if sf_card_face == 0:
+                for i in range(1, len(sf_token["card_faces"])):
+                    LOGGER.info(
+                        "Parsing additional card {0} face {1}".format(
+                            sf_token.get("name"), i
+                        )
+                    )
+                    token_cards += build_mtgjson_tokens([sf_token], i)
+
+            sf_token = face_data
+
         token_card: Dict[str, Any] = {
             "name": sf_token.get("name"),
             "type": sf_token.get("type_line"),
@@ -403,7 +444,7 @@ def build_mtgjson_card(
 
         # Prevent duplicate UUIDs for split card halves
         # Remove the last character and replace with the id of the card face
-        mtgjson_card["uuid"] = sf_card["id"][:-1] + str(sf_card_face)
+        mtgjson_card["uuid"] = sf_card["id"] + str(sf_card_face)
 
         # Split cards and rotational cards have this field, flip cards do not.
         # Remove rotational cards via the additional check

--- a/mtgjson4/outputter.py
+++ b/mtgjson4/outputter.py
@@ -1,0 +1,240 @@
+"""
+Functions used to generate outputs and write out
+"""
+import json
+import pathlib
+from typing import Any, Dict, List
+
+import requests
+
+import mtgjson4
+from mtgjson4 import compile_mtg
+from mtgjson4.provider import wizards
+
+
+def write_to_file(set_name: str, file_contents: Any, do_cleanup: bool = False) -> None:
+    """
+    Write the compiled data to a file with the set's code
+    Will ensure the output directory exists first
+    """
+    mtgjson4.COMPILED_OUTPUT_DIR.mkdir(exist_ok=True)
+    with pathlib.Path(
+        mtgjson4.COMPILED_OUTPUT_DIR, win_os_fix(set_name) + ".json"
+    ).open("w", encoding="utf-8") as f:
+        if do_cleanup and isinstance(file_contents, dict):
+            if "cards" in file_contents:
+                file_contents["cards"] = compile_mtg.remove_unnecessary_fields(
+                    file_contents["cards"]
+                )
+            if "tokens" in file_contents:
+                file_contents["tokens"] = compile_mtg.remove_unnecessary_fields(
+                    file_contents["tokens"]
+                )
+        json.dump(file_contents, f, indent=4, sort_keys=True, ensure_ascii=False)
+        return
+
+
+def create_all_sets(files_to_ignore: List[str]) -> Dict[str, Any]:
+    """
+    This will create the AllSets.json file
+    by pulling the compile data from the
+    compiled sets and combining them into
+    one conglomerate file.
+    """
+    all_sets_data: Dict[str, Any] = {}
+
+    for set_file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.json"):
+        if set_file.name[:-5] in files_to_ignore:
+            continue
+
+        with set_file.open("r", encoding="utf-8") as f:
+            file_content = json.load(f)
+            set_name = get_set_name_from_file_name(set_file.name.split(".")[0])
+            all_sets_data[set_name] = file_content
+
+    return all_sets_data
+
+
+def create_all_cards(files_to_ignore: List[str]) -> Dict[str, Any]:
+    """
+    This will create the AllCards.json file
+    by pulling the compile data from the
+    compiled sets and combining them into
+    one conglomerate file.
+    """
+    all_cards_data: Dict[str, Any] = {}
+
+    for set_file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.json"):
+        if set_file.name[:-5] in files_to_ignore:
+            continue
+
+        with set_file.open("r", encoding="utf-8") as f:
+            file_content = json.load(f)
+
+            for card in file_content["cards"]:
+                # Since these can vary from printing to printing, we do not include them in the output
+                card.pop("artist", None)
+                card.pop("borderColor", None)
+                card.pop("cardHash", None)
+                card.pop("flavorText", None)
+                card.pop("frameVersion", None)
+                card.pop("hasFoil", None)
+                card.pop("hasNonFoil", None)
+                card.pop("isOnlineOnly", None)
+                card.pop("isOversized", None)
+                card.pop("multiverseId", None)
+                card.pop("number", None)
+                card.pop("originalText", None)
+                card.pop("originalType", None)
+                card.pop("rarity", None)
+                card.pop("reserved", None)
+                card.pop("isTimeshifted", None)
+                card.pop("variations", None)
+                card.pop("watermark", None)
+
+                for foreign in card["foreignData"]:
+                    foreign.pop("multiverseId", None)
+
+                all_cards_data[card["name"]] = card
+
+    return all_cards_data
+
+
+def win_os_fix(set_name: str) -> str:
+    """
+    In the Windows OS, there are certain file names that are not allowed.
+    In case we have a set with such a name, we will add a _ to the end to allow its existence
+    on Windows.
+    :param set_name: Set name
+    :return: Set name with a _ if necessary
+    """
+    if set_name in mtgjson4.BANNED_FILE_NAMES:
+        return set_name + "_"
+
+    return set_name
+
+
+def get_all_set_names(files_to_ignore: List[str]) -> List[str]:
+    """
+    This will create the SetCodes.json file
+    by getting the name of all the files in
+    the set_outputs folder and combining
+    them into a list.
+    :param files_to_ignore: Files to ignore in set_outputs folder
+    :return: List of all set names
+    """
+    all_sets_data: List[str] = []
+
+    for set_file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.json"):
+        if set_file.name[:-5] in files_to_ignore:
+            continue
+        all_sets_data.append(
+            get_set_name_from_file_name(set_file.name.split(".")[0].upper())
+        )
+
+    return sorted(all_sets_data)
+
+
+def get_set_name_from_file_name(set_name: str) -> str:
+    """
+    Some files on Windows break down, such as CON. This is our reverse mapping.
+    :param set_name: File name to convert to MTG format
+    :return: Real MTG set code
+    """
+    return set_name[:-1] if set_name[:-1] in mtgjson4.BANNED_FILE_NAMES else set_name
+
+
+def get_all_set_list(files_to_ignore: List[str]) -> List[Dict[str, str]]:
+    """
+    This will create the SetList.json file
+    by getting the info from all the files in
+    the set_outputs folder and combining
+    them into the old v3 structure.
+    :param files_to_ignore: Files to ignore in set_outputs folder
+    :return: List of all set dicts
+    """
+    all_sets_data: List[Dict[str, str]] = []
+
+    for set_file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.json"):
+        if set_file.name[:-5] in files_to_ignore:
+            continue
+
+        with set_file.open("r", encoding="utf-8") as f:
+            file_content = json.load(f)
+            all_sets_data.append(
+                {
+                    "name": file_content.get("name", None),
+                    "code": file_content.get("code", None),
+                    "releaseDate": file_content.get("releaseDate", None),
+                }
+            )
+
+    return sorted(all_sets_data, key=lambda set_info: set_info["name"])
+
+
+def get_version_info() -> Dict[str, str]:
+    """
+    Create a version file for updating purposes
+    :return: Version file
+    """
+    return {"version": mtgjson4.__VERSION__, "date": mtgjson4.__VERSION_DATE__}
+
+
+def create_standard_only_output(files_to_ignore: List[str]) -> Dict[str, Any]:
+    standard_data: Dict[str, Any] = {}
+
+    # Get all sets currently in standard
+    standard_url_content = requests.get("https://whatsinstandard.com/api/v5/sets.json")
+    standard_json = [
+        set_obj["code"]
+        for set_obj in json.loads(standard_url_content)["sets"]
+    ]
+
+    for set_file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.json"):
+        if set_file.name[:-5] in files_to_ignore:
+            continue
+
+        if set_file.name[:-5] in standard_json:
+            with set_file.open("r", encoding="utf-8") as f:
+                file_content = json.load(f)
+                set_name = get_set_name_from_file_name(set_file.name.split(".")[0])
+                standard_data[set_name] = file_content
+
+    return standard_data
+
+
+def create_and_write_compiled_outputs() -> None:
+    """
+    This method class will create the combined output files
+    of AllSets.json and AllCards.json
+    """
+    # Files that should not be combined into compiled outputs
+    files_to_ignore: List[str] = [
+        mtgjson4.ALL_SETS_OUTPUT,
+        mtgjson4.ALL_CARDS_OUTPUT,
+        mtgjson4.SET_CODES_OUTPUT,
+        mtgjson4.SET_LIST_OUTPUT,
+        mtgjson4.KEY_WORDS_OUTPUT,
+        mtgjson4.VERSION_OUTPUT,
+    ]
+
+    # Actual compilation process of the method
+    # The ordering _shouldn't necessarily_ matter
+    # but it works as is, so no need to tweak it
+    all_sets = create_all_sets(files_to_ignore)
+    write_to_file(mtgjson4.ALL_SETS_OUTPUT, all_sets)
+
+    all_cards = create_all_cards(files_to_ignore)
+    write_to_file(mtgjson4.ALL_CARDS_OUTPUT, all_cards)
+
+    all_set_codes = get_all_set_names(files_to_ignore)
+    write_to_file(mtgjson4.SET_CODES_OUTPUT, all_set_codes)
+
+    set_list_info = get_all_set_list(files_to_ignore)
+    write_to_file(mtgjson4.SET_LIST_OUTPUT, set_list_info)
+
+    key_words = wizards.compile_comp_output()
+    write_to_file(mtgjson4.KEY_WORDS_OUTPUT, key_words)
+
+    version_info = get_version_info()
+    write_to_file(mtgjson4.VERSION_OUTPUT, version_info)

--- a/mtgjson4/provider/gamepedia.py
+++ b/mtgjson4/provider/gamepedia.py
@@ -1,0 +1,43 @@
+"""Gamepedia retrieval and processing"""
+import contextvars
+from typing import List
+
+import bs4
+from mtgjson4.provider import scryfall
+import requests
+
+SESSION: contextvars.ContextVar = contextvars.ContextVar("SESSION_GAMEPEDIA")
+
+MODERN_GAMEPEDIA_URL: str = "https://mtg.gamepedia.com/Modern"
+
+
+def strip_bad_sf_chars(bad_text: str) -> str:
+    """
+    Since we're searching Scryfall via name and not set code, we will
+    have to strip the names to the bare minimums to get a valid result
+    back.
+    """
+    for bad_char in [" ", ":", "'"]:
+        bad_text = bad_text.replace(bad_char, "")
+
+    return bad_text
+
+
+def get_modern_sets() -> List[str]:
+    """
+    Pull the modern legal page from Gamepedia and parse it out
+    to get the sets that are legal in modern
+    :return: List of set codes legal in modern
+    """
+    modern_page_content = requests.get(MODERN_GAMEPEDIA_URL)
+
+    soup = bs4.BeautifulSoup(modern_page_content.text, "html.parser")
+    soup = soup.find("div", class_="div-col columns column-width")
+    soup = soup.findAll("a")
+
+    modern_legal_sets = [
+        scryfall.get_set_header(strip_bad_sf_chars(x.text)).get("code", "").upper()
+        for x in soup
+    ]
+
+    return modern_legal_sets

--- a/mtgjson4/provider/gatherer.py
+++ b/mtgjson4/provider/gatherer.py
@@ -8,7 +8,7 @@ import bs4
 from mtgjson4 import util
 
 LOGGER = logging.getLogger(__name__)
-SESSION: contextvars.ContextVar = contextvars.ContextVar("SESSION")
+SESSION: contextvars.ContextVar = contextvars.ContextVar("SESSION_GATHERER")
 
 GATHERER_CARD = "http://gatherer.wizards.com/Pages/Card/Details.aspx"
 
@@ -71,6 +71,7 @@ def get_cards(multiverse_id: str) -> List[GathererCard]:
         timeout=5.0,
     )
     LOGGER.info("Retrieved: %s", response.url)
+    session.close()
 
     return parse_cards(response.text)
 

--- a/mtgjson4/provider/scryfall.py
+++ b/mtgjson4/provider/scryfall.py
@@ -12,7 +12,7 @@ import requests
 import requests.adapters
 
 LOGGER = logging.getLogger(__name__)
-SESSION: contextvars.ContextVar = contextvars.ContextVar("SESSION")
+SESSION: contextvars.ContextVar = contextvars.ContextVar("SESSION_SCRYFALL")
 
 SCRYFALL_API_SETS: str = "https://api.scryfall.com/sets/"
 SCRYFALL_API_CARD: str = "https://api.scryfall.com/cards/"
@@ -52,8 +52,24 @@ def download(scryfall_url: str) -> Dict[str, Any]:
     request_api_json: Dict[str, Any] = response.json()
 
     LOGGER.info("Downloaded URL: {0}".format(scryfall_url))
-
+    session.close()
     return request_api_json
+
+
+def get_set_header(set_name: str) -> Dict[str, Any]:
+    """
+    Get just the header (not card contents) of a set by its name
+    :param set_name:
+    :return:
+    """
+    set_api_json: Dict[str, Any] = download(SCRYFALL_API_SETS + set_name)
+    if set_api_json["object"] == "error":
+        LOGGER.warning(
+            "Set header api download failed for {0}: {1}".format(set_name, set_api_json)
+        )
+        return {}
+
+    return set_api_json
 
 
 def get_set(set_code: str) -> List[Dict[str, Any]]:

--- a/mtgjson4/provider/tcgplayer.py
+++ b/mtgjson4/provider/tcgplayer.py
@@ -12,7 +12,7 @@ from mtgjson4 import util
 import requests
 
 LOGGER = logging.getLogger(__name__)
-SESSION: contextvars.ContextVar = contextvars.ContextVar("SESSION")
+SESSION: contextvars.ContextVar = contextvars.ContextVar("SESSION_TCGPLAYER")
 TCGPLAYER_API_VERSION: contextvars.ContextVar = contextvars.ContextVar("API_TCGPLAYER")
 
 
@@ -84,7 +84,8 @@ def download(tcgplayer_url: str, params_str: Dict[str, Any] = None) -> str:
         timeout=5.0,
     )
 
-    LOGGER.info("Downloaded URL: {0}".format(tcgplayer_url))
+    LOGGER.info("Downloaded URL: {0}".format(response.url))
+    session.close()
 
     if response.status_code != 200:
         LOGGER.warning(

--- a/mtgjson4/provider/wizards.py
+++ b/mtgjson4/provider/wizards.py
@@ -11,7 +11,7 @@ from mtgjson4 import util
 import unidecode
 
 LOGGER = logging.getLogger(__name__)
-SESSION: contextvars.ContextVar = contextvars.ContextVar("SESSION")
+SESSION: contextvars.ContextVar = contextvars.ContextVar("SESSION_WIZARDS")
 
 COMP_RULES: str = "https://magic.wizards.com/en/game-info/gameplay/rules-and-formats/rules"
 
@@ -27,7 +27,7 @@ def download_from_wizards(url: str) -> str:
     response.encoding = "windows-1252"  # WHY DO THEY DO THIS
 
     LOGGER.info("Retrieved: %s", response.url)
-
+    session.close()
     return response.text
 
 


### PR DESCRIPTION
Fix #155 
Fix #159 
Fix #117

This PR adds Standard.json, Modern.json, AllSetsNoUn.json, and AllCardsNoUn.json to our compiled outputs repertoire. 

Also reverts the session closures as it's still buggy, but now we'll be stable.

Test Files:
Sets:
[DOM.json.txt](https://github.com/mtgjson/mtgjson4/files/2654836/DOM.json.txt)
[GRN.json.txt](https://github.com/mtgjson/mtgjson4/files/2654838/GRN.json.txt)
[LEA.json.txt](https://github.com/mtgjson/mtgjson4/files/2654815/LEA.json.txt)
[M15.json.txt](https://github.com/mtgjson/mtgjson4/files/2654816/M15.json.txt)
[M19.json.txt](https://github.com/mtgjson/mtgjson4/files/2654817/M19.json.txt)
[RIX.json.txt](https://github.com/mtgjson/mtgjson4/files/2654819/RIX.json.txt)
[UNH.json.txt](https://github.com/mtgjson/mtgjson4/files/2654822/UNH.json.txt)
[UST.json.txt](https://github.com/mtgjson/mtgjson4/files/2654823/UST.json.txt)
[XLN.json.txt](https://github.com/mtgjson/mtgjson4/files/2654825/XLN.json.txt)

Compiled Outputs:
[AllCards.json.txt](https://github.com/mtgjson/mtgjson4/files/2654807/AllCards.json.txt)
[AllCardsNoUn.json.txt](https://github.com/mtgjson/mtgjson4/files/2654809/AllCardsNoUn.json.txt)
[Keywords.json.txt](https://github.com/mtgjson/mtgjson4/files/2654814/Keywords.json.txt)
[Modern.json.txt](https://github.com/mtgjson/mtgjson4/files/2654818/Modern.json.txt)
[SetCodes.json.txt](https://github.com/mtgjson/mtgjson4/files/2654820/SetCodes.json.txt)
[Standard.json.txt](https://github.com/mtgjson/mtgjson4/files/2654821/Standard.json.txt)
[version.json.txt](https://github.com/mtgjson/mtgjson4/files/2654824/version.json.txt)

___

Due to build issues, this PR also addresses #159 for tokens not appearing correctly when defined in the main set as a double faced token. Will move to tokens array and split them up correctly.

[F17.json.txt](https://github.com/mtgjson/mtgjson4/files/2655970/F17.json.txt)
[F18.json.txt](https://github.com/mtgjson/mtgjson4/files/2655971/F18.json.txt)

___

This PR also addresses #117 to give the a/b/c side values to meld cards. a/b = two main cards, c = melded portion.

[EMN.json.txt](https://github.com/mtgjson/mtgjson4/files/2656006/EMN.json.txt)


**NOTE:** THIS CHANGES HOW UUIDS ARE DONE FOR SPLIT CARDS (INCL SPLIT TOKENS). YOU WILL NEED TO RE-INDEX IF YOU WERE BASED ON THEM
