### PR TITLE
Compression & Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ ___
 | `-a`                        | Build all sets. This overshadows the `-s` flag.                                                                                                 |
 | `-c`                        | After building any/all sets, create the compiled outputs (ex: AllSets, AllCards).                                                               |
 | `-x`                        | Skips sets that have already been built (i.e. set files in the output folder), and build the remaining sets. Must be passed with `-a` or `-s`.  |
+| `-z`                        | Compress the outputs directory contents                                                                                                         |
 | `-s SET [SET ...]`          | Build set code arguments, provided they exist.                                                                                                  |
-| `--skip-sets SET [SET ...]` | Prevents set code arguments from being built, even if passed in via `-a` or `-s`.                                                               |
 | `--skip-tcgplayer`          | If you don't have a TCGPlayer API key, you can disable building of TCGPlayer components.                                                        |
+| `--skip-sets SET [SET ...]` | Prevents set code arguments from being built, even if passed in via `-a` or `-s`.                                                               |
 | `--skip-cache`              | Disables the reading and writing of cached content                                                                                              |
-|
 
 > &nbsp;
 > **Newcomer Note**: Omitting either the `-a` and `-s` flag will yield empty outputted data.
@@ -78,7 +78,9 @@ ___
 Run the program, with any flag(s) you'd like, via:
 
 ```sh
-python3 -m mtgjson4 [-h] [-acx] [-s [SET [SET ...]]] [--skip-tcgplayer] [--skip-cache] [--skip-sets [SET [SET ...]]]
+python3 -m mtgjson4 [-h] [-a] [-c] [-x] [-z] [-s [SET [SET ...]]]
+                    [--skip-tcgplayer] [--skip-sets [SET [SET ...]]]
+                    [--skip-cache]
 ```
 
 Example:

--- a/mtgjson4/__init__.py
+++ b/mtgjson4/__init__.py
@@ -13,23 +13,26 @@ __MAINTAINER__ = "Zach Halpern (GitHub: @ZeldaZach)"
 __MAINTAINER_EMAIL__ = "zahalpern+github@gmail.com"
 __REPO_URL__ = "https://github.com/mtgjson/mtgjson"
 
-# Globals
+# Globals -- constant types
 SUPERTYPES: List[str] = ["Basic", "Host", "Legendary", "Ongoing", "Snow", "World"]
 BASIC_LANDS: List[str] = ["Plains", "Island", "Swamp", "Mountain", "Forest"]
+
+# Globals -- paths
 TOP_LEVEL_DIR: pathlib.Path = pathlib.Path(__file__).resolve().parent.parent
 COMPILED_OUTPUT_DIR: pathlib.Path = TOP_LEVEL_DIR.joinpath("json_" + __VERSION__)
 LOG_DIR: pathlib.Path = TOP_LEVEL_DIR.joinpath("logs")
 CONFIG_PATH: pathlib.Path = TOP_LEVEL_DIR.joinpath("mtgjson.properties")
 RESOURCE_PATH: pathlib.Path = TOP_LEVEL_DIR.joinpath("mtgjson4").joinpath("resources")
+
+# Globals -- caches
 SESSION_CACHE_EXPIRE_GENERAL: int = 604800  # seconds - 1 week
 SESSION_CACHE_EXPIRE_TCG: int = 604800  # seconds - 1 week
 SESSION_CACHE_EXPIRE_SCRYFALL: int = 604800  # seconds - 1 week
 SESSION_CACHE_EXPIRE_MKM: int = 604800  # seconds - 1 week
 SESSION_CACHE_EXPIRE_STOCKS: int = 604800  # seconds - 1 week
-
 USE_CACHE: contextvars.ContextVar = contextvars.ContextVar("USE_CACHE")
 
-# MKM Globals
+# Globals -- MKM applications
 os.environ["MKM_APP_TOKEN"] = ""
 os.environ["MKM_APP_SECRET"] = ""
 os.environ["MKM_ACCESS_TOKEN"] = ""
@@ -39,20 +42,37 @@ MTGSTOCKS_BUFFER: str = "20202"
 CARD_MARKET_BUFFER: str = "10101"
 
 # Compiled Output Files
-ALL_SETS_OUTPUT: str = "AllSets"
 ALL_CARDS_OUTPUT: str = "AllCards"
-SET_LIST_OUTPUT: str = "SetList"
-COMPILED_LIST_OUTPUT: str = "CompiledList"
-KEY_WORDS_OUTPUT: str = "Keywords"
-VERSION_OUTPUT: str = "version"
-STANDARD_OUTPUT: str = "Standard"
-MODERN_OUTPUT: str = "Modern"
-VINTAGE_OUTPUT: str = "Vintage"
-REFERRAL_DB_OUTPUT: str = "ReferralMap"
-ALL_SETS_DIR_OUTPUT: str = "AllSetFiles"
 ALL_DECKS_DIR_OUTPUT: str = "AllDeckFiles"
