### PR TITLE
Better handle of face artists

### DIFF
--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -668,7 +668,10 @@ def build_mtgjson_card(
         if sf_card["card_faces"][-1]["oracle_text"].startswith("Aftermath"):
             single_card.set("layout", "aftermath")
 
-        single_card.set("artist", sf_card["card_faces"][sf_card_face].get("artist", ""))
+        # Only set artist if it is defined within the face
+        # Otherwise we will define it later
+        if sf_card["card_faces"][sf_card_face].get("artist", None):
+            single_card.set("artist", sf_card["card_faces"][sf_card_face]["artist"])
 
         # Recursively parse the other cards within this card too
         # Only call recursive if it is the first time we see this card object


### PR DESCRIPTION
Fix #403 

Seems that it added a blank artist string, which was parsed out later. Instead, don't set it and let the backup system catch it later on