### PR TITLE
ADD isForeignOnly for sets that are not printed in english

### DIFF
--- a/mtgjson4/__init__.py
+++ b/mtgjson4/__init__.py
@@ -126,6 +126,26 @@ BANNED_FILE_NAMES: List[str] = [
     "PRN",
 ]
 
+# Globals -- non-english sets
+NON_ENGLISH_SETS: List[str] = [
+    "PMPS11",
+    "PS11",
+    "PMPS10",
+    "PMPS09",
+    "PMPS08",
+    "PMPS07",
+    "PMPS06",
+    "PSA1",
+    "PMPS",
+    "PJJT",
+    "PHJ",
+    "PRED",
+    "REN",
+    "RIN",
+    "4BB",
+    "FBB",
+]
+
 
 def init_logger() -> None:
     """

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -95,6 +95,9 @@ def build_output_file(
     if "foil_only" in set_config.keys():
         output_file["isFoilOnly"] = set_config["foil_only"]
 
+    if set_code.upper() in mtgjson4.NON_ENGLISH_SETS:
+        output_file["isForeignOnly"] = True
+
     # Add booster info based on boosters resource (manually maintained for the time being)
     with mtgjson4.RESOURCE_PATH.joinpath("boosters.json").open(
         "r", encoding="utf-8"

--- a/mtgjson4/mtgjson_card.py
+++ b/mtgjson4/mtgjson_card.py
@@ -56,7 +56,10 @@ class MTGJSONCard:
         :param other: Other card
         :return: Less than or greater than
         """
-        return int(self.get("number")) < int(other.get("number"))
+        try:
+            return int(self.get("number")) < int(other.get("number"))
+        except ValueError:
+            return self.get("number") < other.get("number")
 
     def clear(self) -> None:
         """

--- a/mtgjson4/mtgjson_card.py
+++ b/mtgjson4/mtgjson_card.py
@@ -59,7 +59,7 @@ class MTGJSONCard:
         try:
             return int(self.get("number")) < int(other.get("number"))
         except ValueError:
-            return self.get("number") < other.get("number")
+            return bool(self.get("number") < other.get("number"))
 
     def clear(self) -> None:
         """


### PR DESCRIPTION
Fix #346 

Add the field `isForeignOnly` to indicate a set is not in english in any way.