+ALL_SETS_DIR_OUTPUT: str = "AllSetFiles"
+ALL_SETS_OUTPUT: str = "AllSets"
 CARD_TYPES_OUTPUT: str = "CardTypes"
+COMPILED_LIST_OUTPUT: str = "CompiledList"
 DECK_LISTS_OUTPUT: str = "DeckLists"
+KEY_WORDS_OUTPUT: str = "Keywords"
+MODERN_OUTPUT: str = "Modern"
+REFERRAL_DB_OUTPUT: str = "ReferralMap"
+SET_LIST_OUTPUT: str = "SetList"
+STANDARD_OUTPUT: str = "Standard"
+VERSION_OUTPUT: str = "version"
+VINTAGE_OUTPUT: str = "Vintage"
+
+OUTPUT_FILES: List[str] = [
+    ALL_CARDS_OUTPUT,
+    ALL_DECKS_DIR_OUTPUT,
+    ALL_SETS_DIR_OUTPUT,
+    ALL_SETS_OUTPUT,
+    CARD_TYPES_OUTPUT,
+    COMPILED_LIST_OUTPUT,
+    DECK_LISTS_OUTPUT,
+    KEY_WORDS_OUTPUT,
+    MODERN_OUTPUT,
+    REFERRAL_DB_OUTPUT,
+    SET_LIST_OUTPUT,
+    STANDARD_OUTPUT,
+    VERSION_OUTPUT,
+    VINTAGE_OUTPUT,
+]
 
 # Provider tags
 SCRYFALL_PROVIDER_ID = "sf"

--- a/mtgjson4/__main__.py
+++ b/mtgjson4/__main__.py
@@ -8,7 +8,7 @@ import sys
 from typing import Any, Dict, List
 
 import mtgjson4
-from mtgjson4 import compile_mtg, outputter
+from mtgjson4 import compile_mtg, compressor, outputter
 from mtgjson4.mtgjson_card import MTGJSONCard
 from mtgjson4.provider import scryfall
 import mtgjson4.util
@@ -85,6 +85,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--skip-tcgplayer", action="store_true")
     parser.add_argument("--skip-sets", metavar="SET", nargs="*", type=str)
     parser.add_argument("--skip-cache", action="store_true")
+    parser.add_argument("-z", action="store_true")
 
     # Ensure there are args
     if len(sys.argv) < 2:
@@ -130,6 +131,7 @@ def main() -> None:
     Main Method
     """
     args: argparse.Namespace = parse_args()
+    mtgjson4.USE_CACHE.set(not args.skip_cache)
 
     if not mtgjson4.CONFIG_PATH.is_file():
         LOGGER.warning(
@@ -137,7 +139,6 @@ def main() -> None:
                 mtgjson4.CONFIG_PATH
             )
         )
-    mtgjson4.USE_CACHE.set(not args.skip_cache)
 
     # Determine set(s) to build
     args_s = args.s if args.s else []
@@ -174,8 +175,14 @@ def main() -> None:
 
     # Compile the additional outputs
     if args.c:
-        LOGGER.info("Compiling Additional Outputs")
+        LOGGER.info("Compiling additional outputs")
         mtgjson4.outputter.create_and_write_compiled_outputs()
+
+    # Compress the output folder
+    if args.z:
+        LOGGER.info("Start compressing for production")
+        compressor.compress_output_folder()
+        LOGGER.info("Finished compressing for production")
 
 
 if __name__ == "__main__":

--- a/mtgjson4/__main__.py
+++ b/mtgjson4/__main__.py
@@ -79,13 +79,13 @@ def parse_args() -> argparse.Namespace:
     """
     parser = argparse.ArgumentParser(description="")
     parser.add_argument("-a", action="store_true")
-    parser.add_argument("-s", metavar="SET", nargs="*", type=str)
     parser.add_argument("-c", action="store_true")
     parser.add_argument("-x", action="store_true")
+    parser.add_argument("-z", action="store_true")
+    parser.add_argument("-s", metavar="SET", nargs="*", type=str)
     parser.add_argument("--skip-tcgplayer", action="store_true")
     parser.add_argument("--skip-sets", metavar="SET", nargs="*", type=str)
     parser.add_argument("--skip-cache", action="store_true")
