### PR TITLE
ADD back support for variation printings of cards

### DIFF
--- a/mtgjson4/__main__.py
+++ b/mtgjson4/__main__.py
@@ -2,15 +2,10 @@
 # pylint: disable=too-many-lines
 
 import argparse
-import json
 import logging
 import pathlib
-import re
 import sys
 from typing import Any, Dict, List, Optional
-
-import bs4
-import requests
 
 from mtgjson4 import compile_mtg
 import mtgjson4.outputter
@@ -132,17 +127,6 @@ def main() -> None:
     if args.c:
         LOGGER.info("Compiling Additional Outputs")
         mtgjson4.outputter.create_and_write_compiled_outputs()
-
-
-def get_mkm_set_ids():
-    mkm_page = requests.get("https://www.cardmarket.com/en/Magic/Products/Sets")
-    soup = bs4.BeautifulSoup(mkm_page.text, "html.parser")
-    select = soup.find("select", {"id": re.compile("idExpansion*")})
-    values = select.findAll("option")
-    mkm_codes = {}
-    for val in values:
-        mkm_codes[val.text] = int(val["value"])
-    return json.dumps(mkm_codes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Scryfall removed variations from the default set returned values. This adds them back to re-gain support.

Fix #231 

Example files:
[ARN.old.json.txt](https://github.com/mtgjson/mtgjson/files/2974559/ARN.old.json.txt)
[ARN.new.json.txt](https://github.com/mtgjson/mtgjson/files/2974558/ARN.new.json.txt)
[diff.txt](https://github.com/mtgjson/mtgjson/files/2974557/diff.txt)
