### PR TITLE
split duel decks into a/b decks ("duelDeck": "LETTER")

### DIFF
--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -101,7 +101,7 @@ def build_output_file(
     # Add Variations to each entry
     add_variations_field(output_file["cards"])
 
-    if "DD" == set_code[:2]:
+    if set_code[:2] == "DD":
         mark_duel_decks(output_file["cards"])
 
     return output_file

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -101,6 +101,9 @@ def build_output_file(
     # Add Variations to each entry
     add_variations_field(output_file["cards"])
 
+    if "DD" == set_code[:2]:
+        mark_duel_decks(output_file["cards"])
+
     return output_file
 
 
@@ -490,6 +493,27 @@ def get_cmc(mana_cost: str) -> float:
             total += 1
 
     return total
+
+
+def mark_duel_decks(cards: List[Dict[str, Any]]) -> None:
+    """
+    Duel decks are usually put together where the cards
+    in the first deck are at the beginning, followed
+    by basics, then start the second deck. We exploit
+    this property to mark them as decks "a" and "b"
+    :param cards: Cards in duel deck, sorted by number
+    """
+    basic_land_marked = False
+    side_market = "a"
+
+    for card in cards:
+        if card["name"] in mtgjson4.BASIC_LANDS:
+            basic_land_marked = True
+        elif basic_land_marked:
+            side_market = chr(ord(side_market) + 1)
+            basic_land_marked = False
+
+        card["duelDeck"] = side_market
 
 
 def build_mtgjson_card(


### PR DESCRIPTION
Fix #75 

Split duel decks via a new field: `duelDeck (string)` which contains either "a" or "b" to indicate what deck it's in.

The way this is accomplished (right now) is to find the basic land string, then split it. [Card 1 .. Last Basic in first string of basics] U [Next card .. Card N]

Files:
[DDT.json.txt](https://github.com/mtgjson/mtgjson4/files/2689634/DDT.json.txt)
[DDU.json.txt](https://github.com/mtgjson/mtgjson4/files/2689635/DDU.json.txt)