-    parser.add_argument("-z", action="store_true")
 
     # Ensure there are args
     if len(sys.argv) < 2:

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -535,7 +535,7 @@ def convert_to_mtgjson(sf_cards: List[Dict[str, Any]]) -> List[MTGJSONCard]:
     # Clear sessions before the fork() to prevent awk issues with urllib3
     SESSION.set(None)
 
-    with multiprocessing.Pool(processes=8) as pool:
+    with multiprocessing.Pool(multiprocessing.cpu_count()) as pool:
         results: List[Any] = pool.map(build_mtgjson_card, sf_cards)
 
         all_cards: List[MTGJSONCard] = []

--- a/mtgjson4/compressor.py
+++ b/mtgjson4/compressor.py
@@ -1,0 +1,111 @@
+""" MTGJSON Compression Tools """
+import bz2
+import gzip
+import logging
+import lzma
+import multiprocessing
+import pathlib
+import shutil
+from typing import Any, Callable, List
+import zipfile
+
+import mtgjson4
+
+LOGGER = logging.getLogger(__name__)
+
+
+def compress_output_folder() -> None:
+    """
+    Compress all files within the output folder, to prepare for
+    uploads to production
+    """
+    sql_files = [file for file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.sqlite")]
+
+    set_files = [
+        file
+        for file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.json")
+        if file.stem not in mtgjson4.OUTPUT_FILES
+    ]
+
+    compiled_files = [
+        file
+        for file in mtgjson4.COMPILED_OUTPUT_DIR.glob("*.json")
+        if file.stem in mtgjson4.OUTPUT_FILES
+    ]
+
+    deck_files = [
+        file for file in mtgjson4.COMPILED_OUTPUT_DIR.joinpath("decks").glob("*.json")
+    ]
+
+    # Compress individual files
+    LOGGER.info("Compressing individual files")
+    with multiprocessing.Pool(multiprocessing.cpu_count()) as pool:
+        pool.map(compress_file, sql_files + compiled_files + set_files + deck_files)
+
+    # Compress folders for each set file, and each deck file
+    compress_directory(set_files, "AllSetFiles")
+    compress_directory(deck_files, "AllDeckFiles")
+
+
+def compress_directory(files_to_compress: List[pathlib.Path], output_name: str) -> None:
+    """
+    Compress a directory using all supported compression methods
+    :param files_to_compress: Files to compress into a single archive
+    :param output_name: Name to give compressed archive
+    """
+    temp_dir = mtgjson4.COMPILED_OUTPUT_DIR.joinpath(output_name)
+
+    # Copy files to temporary folder
+    LOGGER.info("Creating temporary directory for {}".format(output_name))
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    for file in files_to_compress:
+        shutil.copy(str(file), str(temp_dir))
+
+    # Compress the archives
+    LOGGER.info("Compressing {}".format(temp_dir.name))
+    with multiprocessing.Pool(multiprocessing.cpu_count()) as pool:
+        # Compression methods
+        pool.apply_async(shutil.make_archive, (temp_dir, "bztar", str(temp_dir)))
+        pool.apply_async(shutil.make_archive, (temp_dir, "gztar", str(temp_dir)))
+        pool.apply_async(shutil.make_archive, (temp_dir, "xztar", str(temp_dir)))
+        pool.apply_async(shutil.make_archive, (temp_dir, "zip", str(temp_dir)))
+
+        # Wait for compressions to finish
+        pool.close()
+        pool.join()
+
+    # Delete the temporary folder
+    LOGGER.info("Removing temporary directory for {}".format(output_name))
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def compress_file(file_path: pathlib.Path) -> None:
+    """
+    Compress a single file using all supported compression methods
+    :param file_path: Path of file to compress
+    """
+    LOGGER.info("Compressing {}".format(file_path.name))
+    __generic_compressor(file_path, ".bz2", bz2.compress)
+    __generic_compressor(file_path, ".gz", gzip.compress)
+    __generic_compressor(file_path, ".xz", lzma.compress)
+
+    # Zip files are done a bit differently
+    with zipfile.ZipFile(str(file_path) + ".zip", "w") as zip_out:
+        zip_out.write(file_path, file_path.name, zipfile.ZIP_DEFLATED)
+
+
+def __generic_compressor(
+    input_file_path: pathlib.Path,
+    file_ending: str,
+    compress_function: Callable[[Any], Any],
+) -> None:
+    """
+    Compress a single file
+    :param input_file_path: File to compress
+    :param file_ending: Ending to add onto archive
+    :param compress_function: Function that compresses
+    """
+    output_file_path = pathlib.Path(str(input_file_path) + file_ending)
+
+    with input_file_path.open("rb") as f_in, output_file_path.open("wb") as f_out:
+        f_out.write(compress_function(f_in.read()))

--- a/mtgjson4/outputter.py
+++ b/mtgjson4/outputter.py
@@ -318,7 +318,7 @@ def create_compiled_list(files_to_add: List[str]) -> Dict[str, Any]:
     :return: Dict to write
     """
     return {
-        "files": files_to_add,
+        "files": sorted(files_to_add),
         "meta": {"version": mtgjson4.__VERSION__, "date": mtgjson4.__VERSION_DATE__},
     }
 
@@ -329,29 +329,14 @@ def create_and_write_compiled_outputs() -> None:
     (ex: AllSets.json, AllCards.json, Standard.json)
     """
     # Compiled output files
-    files_to_ignore: List[str] = [
-        mtgjson4.ALL_CARDS_OUTPUT,
-        mtgjson4.ALL_DECKS_DIR_OUTPUT,
-        mtgjson4.ALL_SETS_DIR_OUTPUT,
-        mtgjson4.ALL_SETS_OUTPUT,
-        mtgjson4.CARD_TYPES_OUTPUT,
-        mtgjson4.COMPILED_LIST_OUTPUT,
-        mtgjson4.DECK_LISTS_OUTPUT,
-        mtgjson4.KEY_WORDS_OUTPUT,
-        mtgjson4.MODERN_OUTPUT,
-        mtgjson4.SET_LIST_OUTPUT,
-        mtgjson4.STANDARD_OUTPUT,
-        mtgjson4.VERSION_OUTPUT,
-        mtgjson4.VINTAGE_OUTPUT,
-    ]
 
     # CompiledList.json -- do not include ReferralMap
     write_to_file(
-        mtgjson4.COMPILED_LIST_OUTPUT, create_compiled_list(sorted(files_to_ignore))
+        mtgjson4.COMPILED_LIST_OUTPUT,
+        create_compiled_list(
+            list(set(mtgjson4.OUTPUT_FILES) - {mtgjson4.REFERRAL_DB_OUTPUT})
+        ),
     )
-
-    # File that should be also ignored -- must be added AFTER CompiledList.json
-    files_to_ignore.append(mtgjson4.REFERRAL_DB_OUTPUT)
 
     # Keywords.json
     key_words = wizards.compile_comp_output()
@@ -366,15 +351,15 @@ def create_and_write_compiled_outputs() -> None:
     write_to_file(mtgjson4.VERSION_OUTPUT, version_info)
 
     # SetList.json
-    set_list_info = get_all_set_list(files_to_ignore)
+    set_list_info = get_all_set_list(mtgjson4.OUTPUT_FILES)
     write_to_file(mtgjson4.SET_LIST_OUTPUT, set_list_info)
 
     # AllSets.json
-    all_sets = create_all_sets(files_to_ignore)
+    all_sets = create_all_sets(mtgjson4.OUTPUT_FILES)
     write_to_file(mtgjson4.ALL_SETS_OUTPUT, all_sets)
 
     # AllCards.json
-    all_cards = create_all_cards(files_to_ignore)
+    all_cards = create_all_cards(mtgjson4.OUTPUT_FILES)
     write_to_file(mtgjson4.ALL_CARDS_OUTPUT, all_cards)
 
     # Standard.json
@@ -384,7 +369,7 @@ def create_and_write_compiled_outputs() -> None:
     write_to_file(mtgjson4.MODERN_OUTPUT, create_modern_only_output())
 
     # Vintage.json
-    all_sets_no_fun = create_vintage_only_output(files_to_ignore)
+    all_sets_no_fun = create_vintage_only_output(mtgjson4.OUTPUT_FILES)
     write_to_file(mtgjson4.VINTAGE_OUTPUT, all_sets_no_fun)
 
     # decks/*.json


### PR DESCRIPTION
- Add compression operation to the build script (-z)
- Cleanup for global variables
- MP uses cpu count over hardcoded value
- Outputter fixed up so no longer has to have specific ordering

Single file test:
```
$ md5sum GTC*.json
33fcfa6b3d9f5aa831d54fcfda8643d1  GTC 2.json
33fcfa6b3d9f5aa831d54fcfda8643d1  GTC 3.json
33fcfa6b3d9f5aa831d54fcfda8643d1  GTC 4.json
33fcfa6b3d9f5aa831d54fcfda8643d1  GTC 5.json
33fcfa6b3d9f5aa831d54fcfda8643d1  GTC.json
```

```
$ md5sum AllSetFiles/* | md5sum
4295aab7789378da9885cb85daf317cd  -
$ rm -rf AllSetFiles
$ mv AllSetFiles\ 2 AllSetFiles
$ md5sum AllSetFiles/* | md5sum
4295aab7789378da9885cb85daf317cd  -
```