### PR TITLE
Remove faceCMC from flip cards as it's not relevant there

### DIFF
--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -546,7 +546,7 @@ def build_mtgjson_card(
                 "faceConvertedManaCost",
                 get_cmc(sf_card["mana_cost"].split("//")[sf_card_face].strip()),
             )
-        elif sf_card["layout"] in ["split", "flip", "transform", "aftermath"]:
+        elif sf_card["layout"] in ["split", "transform", "aftermath"]:
             # Handle non-normal cards, as they'll a face split
             single_card.set(
                 "faceConvertedManaCost",


### PR DESCRIPTION
Fix #294 

After talking with several entities, I've come to realize faceCMC is not relevant for flip cards. It doesn't have a second cast-able half and it holds the value of the top, so it would be the same. As such, this is now removed. 

[BOK.json.txt](https://github.com/mtgjson/mtgjson/files/3086663/BOK.json.txt)
[diff.txt](https://github.com/mtgjson/mtgjson/files/3086664/diff.txt)
