### PR TITLE
Add translations

### DIFF
--- a/mtgjson4/__init__.py
+++ b/mtgjson4/__init__.py
@@ -22,6 +22,7 @@ RESOURCE_PATH: pathlib.Path = TOP_LEVEL_DIR.joinpath("mtgjson4").joinpath("resou
 SESSION_CACHE_EXPIRE_GATHERER: int = 604800  # seconds - 1 week
 SESSION_CACHE_EXPIRE_TCG: int = 604800  # seconds - 1 week
 SESSION_CACHE_EXPIRE_SCRYFALL: int = 604800  # seconds - 1 week
+SESSION_CACHE_EXPIRE_MKM: int = 604800  # seconds - 1 week
 
 
 # Compiled Output Files

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Set, Tuple, Union
 import uuid
 
 import mtgjson4
-from mtgjson4.provider import gatherer, scryfall, tcgplayer
+from mtgjson4.provider import gatherer, magic_card_market, scryfall, tcgplayer
 from mtgjson4.util import is_number
 
 LOGGER = logging.getLogger(__name__)
@@ -43,6 +43,12 @@ def build_output_file(
     output_file["keyruneCode"] = (
         pathlib.Path(set_config["icon_svg_uri"]).name.split(".")[0].upper()
     )
+
+    # Add translations to the files
+    try:
+        output_file["translations"] = magic_card_market.get_translations(set_code)
+    except KeyError:
+        LOGGER.warning("Unable to find set translations for {}".format(set_code))
 
     # Add Card Market information, if it exists
     with mtgjson4.RESOURCE_PATH.joinpath("mkm_information.json").open("r") as f:

--- a/mtgjson4/provider/magic_card_market.py
+++ b/mtgjson4/provider/magic_card_market.py
@@ -1,0 +1,112 @@
+"""Magic Card Market retrieval and processing."""
+
+import contextvars
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+import bs4
+
+import mtgjson4
+from mtgjson4 import util
+
+# The offerings of MKM as of 2019-03-19
+CARD_MARKET_LANGUAGES: List[Dict[str, str]] = [
+    {"code": "en", "lang": "English"},
+    {"code": "fr", "lang": "French"},
+    {"code": "de", "lang": "German"},
+    {"code": "it", "lang": "Italian"},
+    {"code": "es", "lang": "Spanish"},
+]
+
+CARD_MARKET_URL: str = "https://www.cardmarket.com/{}/Magic/Expansions"
+SESSION: contextvars.ContextVar = contextvars.ContextVar("SESSION_MKM")
+TRANSLATION_TABLE: contextvars.ContextVar = contextvars.ContextVar("TRANSLATION_TABLE")
+LOGGER = logging.getLogger(__name__)
+
+
+def get_translations(set_code: Optional[str] = None) -> Any:
+    """
+    Get the translation table that was pre-built OR a specific
+    set from the translation table. Will also build the
+    table if necessary.
+    Return value w/o set_code: {SET_CODE: {SET_LANG: TRANSLATION, ...}, ...}
+    Return value w/  set_code: SET_CODE: {SET_LANG: TRANSLATION, ...}
+    :return: Translation table
+    """
+    if not TRANSLATION_TABLE.get(None):
+        build_translation_table()
+
+    if set_code:
+        return TRANSLATION_TABLE.get()[set_code]
+    return TRANSLATION_TABLE.get()
+
+
+def prebuild_translation_table() -> List[Dict[str, str]]:
+    """
+    Build a table of dicts that contains the translation
+    of each set. Since MKM returns the same order for
+    each page, just translated into a different language,
+    we can exploit this to build an anonymous array and
+    construct it in a later function.
+    :return: List[Dict[str, str]] with language: "set name"
+    """
+    session = util.get_generic_session()
+    translation_list: List[Dict[str, str]] = []
+
+    for lang_map in CARD_MARKET_LANGUAGES:
+        mkm_url = CARD_MARKET_URL.format(lang_map["code"])
+        response: Any = session.get(mkm_url)
+        LOGGER.info("Downloaded: {} (Cache = {})".format(mkm_url, response.from_cache))
+
+        # Parse the data and pluck all anchor tags with a set URL
+        # inside of their href tag.
+        soup = bs4.BeautifulSoup(response.text, "html.parser")
+        magic_sets = soup.find_all(
+            "a", href=re.compile(r"/{}/Magic/Expansions/.*".format(lang_map["code"]))
+        )
+
+        # Pre-fill our table so we can index into it
+        if not translation_list:
+            translation_list = [{}] * len(magic_sets)
+
+        for index, header in enumerate(magic_sets):
+            if translation_list[index]:
+                # Merge the two dicts
+                translation_list[index] = {
+                    **translation_list[index],
+                    **{lang_map["lang"]: header.text},
+                }
+            else:
+                translation_list[index] = {lang_map["lang"]: header.text}
+
+    return translation_list
+
+
+def build_translation_table() -> Dict[str, Dict[str, str]]:
+    """
+    Calls for the pre-building of the table, then goes through
+    the MKM information we have stored in resources and plays
+    match maker to create a simple access dictionary for
+    future insertions.
+    :return: {SET_CODE: {LANGUAGE: TRANSLATED_SET, ...}, ...}
+    """
+    LOGGER.info("Compiling set translations")
+    initial_table = prebuild_translation_table()
+
+    with mtgjson4.RESOURCE_PATH.joinpath("mkm_information.json").open("r") as f:
+        mkm_stuff = json.load(f)
+
+    # The Big-O time of this is bad, but there are only a few hundred
+    # elements in each, so not _too_ big a deal here.
+    translation_table = {}
+    for set_content in initial_table:
+        for key, value in mkm_stuff.items():
+            if value["mcmName"] == set_content["English"]:
+                del set_content["English"]
+                translation_table[key] = set_content
+                break
+
+    TRANSLATION_TABLE.set(translation_table)
+    return translation_table

--- a/mtgjson4/util.py
+++ b/mtgjson4/util.py
@@ -42,11 +42,13 @@ def get_generic_session() -> requests.Session:
         backend="sqlite",
         expire_after=mtgjson4.SESSION_CACHE_EXPIRE_GATHERER,
     )
+
     session: Optional[requests.Session] = SESSION.get(None)
-    if session is None:
+    if not session:
         session = requests.Session()
         session = retryable_session(session)
         SESSION.set(session)
+
     return session
 
 


### PR DESCRIPTION
Add translations for Spanish, French, Italian, and German to all sets available. Fix #269 

The content is pulled from MKM and parsed to get a rough translation. It's _good enough_ for what it is, and we can manually correct if necessary.

Future improvements are to add Portuguese (Which someone offered to help with), Chinese Traditional, Chinese Simplified, Japanese, Korean, and Russian

Examples:
[XLN.json.txt](https://github.com/mtgjson/mtgjson/files/2985903/XLN.json.txt)
[ORI.json.txt](https://github.com/mtgjson/mtgjson/files/2985904/ORI.json.txt)
[LEA.json.txt](https://github.com/mtgjson/mtgjson/files/2985905/LEA.json.txt)
