### PR TITLE
Handle precons

### DIFF
--- a/mtgjson4/outputter.py
+++ b/mtgjson4/outputter.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List
 
 import mtgjson4
 from mtgjson4 import util
-from mtgjson4.provider import gamepedia, scryfall, wizards, magic_precons
+from mtgjson4.provider import gamepedia, magic_precons, scryfall, wizards
 
 STANDARD_API_URL: str = "https://whatsinstandard.com/api/v5/sets.json"
 
@@ -50,9 +50,9 @@ def write_to_file(set_name: str, file_contents: Any, do_cleanup: bool = False) -
     Will ensure the output directory exists first
     """
     mtgjson4.COMPILED_OUTPUT_DIR.mkdir(exist_ok=True)
-    with mtgjson4.COMPILED_OUTPUT_DIR.joinpath(win_os_fix(set_name) + ".json").open(
-        "w", encoding="utf-8"
-    ) as f:
+    with mtgjson4.COMPILED_OUTPUT_DIR.joinpath(
+        util.win_os_fix(set_name) + ".json"
+    ).open("w", encoding="utf-8") as f:
         if do_cleanup and isinstance(file_contents, dict):
             if "cards" in file_contents:
                 file_contents["cards"] = remove_unnecessary_fields(
@@ -191,20 +191,6 @@ def create_all_cards(files_to_ignore: List[str]) -> Dict[str, Any]:
     return all_cards_data
 
 
-def win_os_fix(set_name: str) -> str:
-    """
-    In the Windows OS, there are certain file names that are not allowed.
-    In case we have a set with such a name, we will add a _ to the end to allow its existence
-    on Windows.
-    :param set_name: Set name
-    :return: Set name with a _ if necessary
-    """
-    if set_name in mtgjson4.BANNED_FILE_NAMES:
-        return set_name + "_"
-
-    return set_name
-
-
 def get_all_set_names(files_to_ignore: List[str]) -> List[str]:
     """
     This will create the SetCodes.json file
@@ -296,7 +282,9 @@ def create_standard_only_output() -> Dict[str, Any]:
     ]
 
     for set_code in standard_json:
