### PR TITLE
Add tcgplayer urls

### DIFF
--- a/mtgjson4/__init__.py
+++ b/mtgjson4/__init__.py
@@ -30,6 +30,7 @@ STANDARD_OUTPUT: str = "Standard"
 MODERN_OUTPUT: str = "Modern"
 ALL_CARDS_NO_FUN_OUTPUT: str = "AllCardsNoUn"
 ALL_SETS_NO_FUN_OUTPUT: str = "AllSetsNoUn"
+REFERRAL_DB_OUTPUT: str = "ReferralMap"
 
 LANGUAGE_MAP: Dict[str, str] = {
     "en": "English",

--- a/mtgjson4/__main__.py
+++ b/mtgjson4/__main__.py
@@ -114,9 +114,7 @@ def main() -> None:
 
     for set_code in set_list:
         sf_set: List[Dict[str, Any]] = scryfall.get_set(set_code)
-        compiled: Dict[str, Any] = compile_mtg.build_output_file(
-            sf_set, set_code, args.skip_tcgplayer
-        )
+        compiled = compile_mtg.build_output_file(sf_set, set_code, args.skip_tcgplayer)
 
         # If we have at least 1 card, dump to file SET.json
         if compiled["cards"] or compiled["tokens"]:

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -1,5 +1,4 @@
 """Compile incoming data into the target output format."""
-
 import contextvars
 import copy
 import json
@@ -204,10 +203,11 @@ def add_tcgplayer_fields(
         prod_id = tcgplayer.get_card_property(card["name"], tcg_card_objs, "productId")
         prod_url = tcgplayer.get_card_property(card["name"], tcg_card_objs, "url")
 
-        if prod_id:
+        if prod_id and prod_url:
             card["tcgplayerProductId"] = prod_id
-        if prod_url:
-            card["tcgplayerPurchaseUrl"] = prod_url + "?partner=mtgjson"
+            card["tcgplayerPurchaseUrl"] = tcgplayer.log_redirection_url(
+                card["tcgplayerProductId"], prod_url
+            )
 
     return cards
 

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -80,9 +80,9 @@ def build_output_file(
     card_holder, added_tokens = transpose_tokens(card_holder)
 
     # Add TCGPlayer information
+    output_file["tcgplayerGroupId"] = set_config.get("tcgplayer_id")
     if not skip_tcgplayer:
-        output_file["tcgplayerGroupId"] = tcgplayer.get_group_id(set_code.upper())
-        card_holder = add_tcgplayer_ids(output_file["tcgplayerGroupId"], card_holder)
+        card_holder = add_tcgplayer_fields(output_file["tcgplayerGroupId"], card_holder)
 
     # Set sizes; BASE SET SIZE WILL BE UPDATED BELOW
     output_file["totalSetSize"] = len(sf_cards)
@@ -188,7 +188,7 @@ def transpose_tokens(
     return cards, tokens
 
 
-def add_tcgplayer_ids(
+def add_tcgplayer_fields(
     group_id: int, cards: List[Dict[str, Any]]
 ) -> List[Dict[str, Any]]:
     """
@@ -201,9 +201,13 @@ def add_tcgplayer_ids(
     tcg_card_objs = tcgplayer.get_group_id_cards(group_id)
 
     for card in cards:
-        prod_id = tcgplayer.get_card_id(card["name"], tcg_card_objs)
-        if prod_id > 0:
+        prod_id = tcgplayer.get_card_property(card["name"], tcg_card_objs, "productId")
+        prod_url = tcgplayer.get_card_property(card["name"], tcg_card_objs, "url")
+
+        if prod_id:
             card["tcgplayerProductId"] = prod_id
+        if prod_url:
+            card["tcgplayerPurchaseUrl"] = prod_url + "?partner=mtgjson"
 
     return cards
 

--- a/mtgjson4/outputter.py
+++ b/mtgjson4/outputter.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List
 
 import mtgjson4
 from mtgjson4 import compile_mtg, util
-from mtgjson4.provider import gamepedia, scryfall, wizards
+from mtgjson4.provider import gamepedia, scryfall, tcgplayer, wizards
 
 STANDARD_API_URL: str = "https://whatsinstandard.com/api/v5/sets.json"
 
@@ -37,7 +37,6 @@ def write_to_file(set_name: str, file_contents: Any, do_cleanup: bool = False) -
                     file_contents["tokens"]
                 )
         json.dump(file_contents, f, indent=4, sort_keys=True, ensure_ascii=False)
-        return
 
 
 def create_all_sets(files_to_ignore: List[str]) -> Dict[str, Any]:
@@ -293,6 +292,7 @@ def create_and_write_compiled_outputs() -> None:
         mtgjson4.MODERN_OUTPUT,
         mtgjson4.ALL_CARDS_NO_FUN_OUTPUT,
         mtgjson4.ALL_SETS_NO_FUN_OUTPUT,
+        mtgjson4.REFERRAL_DB_OUTPUT,
     ]
 
     # AllSets.json
@@ -328,3 +328,11 @@ def create_and_write_compiled_outputs() -> None:
     # AllCardsNoUn.json
     all_cards_no_fun = create_all_cards_no_funny(files_to_ignore)
     write_to_file(mtgjson4.ALL_CARDS_NO_FUN_OUTPUT, all_cards_no_fun)
+
+    # MTGJSONReferrals.json
+    if tcgplayer.TCGP_REDIR_DB.get(None):
+        with pathlib.Path(
+            mtgjson4.COMPILED_OUTPUT_DIR, mtgjson4.REFERRAL_DB_OUTPUT + ".txt"
+        ).open("w") as f:
+            for key, value in tcgplayer.TCGP_REDIR_DB.get().items():
+                f.write("{}\t{}\n".format(key, value))

--- a/mtgjson4/provider/tcgplayer.py
+++ b/mtgjson4/provider/tcgplayer.py
@@ -105,34 +105,6 @@ def download(tcgplayer_url: str, params_str: Dict[str, Any] = None) -> str:
     return response.text
 
 
-def get_group_id(set_code: str) -> int:
-    """
-    Find the TCGPlayer group ID for a specific set
-    :param set_code: Set to find group ID for
-    :return: Group ID or Not found (-1)
-    """
-    offset = 0
-    # TCGPlayer will only send 100 results at a time, so we need to
-    # page through the data to find the appropriate set
-    while True:
-        tcg_data = json.loads(
-            download(
-                "http://api.tcgplayer.com/[API_VERSION]/catalog/categories/1/groups",
-                {"limit": "100", "offset": offset},
-            )
-        )
-
-        if not tcg_data["results"]:
-            break
-
-        for set_content in tcg_data["results"]:
-            if set_content["abbreviation"] == set_code.upper():
-                return int(set_content.get("groupId", -1))
-
-        offset += len(tcg_data["results"])
-    return -1
-
-
 def get_group_id_cards(group_id: int) -> List[Dict[str, Any]]:
     """
     Given a group_id, get all the cards within that set.

--- a/mtgjson4/provider/tcgplayer.py
+++ b/mtgjson4/provider/tcgplayer.py
@@ -174,16 +174,19 @@ def get_group_id_cards(group_id: int) -> List[Dict[str, Any]]:
     return cards
 
 
-def get_card_id(card_name: str, card_list: List[Dict[str, Any]]) -> int:
+def get_card_property(
+    card_name: str, card_list: List[Dict[str, Any]], card_field: str
+) -> Any:
     """
     Go through the passed in card object list to find the matching
-    card from the set and get its ID.
-    :param card_name: Card to find in the list
-    :param card_list: List of card objects from TCGPlayer
-    :return: Card ID or Default (-1)
+    card from the set and get its attribute.
+    :param card_name: Card name to find in the list
+    :param card_list: List of TCGPlayer card objects
+    :param card_field: Field to pull from TCGPlayer card object
+    :return: Value of field
     """
     for card in card_list:
         if card_name.lower() == card["name"].lower():
-            return card.get("productId", -1)
+            return card.get(card_field, None)
 
-    return -1
+    return None

--- a/mtgjson4/provider/tcgplayer.py
+++ b/mtgjson4/provider/tcgplayer.py
@@ -161,4 +161,5 @@ def get_card_property(
         if card_name.lower() == card["name"].lower():
             return card.get(card_field, None)
 
+    LOGGER.warning("Unable to find card {} in TCGPlayer card list".format(card_name))
     return None


### PR DESCRIPTION
This will add URLs to the outputs so people can easier integrate them into their programs.

The redirections are handled by apache with a `RewriteMap` generated by `httxt2dbm -i ReferralMap.txt -o /etc/apache2/json_tcg_map.dbm`  where the referralmap is generated by this code

```apache2
RewriteEngine On
# Rewrite links to head to TCGPlayer
RewriteMap tcgplayer_map "dbm:/etc/apache2/json_tcg_map.dbm"
RewriteCond ${tcgplayer_map:$1} !=""
RewriteRule ^/links/(.*)$ "${tcgplayer_map:$1}" [NC]
```

[ORI.json.txt](https://github.com/mtgjson/mtgjson/files/2747291/ORI.json.txt)
[RTR.json.txt](https://github.com/mtgjson/mtgjson/files/2747292/RTR.json.txt)
