### PR TITLE
Make decks more distinguished by including set codes in names.

### DIFF
--- a/mtgjson4/outputter.py
+++ b/mtgjson4/outputter.py
@@ -396,7 +396,7 @@ def create_and_write_compiled_outputs() -> None:
     deck_names = []
     for deck in magic_precons.build_and_write_decks(DECKS_URL):
         deck_name = util.capital_case_without_symbols(deck["name"])
-        write_deck_to_file(deck_name, deck)
+        write_deck_to_file("{}_{}".format(deck_name, deck["code"]), deck)
         deck_names.append(
             {
                 "code": deck["code"],


### PR DESCRIPTION
Fix #365 

Decks are now more distinguished by including set codes in the names.

<img width="290" alt="Screenshot 2019-06-12 13 43 45" src="https://user-images.githubusercontent.com/7460172/59373647-1bffef00-8d18-11e9-88fb-b6517d93ae5e.png">