-        set_file = mtgjson4.COMPILED_OUTPUT_DIR.joinpath(win_os_fix(set_code) + ".json")
+        set_file = mtgjson4.COMPILED_OUTPUT_DIR.joinpath(
+            util.win_os_fix(set_code) + ".json"
+        )
 
         if not set_file.is_file():
             LOGGER.warning(
@@ -321,7 +309,9 @@ def create_modern_only_output() -> Dict[str, Any]:
     modern_data: Dict[str, Any] = {}
 
     for set_code in gamepedia.get_modern_sets():
-        set_file = mtgjson4.COMPILED_OUTPUT_DIR.joinpath(win_os_fix(set_code) + ".json")
+        set_file = mtgjson4.COMPILED_OUTPUT_DIR.joinpath(
+            util.win_os_fix(set_code) + ".json"
+        )
 
         if not set_file.is_file():
             LOGGER.warning(
@@ -433,4 +423,7 @@ def create_and_write_compiled_outputs() -> None:
     write_to_file(mtgjson4.VINTAGE_OUTPUT, all_sets_no_fun)
 
     # decks/*.json
-    magic_precons.build_and_write_decks("/Users/zachary/Downloads/export_decks.json")
+    for deck in magic_precons.build_and_write_decks(
+        "/Users/zachary/Downloads/export_decks.json"
+    ):
+        write_deck_to_file(util.capital_case_without_symbols(deck["name"]), deck)

--- a/mtgjson4/outputter.py
+++ b/mtgjson4/outputter.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List
 
 import mtgjson4
 from mtgjson4 import util
-from mtgjson4.provider import gamepedia, scryfall, wizards
+from mtgjson4.provider import gamepedia, scryfall, wizards, magic_precons
 
 STANDARD_API_URL: str = "https://whatsinstandard.com/api/v5/sets.json"
 
@@ -431,3 +431,6 @@ def create_and_write_compiled_outputs() -> None:
     # Vintage.json
     all_sets_no_fun = create_vintage_only_output(files_to_ignore)
     write_to_file(mtgjson4.VINTAGE_OUTPUT, all_sets_no_fun)
+
+    # decks/*.json
+    magic_precons.build_and_write_decks("/Users/zachary/Downloads/export_decks.json")

--- a/mtgjson4/outputter.py
+++ b/mtgjson4/outputter.py
@@ -30,6 +30,20 @@ def write_tcgplayer_information(data: Dict[str, str]) -> None:
             f.write("{}\t{}\n".format(key, value))
 
 
+def write_deck_to_file(file_name: str, file_contents: Any) -> None:
+    """
+    Write out the precons to the file system
+    :param file_name: Name to give the deck
+    :param file_contents: Contents of the deck
+    """
+    mtgjson4.COMPILED_OUTPUT_DIR.mkdir(exist_ok=True)
+    mtgjson4.COMPILED_OUTPUT_DIR.joinpath("decks").mkdir(exist_ok=True)
+    with mtgjson4.COMPILED_OUTPUT_DIR.joinpath("decks", file_name + ".json").open(
+        "w", encoding="utf-8"
+    ) as f:
+        json.dump(file_contents, f, indent=4, sort_keys=True, ensure_ascii=False)
+
+
 def write_to_file(set_name: str, file_contents: Any, do_cleanup: bool = False) -> None:
     """
     Write the compiled data to a file with the set's code

--- a/mtgjson4/outputter.py
+++ b/mtgjson4/outputter.py
@@ -11,6 +11,7 @@ import mtgjson4
 from mtgjson4 import util
 from mtgjson4.provider import gamepedia, magic_precons, scryfall, wizards
 
+DECKS_URL: str = "https://raw.githubusercontent.com/taw/magic-preconstructed-decks-data/master/decks.json"
 STANDARD_API_URL: str = "https://whatsinstandard.com/api/v5/sets.json"
 
 LOGGER = logging.getLogger(__name__)
@@ -131,7 +132,7 @@ def create_all_sets(files_to_ignore: List[str]) -> Dict[str, Any]:
     all_sets_data: Dict[str, Any] = {}
 
     for set_file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.json"):
-        if set_file.name[:-5] in files_to_ignore:
+        if set_file.stem in files_to_ignore:
             continue
 
         with set_file.open("r", encoding="utf-8") as f:
@@ -152,7 +153,7 @@ def create_all_cards(files_to_ignore: List[str]) -> Dict[str, Any]:
     all_cards_data: Dict[str, Any] = {}
 
     for set_file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.json"):
-        if set_file.name[:-5] in files_to_ignore:
+        if set_file.stem in files_to_ignore:
             continue
 
         with set_file.open("r", encoding="utf-8") as f:
@@ -203,7 +204,7 @@ def get_all_set_names(files_to_ignore: List[str]) -> List[str]:
     all_sets_data: List[str] = []
 
     for set_file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.json"):
-        if set_file.name[:-5] in files_to_ignore:
+        if set_file.stem in files_to_ignore:
             continue
         all_sets_data.append(
             get_set_name_from_file_name(set_file.name.split(".")[0].upper())
@@ -233,7 +234,8 @@ def get_all_set_list(files_to_ignore: List[str]) -> List[Dict[str, str]]:
     all_sets_data: List[Dict[str, str]] = []
 
     for set_file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.json"):
-        if set_file.name[:-5] in files_to_ignore:
+        print(set_file.stem)
+        if set_file.stem in files_to_ignore:
             continue
 
         with set_file.open("r", encoding="utf-8") as f:
@@ -423,7 +425,5 @@ def create_and_write_compiled_outputs() -> None:
     write_to_file(mtgjson4.VINTAGE_OUTPUT, all_sets_no_fun)
 
     # decks/*.json
-    for deck in magic_precons.build_and_write_decks(
-        "/Users/zachary/Downloads/export_decks.json"
-    ):
+    for deck in magic_precons.build_and_write_decks(DECKS_URL):
         write_deck_to_file(util.capital_case_without_symbols(deck["name"]), deck)

--- a/mtgjson4/provider/magic_precons.py
+++ b/mtgjson4/provider/magic_precons.py
@@ -105,8 +105,3 @@ def build_single_card(precon_card: Dict[str, Any]) -> List[Dict[str, Any]]:
         LOGGER.warning("No match for {}".format(precon_card))
 
     return cards
-
-
-if __name__ == "__main__":
-    mtgjson4.init_logger()
-    build_and_write_decks("/Users/zachary/Downloads/export_decks.json")

--- a/mtgjson4/provider/magic_precons.py
+++ b/mtgjson4/provider/magic_precons.py
@@ -16,6 +16,7 @@ def build_and_write_decks(decks_path: str) -> Iterator[Dict[str, Any]]:
     Given the path to the precons list, this will
     compile them in MTGJSONv4 format and write out
     the decks to the "decks/" folder.
+    :return Each deck completed, one by one
     """
     with pathlib.Path(decks_path).open("r", encoding="utf-8") as f:
         content = json.load(f)

--- a/mtgjson4/provider/magic_precons.py
+++ b/mtgjson4/provider/magic_precons.py
@@ -3,7 +3,7 @@ import json
 import logging
 import multiprocessing
 import pathlib
-from typing import Any, Dict, Generator, List
+from typing import Any, Dict, Iterator, List
 
 import mtgjson4
 import mtgjson4.util
@@ -11,7 +11,7 @@ import mtgjson4.util
 LOGGER = logging.getLogger(__name__)
 
 
-def build_and_write_decks(decks_path: str) -> Generator[Dict[str, Any], None, None]:
+def build_and_write_decks(decks_path: str) -> Iterator[Dict[str, Any]]:
     """
     Given the path to the precons list, this will
     compile them in MTGJSONv4 format and write out

--- a/mtgjson4/provider/magic_precons.py
+++ b/mtgjson4/provider/magic_precons.py
@@ -1,0 +1,112 @@
+"""Card information provider for Precons."""
+import json
+import logging
+import multiprocessing
+import pathlib
+import re
+from typing import Any, Dict, List
+
+import mtgjson4
+from mtgjson4.outputter import win_os_fix, write_deck_to_file
+
+LOGGER = logging.getLogger(__name__)
+
+
+def build_and_write_decks(precon_path: str) -> None:
+    """
+    Given the path to the precons list, this will
+    compile them in MTGJSONv4 format and write out
+    the decks to the "decks/" folder.
+    """
+    with pathlib.Path(precon_path).open("r", encoding="utf-8") as f:
+        content = json.load(f)
+
+    for deck in content:
+        deck_to_output = {
+            "name": deck["name"],
+            "code": deck["set_code"].upper(),
+            "type": deck["type"],
+            "mainBoard": [],
+            "sideBoard": [],
+        }
+
+        with multiprocessing.Pool(processes=8) as pool:
+            # Pool main board first
+            results: List[Any] = pool.map(build_single_card, deck["cards"])
+            for cards in results:
+                for card in cards:
+                    deck_to_output["mainBoard"].append(card)
+
+            # Now pool side board
+            results = pool.map(build_single_card, deck["sideboard"])
+            for cards in results:
+                for card in cards:
+                    deck_to_output["sideBoard"].append(card)
+
+        write_deck_to_file(capital_case_without_symbols(deck["name"]), deck_to_output)
+        LOGGER.info("Finished set {}".format(deck["name"]))
+
+
+def capital_case_without_symbols(name: str) -> str:
+    """
+    Determine the name of the output file by stripping
+    all special characters and capital casing the words.
+    :param name: Deck name (unsanitized)
+    :return: Sanitized deck name
+    """
+    word_characters_only_regex = re.compile(r"[^\w]")
+    capital_case = "".join(x for x in name.title() if not x.isspace())
+
+    return word_characters_only_regex.sub("", capital_case)
+
+
+def get_mtgjson_set_code(set_code: str) -> str:
+    """
+    Some set codes are wrong, so this will sanitize
+    the set_code passed in
+    :param set_code: Set code (unsanitized)
+    :return: Sanitized set code
+    """
+    with mtgjson4.RESOURCE_PATH.joinpath("gatherer_set_codes.json").open(
+        "r", encoding="utf-8"
+    ) as f:
+        json_dict = json.load(f)
+        for key, value in json_dict.items():
+            if set_code == value:
+                return str(key)
+
+    return win_os_fix(set_code)
+
+
+def build_single_card(precon_card: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Build the MTGJSONv4 card for each pre-con card
+    in the deck.
+    :param precon_card: Card to build Precon format
+    :return: Card(s) built from the card MTGJSONv4 format
+    """
+    with mtgjson4.COMPILED_OUTPUT_DIR.joinpath(
+        get_mtgjson_set_code(precon_card["set_code"].upper()) + ".json"
+    ).open("r") as f:
+        compiled_file = json.load(f)
+
+    cards = []
+    for mtgjson_card in compiled_file["cards"]:
+        if "//" in precon_card["name"]:
+            if precon_card["number"][-1].isalpha():
+                precon_card["number"] = precon_card["number"][:-1]
+
+        if mtgjson_card["number"] == precon_card["number"]:
+            mtgjson_card["count"] = precon_card["count"]
+            mtgjson_card["isFoil"] = precon_card["foil"]
+            cards.append(mtgjson_card)
+
+    if not cards:
+        LOGGER.warning("No match for {}".format(precon_card))
+
+    return cards
+
+
+if __name__ == "__main__":
+    mtgjson4.init_logger()
+    build_and_write_decks("/Users/zachary/Downloads/export_decks.json")

--- a/mtgjson4/provider/magic_precons.py
+++ b/mtgjson4/provider/magic_precons.py
@@ -2,8 +2,9 @@
 import json
 import logging
 import multiprocessing
-import pathlib
 from typing import Any, Dict, Iterator, List
+
+import requests
 
 import mtgjson4
 import mtgjson4.util
@@ -11,17 +12,17 @@ import mtgjson4.util
 LOGGER = logging.getLogger(__name__)
 
 
-def build_and_write_decks(decks_path: str) -> Iterator[Dict[str, Any]]:
+def build_and_write_decks(decks_url: str) -> Iterator[Dict[str, Any]]:
     """
-    Given the path to the precons list, this will
+    Given the URL to the precons list, this will
     compile them in MTGJSONv4 format and write out
     the decks to the "decks/" folder.
     :return Each deck completed, one by one
     """
-    with pathlib.Path(decks_path).open("r", encoding="utf-8") as f:
-        content = json.load(f)
+    decks_content = requests.get(decks_url).json()
+    LOGGER.info("Downloaded URL: {0}".format(decks_url))
 
-    for deck in content:
+    for deck in decks_content:
         deck_to_output = {
             "name": deck["name"],
             "code": deck["set_code"].upper(),
@@ -47,7 +48,7 @@ def build_and_write_decks(decks_path: str) -> Iterator[Dict[str, Any]]:
                 for card in cards:
                     deck_to_output["sideBoard"].append(card)
 
-        LOGGER.info("Finished set {}".format(deck["name"]))
+        LOGGER.info("Finished deck {}".format(deck["name"]))
         yield deck_to_output
 
 

--- a/mtgjson4/provider/wizards.py
+++ b/mtgjson4/provider/wizards.py
@@ -25,7 +25,7 @@ def download_from_wizards(url: str) -> str:
     response = session.get(url=url, timeout=5.0)
     response.encoding = "windows-1252"  # WHY DO THEY DO THIS
 
-    LOGGER.info("Retrieved: %s", response.url)
+    LOGGER.info("Downloaded URL: {0}".format(response.url))
     session.close()
     return response.text
 

--- a/mtgjson4/util.py
+++ b/mtgjson4/util.py
@@ -1,10 +1,14 @@
 """Utility functions."""
 import contextvars
+import json
+import re
 from typing import Optional
 
 import requests
 import requests.adapters
 import urllib3.util.retry
+
+import mtgjson4
 
 SESSION: contextvars.ContextVar = contextvars.ContextVar("SESSION")
 
@@ -57,3 +61,48 @@ def is_number(string: str) -> bool:
         pass
 
     return False
+
+
+def win_os_fix(set_name: str) -> str:
+    """
+    In the Windows OS, there are certain file names that are not allowed.
+    In case we have a set with such a name, we will add a _ to the end to allow its existence
+    on Windows.
+    :param set_name: Set name
+    :return: Set name with a _ if necessary
+    """
+    if set_name in mtgjson4.BANNED_FILE_NAMES:
+        return set_name + "_"
+
+    return set_name
+
+
+def capital_case_without_symbols(name: str) -> str:
+    """
+    Determine the name of the output file by stripping
+    all special characters and capital casing the words.
+    :param name: Deck name (unsanitized)
+    :return: Sanitized deck name
+    """
+    word_characters_only_regex = re.compile(r"[^\w]")
+    capital_case = "".join(x for x in name.title() if not x.isspace())
+
+    return word_characters_only_regex.sub("", capital_case)
+
+
+def get_mtgjson_set_code(set_code: str) -> str:
+    """
+    Some set codes are wrong, so this will sanitize
+    the set_code passed in
+    :param set_code: Set code (unsanitized)
+    :return: Sanitized set code
+    """
+    with mtgjson4.RESOURCE_PATH.joinpath("gatherer_set_codes.json").open(
+        "r", encoding="utf-8"
+    ) as f:
+        json_dict = json.load(f)
+        for key, value in json_dict.items():
+            if set_code == value:
+                return str(key)
+
+    return win_os_fix(set_code)

--- a/mtgjson4/util.py
+++ b/mtgjson4/util.py
@@ -105,4 +105,4 @@ def get_mtgjson_set_code(set_code: str) -> str:
             if set_code == value:
                 return str(key)
 
-    return win_os_fix(set_code)
+    return set_code


### PR DESCRIPTION
Fix #64 

This adds support for pre-constructed decks. They can be found in the `decks/` folder, indexed by the name they were given.

Several cards are currently missing due to incompatibilities, but taw has been informed and a fix should be in the works. These will (hopefully) be fixed upstream by the time we release, but can be updated in a future version.

~~Just need to wait for @taw to put this file up on a permanent location before we can get this in :)~~

Example decks: https://www.dropbox.com/s/twdckamrhth9jn7/decks.zip?dl=0