### PR TITLE
Several breaking changes

### DIFF
--- a/mtgjson4/__init__.py
+++ b/mtgjson4/__init__.py
@@ -28,8 +28,7 @@ KEY_WORDS_OUTPUT: str = "Keywords"
 VERSION_OUTPUT: str = "version"
 STANDARD_OUTPUT: str = "Standard"
 MODERN_OUTPUT: str = "Modern"
-ALL_CARDS_NO_FUN_OUTPUT: str = "AllCardsNoUn"
-ALL_SETS_NO_FUN_OUTPUT: str = "AllSetsNoUn"
+VINTAGE_OUTPUT: str = "Vintage"
 REFERRAL_DB_OUTPUT: str = "ReferralMap"
 
 LANGUAGE_MAP: Dict[str, str] = {

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -369,7 +369,7 @@ def add_start_flag_and_count_modified(
                 item for item in mtgjson_cards if item["scryfallId"] == sf_card["id"]
             )
             if card:
-                card["starter"] = True
+                card["isStarter"] = True
         except StopIteration:
             LOGGER.warning(
                 "Passed on {0} with SF_ID {1}".format(

--- a/mtgjson4/outputter.py
+++ b/mtgjson4/outputter.py
@@ -358,8 +358,7 @@ def create_and_write_compiled_outputs() -> None:
         mtgjson4.VERSION_OUTPUT,
         mtgjson4.STANDARD_OUTPUT,
         mtgjson4.MODERN_OUTPUT,
-        mtgjson4.ALL_CARDS_NO_FUN_OUTPUT,
-        mtgjson4.ALL_SETS_NO_FUN_OUTPUT,
+        mtgjson4.VINTAGE_OUTPUT,
         mtgjson4.REFERRAL_DB_OUTPUT,
     ]
 
@@ -389,10 +388,6 @@ def create_and_write_compiled_outputs() -> None:
     # Modern.json
     write_to_file(mtgjson4.MODERN_OUTPUT, create_modern_only_output())
 
-    # AllSetsNoUn.json
+    # Vintage.json
     all_sets_no_fun = create_all_sets_no_funny(files_to_ignore)
-    write_to_file(mtgjson4.ALL_SETS_NO_FUN_OUTPUT, all_sets_no_fun)
-
-    # AllCardsNoUn.json
-    all_cards_no_fun = create_all_cards_no_funny(files_to_ignore)
-    write_to_file(mtgjson4.ALL_CARDS_NO_FUN_OUTPUT, all_cards_no_fun)
+    write_to_file(mtgjson4.VINTAGE_OUTPUT, all_sets_no_fun)


### PR DESCRIPTION
starter -> isStarter.
AllSetsNoUn.json -> Vintage.json.
Discontinue of AllCardsNoUn.json.

starter change was noted to happen in prior release.
Will add apache redirect rule for AllSetsNoUn to Vintage.
Had < 50 downloads of AllCardsNoUn since release. Doesn't seem worth supporting any longer, and adds confusion with the other one renamed to Vintage instead of VintageSets.
