### PR TITLE
Add isPaper isMtgo and isArena to card attributes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -28,7 +28,8 @@ disable=
     too-many-branches,
     import-error,
     too-many-public-methods,
-    duplicate-code
+    duplicate-code,
+    too-many-locals
 
 
 [REPORTS]

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -769,6 +769,10 @@ def build_mtgjson_card(
             single_card.clean_up_watermark,
         )
 
+    # "isPaper", "isMtgo", "isArena"
+    for game_mode in sf_card.get("games"):
+        single_card.set("is{}".format(game_mode.capitalize()), True)
+
     if "flavor_text" in face_data:
         single_card.set("flavorText", face_data.get("flavor_text"))
     else:

--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -770,7 +770,7 @@ def build_mtgjson_card(
         )
 
     # "isPaper", "isMtgo", "isArena"
-    for game_mode in sf_card.get("games"):
+    for game_mode in sf_card.get("games", []):
         single_card.set("is{}".format(game_mode.capitalize()), True)
 
     if "flavor_text" in face_data:


### PR DESCRIPTION
Fix #396 

Pops right from SF's games array. It has 3 possible values, and this allows for future improvements.


[diff.txt](https://github.com/mtgjson/mtgjson/files/3327861/diff.txt)
[DOM.json.txt](https://github.com/mtgjson/mtgjson/files/3327862/DOM.json.txt)
