### PR TITLE
add Scryfall as a first source for TCGPlayer Product IDs

### DIFF
--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -203,7 +203,7 @@ def add_tcgplayer_fields(
     group_id: int, cards: List[Dict[str, Any]]
 ) -> List[Dict[str, Any]]:
     """
-    For each card in the set, we will find its tcgplayer ID
+    For each card in the set, we will find its product URL
     and add it to the card if found
     :param group_id: group to search for the cards
     :param cards: Cards list to add information to
@@ -212,15 +212,14 @@ def add_tcgplayer_fields(
     tcg_card_objs = tcgplayer.get_group_id_cards(group_id)
 
     for card in cards:
-        prod_id = tcgplayer.get_card_property(card["name"], tcg_card_objs, "productId")
+        if not card["tcgplayerProductId"]: # no need to fetch from TCGPlayer if already found in Scryfall
+            card["tcgplayerProductId"] = tcgplayer.get_card_property(card["name"], tcg_card_objs, "productId")
         prod_url = tcgplayer.get_card_property(card["name"], tcg_card_objs, "url")
 
-        if prod_id and prod_url:
-            card["tcgplayerProductId"] = prod_id
+        if card["tcgplayerProductId"] and prod_url:
             card["tcgplayerPurchaseUrl"] = tcgplayer.log_redirection_url(
                 card["tcgplayerProductId"], prod_url
             )
-
     return cards
 
 
@@ -635,6 +634,7 @@ def build_mtgjson_card(
     mtgjson_card["number"] = sf_card.get("collector_number")
     mtgjson_card["isReserved"] = sf_card.get("reserved")
     mtgjson_card["frameEffect"] = sf_card.get("frame_effect")
+    mtgjson_card["tcgplayerProductId"] = sf_card.get("tcgplayer_id")
 
     # Vanguard fields
     mtgjson_card["life"] = sf_card.get("life_modifier")

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -203,7 +203,7 @@ def add_tcgplayer_fields(
     group_id: int, cards: List[Dict[str, Any]]
 ) -> List[Dict[str, Any]]:
     """
-    For each card in the set, we will find its product URL
+    For each card in the set, we will find its tcgplayer ID
     and add it to the card if found
     :param group_id: group to search for the cards
     :param cards: Cards list to add information to

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -212,9 +212,8 @@ def add_tcgplayer_fields(
     tcg_card_objs = tcgplayer.get_group_id_cards(group_id)
 
     for card in cards:
-        if not card[
-            "tcgplayerProductId"
-        ]:  # no need to fetch from TCGPlayer if already found in Scryfall
+        # No need to fetch from TCGPlayer if already found in Scryfall
+        if not card["tcgplayerProductId"]:
             card["tcgplayerProductId"] = tcgplayer.get_card_property(
                 card["name"], tcg_card_objs, "productId"
             )

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -212,8 +212,12 @@ def add_tcgplayer_fields(
     tcg_card_objs = tcgplayer.get_group_id_cards(group_id)
 
     for card in cards:
-        if not card["tcgplayerProductId"]: # no need to fetch from TCGPlayer if already found in Scryfall
-            card["tcgplayerProductId"] = tcgplayer.get_card_property(card["name"], tcg_card_objs, "productId")
+        if not card[
+            "tcgplayerProductId"
+        ]:  # no need to fetch from TCGPlayer if already found in Scryfall
+            card["tcgplayerProductId"] = tcgplayer.get_card_property(
+                card["name"], tcg_card_objs, "productId"
+            )
         prod_url = tcgplayer.get_card_property(card["name"], tcg_card_objs, "url")
 
         if card["tcgplayerProductId"] and prod_url:

--- a/mtgjson4/provider/tcgplayer.py
+++ b/mtgjson4/provider/tcgplayer.py
@@ -158,7 +158,9 @@ def get_card_property(
     :return: Value of field
     """
     for card in card_list:
-        if card_name.lower() == card["name"].lower():
+        # will try to match against Part A for split cards (if applicable)
+        part_a_name = card_name.split("//")[0].strip()
+        if card_name.lower() == part_a_name.lower():
             return card.get(card_field, None)
 
     LOGGER.warning("Unable to find card {} in TCGPlayer card list".format(card_name))


### PR DESCRIPTION
<!-- Thanks for submitting this change to help improve upon MTGJSONv4! If you have any questions, please don't hesitate to ask. -->

Adding Scryfall as a first source for TCGPlayer Product IDs improves coverage of those IDs. TCGPlayer should be retained as a source since Scryfall data is incomplete.