### PR TITLE
UUID Changes

### DIFF
--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -124,7 +124,7 @@ def add_uuid_to_cards(
         generator.seed(
             int(hashlib.sha512(card_hash_code.encode()).hexdigest(), base=16)
         )
-        card["id"] = generator.uuid4()
+        card["uuid"] = generator.uuid4()
 
     for token in tokens:
         # Name + SetCode + Scryfall UUID
@@ -132,7 +132,7 @@ def add_uuid_to_cards(
         generator.seed(
             int(hashlib.sha512(token_hash_code.encode()).hexdigest(), base=16)
         )
-        token["id"] = generator.uuid4()
+        token["uuid"] = generator.uuid4()
 
 
 def transpose_tokens(
@@ -244,10 +244,10 @@ def uniquify_duplicates_in_set(cards: List[Dict[str, Any]]) -> List[Dict[str, An
         repeats_in_set = [
             item
             for item in cards
-            if item["name"] == card["name"] and item["scryfallId"] != card["scryfallId"]
+            if item["name"] == card["name"] and item["uuid"] != card["uuid"]
         ]
 
-        variations = [r["scryfallId"] for r in repeats_in_set]
+        variations = [r["uuid"] for r in repeats_in_set]
         if variations:
             card["variations"] = variations
 

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -72,7 +72,7 @@ def build_output_file(sf_cards: List[Dict[str, Any]], set_code: str) -> Dict[str
         set_code, set_config["search_uri"], card_holder
     )
 
-    # Address duplicate printings in a set
+    # Address duplicates in un-sets
     card_holder = uniquify_duplicates_in_set(card_holder)
 
     # Move bogus tokens out
@@ -95,6 +95,9 @@ def build_output_file(sf_cards: List[Dict[str, Any]], set_code: str) -> Dict[str
 
     # Add UUID to each entry
     add_uuid_to_cards(output_file["cards"], output_file["tokens"], output_file)
+
+    # Add Variations to each entry
+    add_variations_field(output_file["cards"])
 
     return output_file
 
@@ -209,8 +212,6 @@ def uniquify_duplicates_in_set(cards: List[Dict[str, Any]]) -> List[Dict[str, An
     them against each other.
     For silver border sets, we will add (b), (c), ... to the end
     of the card name to do so.
-    For non-silver bordered sets, we will create a "variations"
-    field will be created that has UUID of repeat cards
     :param cards: Cards to check and update for repeats
     :return: updated cards list
     """
@@ -246,7 +247,16 @@ def uniquify_duplicates_in_set(cards: List[Dict[str, Any]]) -> List[Dict[str, An
                 unique_list.append(card)
 
         return unique_list
+    return cards
 
+
+def add_variations_field(cards: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    For non-silver bordered sets, we will create a "variations"
+    field will be created that has UUID of repeat cards
+    :param cards: Cards to check and update for repeats
+    :return: updated cards list
+    """
     # Non-silver border sets use "variations"
     for card in cards:
         repeats_in_set = [

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -114,10 +114,11 @@ def add_uuid_to_cards(
 
     # Only using attributes that _shouldn't_ change over time
     for card in cards:
-        # Name + Set Code + Scryfall UUID + Printed Text (if applicable)
+        # Name + set code + colors (if applicable) + Scryfall UUID + printed text (if applicable)
         card_hash_code = (
             card["name"]
             + file_info["code"]
+            + "".join(card.get("colors", ""))
             + card["scryfallId"]
             + str(card.get("originalText", ""))
         )
@@ -127,8 +128,15 @@ def add_uuid_to_cards(
         card["uuid"] = generator.uuid4()
 
     for token in tokens:
-        # Name + SetCode + Scryfall UUID
-        token_hash_code = token["name"] + file_info["code"] + token["scryfallId"]
+        # Name + set code + colors (if applicable) + power (if applicable) + toughness (if applicable) + Scryfall UUID
+        token_hash_code = (
+            token["name"]
+            + "".join(token.get("colors", ""))
+            + token.get("power", "")
+            + token.get("toughness", "")
+            + file_info["code"]
+            + token["scryfallId"]
+        )
         generator.seed(
             int(hashlib.sha512(token_hash_code.encode()).hexdigest(), base=16)
         )

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -249,16 +249,17 @@ def add_variations_field(cards: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     :return: updated cards list
     """
     # Non-silver border sets use "variations"
-    for card in cards:
-        repeats_in_set = [
-            item
-            for item in cards
-            if item["name"] == card["name"] and item["uuid"] != card["uuid"]
-        ]
+    if cards[0].get("borderColor", None) != "silver":
+        for card in cards:
+            repeats_in_set = [
+                item
+                for item in cards
+                if item["name"] == card["name"] and item["uuid"] != card["uuid"]
+            ]
 
-        variations = [r["uuid"] for r in repeats_in_set]
-        if variations:
-            card["variations"] = variations
+            variations = [r["uuid"] for r in repeats_in_set]
+            if variations:
+                card["variations"] = variations
 
     return cards
 

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -2,19 +2,17 @@
 
 import contextvars
 import copy
-import hashlib
 import json
 import logging
 import multiprocessing
 import pathlib
 import re
+import uuid
 from typing import Any, Dict, List, Set, Tuple
 
 import mtgjson4
 from mtgjson4.provider import gatherer, scryfall, tcgplayer
 from mtgjson4.util import is_number
-
-from faker import Faker
 
 LOGGER = logging.getLogger(__name__)
 
@@ -113,8 +111,6 @@ def add_uuid_to_cards(
     :param tokens: Tokens Array
     :param file_info: <<CONST>> object for the file
     """
-    generator = Faker()
-
     # Only using attributes that _shouldn't_ change over time
     for card in cards:
         # Name + set code + colors (if applicable) + Scryfall UUID + printed text (if applicable)
@@ -125,10 +121,8 @@ def add_uuid_to_cards(
             + card["scryfallId"]
             + str(card.get("originalText", ""))
         )
-        generator.seed(
-            int(hashlib.sha512(card_hash_code.encode()).hexdigest(), base=16)
-        )
-        card["uuid"] = generator.uuid4()
+
+        card["uuid"] = str(uuid.uuid5(uuid.NAMESPACE_DNS, card_hash_code))
 
     for token in tokens:
         # Name + set code + colors (if applicable) + power (if applicable) + toughness (if applicable) + Scryfall UUID
@@ -140,10 +134,7 @@ def add_uuid_to_cards(
             + file_info["code"]
             + token["scryfallId"]
         )
-        generator.seed(
-            int(hashlib.sha512(token_hash_code.encode()).hexdigest(), base=16)
-        )
-        token["uuid"] = generator.uuid4()
+        token["uuid"] = str(uuid.uuid5(uuid.NAMESPACE_DNS, token_hash_code))
 
 
 def transpose_tokens(

--- a/mtgjson4/provider/tcgplayer.py
+++ b/mtgjson4/provider/tcgplayer.py
@@ -88,11 +88,18 @@ def download(tcgplayer_url: str, params_str: Dict[str, Any] = None) -> str:
     session.close()
 
     if response.status_code != 200:
-        LOGGER.warning(
-            "Status Code: {} Failed to download from TCGPlayer with URL: {}, Params: {}".format(
-                response.status_code, tcgplayer_url, params_str
+        if response.status_code == 404:
+            LOGGER.info(
+                "Status Code: {} Failed to download from TCGPlayer with URL: {}, Params: {}".format(
+                    response.status_code, response.url, params_str
+                )
             )
-        )
+        else:
+            LOGGER.warning(
+                "Status Code: {} Failed to download from TCGPlayer with URL: {}, Params: {}".format(
+                    response.status_code, response.url, params_str
+                )
+            )
         return ""
 
     return response.text

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 beautifulsoup4
-Faker
 requests
 unidecode
 urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4
+Faker
 requests
 unidecode
 urllib3


### PR DESCRIPTION
Fix #169 

Re-Re-Address the UUID problems. We are now generating our own UUIDv5 via a custom string.

Old UUIDs, which were scryfall IDs, are now called `scryfallId` so people can link to cards appropriately. These are _not_ a unique field

Also fixes Reserve not being pruned correctly.

And tcgplayer logging being dumb

Files:
[A25.json.txt](https://github.com/mtgjson/mtgjson4/files/2688877/A25.json.txt)
[UNH.json.txt](https://github.com/mtgjson/mtgjson4/files/2688878/UNH.json.txt)
[UST.json.txt](https://github.com/mtgjson/mtgjson4/files/2688879/UST.json.txt)
[ZEN.json.txt](https://github.com/mtgjson/mtgjson4/files/2688880/ZEN.json.txt)
