### PR TITLE
Make printings lowercase to match what we've been doing elsewhere

### DIFF
--- a/mtgjson4/provider/scryfall.py
+++ b/mtgjson4/provider/scryfall.py
@@ -259,6 +259,6 @@ def parse_printings(sf_prints_url: str) -> List[str]:
         return []
 
     for card in prints_api_json["data"]:
-        card_sets.add(card.get("set").upper())
+        card_sets.add(card.get("set"))
 
     return list(card_sets)


### PR DESCRIPTION
Fix #186 

This converts the `printings` field from a list of uppercase to a list of lowercase. Simple change, and it goes in line with other changes we've made with lower casing certain components.