### PR TITLE
Address duplicate tokens in a set (only show one per set)

### DIFF
--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -278,22 +278,28 @@ def build_mtgjson_tokens(
 
             sf_token = face_data
 
-        token_card: Dict[str, Any] = {
-            "name": sf_token.get("name"),
-            "type": sf_token.get("type_line"),
-            "text": sf_token.get("oracle_text"),
-            "power": sf_token.get("power"),
-            "colors": sf_token.get("colors"),
-            "colorIdentity": sf_token.get("color_identity"),
-            "toughness": sf_token.get("toughness"),
-            "loyalty": sf_token.get("loyalty"),
-            "watermark": sf_token.get("watermark"),
-            "uuid": sf_token.get("id"),
-            "borderColor": sf_token.get("border_color"),
-            "artist": sf_token.get("artist"),
-            "isOnlineOnly": sf_token.get("digital"),
-            "number": sf_token.get("collector_number"),
-        }
+        token_card: Dict[str, Any] = {}
+        try:
+            token_card = {
+                "name": sf_token.get("name"),
+                "type": sf_token.get("type_line"),
+                "text": sf_token.get("oracle_text"),
+                "power": sf_token.get("power"),
+                "colors": sf_token.get("colors"),
+                "colorIdentity": sf_token.get("color_identity"),
+                "toughness": sf_token.get("toughness"),
+                "loyalty": sf_token.get("loyalty"),
+                "watermark": sf_token.get("watermark"),
+                "uuid": sf_token["id"],
+                "borderColor": sf_token.get("border_color"),
+                "artist": sf_token.get("artist"),
+                "isOnlineOnly": sf_token.get("digital"),
+                "number": sf_token.get("collector_number"),
+            }
+        except KeyError:
+            # Address duplicates, as only the original seems to have a UUID
+            LOGGER.info("UUID not found in {}. Discarding {}".format(sf_token.get("name"), sf_token))
+            continue
 
         reverse_related: List[str] = []
         if "all_parts" in sf_token:

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -298,7 +298,11 @@ def build_mtgjson_tokens(
             }
         except KeyError:
             # Address duplicates, as only the original seems to have a UUID
-            LOGGER.info("UUID not found in {}. Discarding {}".format(sf_token.get("name"), sf_token))
+            LOGGER.info(
+                "UUID not found in {}. Discarding {}".format(
+                    sf_token.get("name"), sf_token
+                )
+            )
             continue
 
         reverse_related: List[str] = []


### PR DESCRIPTION
Fix #173 
Fix #167

This addresses missing numbers in a set, as there were duplicates pulled from flip tokens. This should work now as expected, having one entry per token and all attributes.

The tokens that were missing numbers also were missing UUIDs, so this is a double hitter :)

[A25.json.txt](https://github.com/mtgjson/mtgjson4/files/2688369/A25.json.txt)
[UST.json.txt](https://github.com/mtgjson/mtgjson4/files/2688370/UST.json.txt)

