### PR TITLE
ADD side to TOKEN_UUID to uniquify it. BREAKING CHANGE.

### DIFF
--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -159,6 +159,7 @@ def add_uuid_to_cards(
             + "".join(token.get("colors", ""))
             + str(token.get("power", ""))
             + str(token.get("toughness", ""))
+            + str(token.get("side", ""))
             + file_info["code"]
             + token["scryfallId"]
         )


### PR DESCRIPTION
Fix #272 

Adds side to diversify the sides of the tokens, since we had a collision. 

Examples:
[UST.old.json.txt](https://github.com/mtgjson/mtgjson/files/2975765/UST.old.json.txt)
[UST.new.json.txt](https://github.com/mtgjson/mtgjson/files/2975766/UST.new.json.txt)
[diff.txt](https://github.com/mtgjson/mtgjson/files/2975764/diff.txt)

