### PR TITLE
Fix dueldeck not marking GS1

### DIFF
--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -158,7 +158,8 @@ def build_output_file(
     # Cleanups and UUIDs
     mtgjson_card.DUEL_DECK_LAND_MARKED.set(False)
     mtgjson_card.DUEL_DECK_SIDE_COMP.set("a")
-    for card in output_file["cards"]:
+
+    for card in sorted(output_file["cards"]):
         card.final_card_cleanup()
     for token in output_file["tokens"]:
         token.final_card_cleanup(is_card=False)

--- a/mtgjson4/mtgjson_card.py
+++ b/mtgjson4/mtgjson_card.py
@@ -42,6 +42,22 @@ class MTGJSONCard:
         """
         return str(self.card_attributes)
 
+    def __eq__(self, other: Any) -> bool:
+        """
+        Determine if two cards are the same
+        :param other: Other card
+        :return: Same card or not
+        """
+        return bool(self.get("number") == other.get("number"))
+
+    def __lt__(self, other: Any) -> bool:
+        """
+        Determine if this card is less than another
+        :param other: Other card
+        :return: Less than or greater than
+        """
+        return int(self.get("number")) < int(other.get("number"))
+
     def clear(self) -> None:
         """
         Clear all attributes on the card

--- a/mtgjson4/mtgjson_card.py
+++ b/mtgjson4/mtgjson_card.py
@@ -262,7 +262,7 @@ class MTGJSONCard:
         """
         self.set("uuid", self.get_uuid(is_card))
 
-        if self.set_code.startswith("DD"):
+        if self.set_code.startswith("DD") or self.set_code in ["GS1"]:
             self.__mark_duel_decks()
 
         self.__remove_unnecessary_fields()


### PR DESCRIPTION
Fix #347 

Made MTGJSON class sortable so we could address incorrect dueldeck markings too.

[diff.txt](https://github.com/mtgjson/mtgjson/files/3219064/diff.txt)

