### PR TITLE
Add foil prices

### DIFF
--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -215,8 +215,11 @@ def add_stocks_data(cards: List[MTGJSONCard]) -> List[MTGJSONCard]:
                 card.set_all(
                     {
                         "mtgstocksId": stocks_data["id"],
-                        "prices": {"paper": stocks_data["prices"]},
-                        # Future additions may include: "mtgo", "paper_foil", and "mtga"
+                        "prices": {
+                            "paper": stocks_data["paper"],
+                            "paper_foil": stocks_data["foil"],
+                        },
+                        # Future additions may include: "mtgo", "mtgo_foil", and "mtga"
                     }
                 )
         else:

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -217,7 +217,7 @@ def add_stocks_data(cards: List[MTGJSONCard]) -> List[MTGJSONCard]:
                         "mtgstocksId": stocks_data["id"],
                         "prices": {
                             "paper": stocks_data["paper"],
-                            "paper_foil": stocks_data["foil"],
+                            "paperFoil": stocks_data["foil"],
                         },
                         # Future additions may include: "mtgo", "mtgo_foil", and "mtga"
                     }

--- a/mtgjson4/provider/mtgstocks.py
+++ b/mtgjson4/provider/mtgstocks.py
@@ -69,6 +69,10 @@ def __get_stocks_data() -> Dict[str, Any]:
         if (not is_file) or cache_expired:
             # Rebuild set translations
             session = __get_session()
+            if not SESSION_TOKEN.get(""):
+                LOGGER.warning("No MTGStocks token found, skipping...")
+                return {}
+
             response: Any = session.get(
                 url=MTG_STOCKS_API_URL.format(SESSION_TOKEN.get("")), timeout=5.0
             )


### PR DESCRIPTION
Foil prices added to the MTGJSON data set. Same frequency as non-foil prices and such.

If cards have foil and/or non-foil, the empty one will be well... empty.

```
{
    "paper": {},
    "paperFoil": {...},
    ...
}
```

**NOTE:** No merge until release is ready (as MTGStocks won't be live with the update until Sunday)