### PR TITLE
Add brackets to planeswalker abilities

### DIFF
--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from mkmsdk.api_map import _API_MAP
 from mkmsdk.mkm import Mkm
-
 import mtgjson4
 from mtgjson4 import mtgjson_card
 from mtgjson4.mtgjson_card import MTGJSONCard
@@ -667,8 +666,8 @@ def build_mtgjson_card(
         # Watermark is only attributed on the front side, so we'll account for it
         single_card.set(
             "watermark",
-            sf_card["card_faces"][0].get("watermark", None),
-            single_card.clean_up_watermark,
+            sf_card["card_faces"][0].get("watermark", ""),
+            single_card.cleanup_watermark,
         )
 
         if sf_card["card_faces"][-1]["oracle_text"].startswith("Aftermath"):
@@ -773,9 +772,7 @@ def build_mtgjson_card(
 
     if "watermark" not in single_card.keys():
         single_card.set(
-            "watermark",
-            face_data.get("watermark", None),
-            single_card.clean_up_watermark,
+            "watermark", face_data.get("watermark", ""), single_card.cleanup_watermark
         )
 
     # "isPaper", "isMtgo", "isArena"
@@ -834,6 +831,12 @@ def build_mtgjson_card(
     single_card.set("supertypes", card_types[0])
     single_card.set("types", card_types[1])
     single_card.set("subtypes", card_types[2])
+
+    # Add brackets around Planeswalker loyalty abilities
+    if "Planeswalker" in single_card.get("types"):
+        single_card.set(
+            "text", single_card.get("text"), single_card.cleanup_planeswalker_costs
+        )
 
     # Handle meld and all parts tokens issues
     # Will re-address naming if a split card already

--- a/mtgjson4/mtgjson_card.py
+++ b/mtgjson4/mtgjson_card.py
@@ -4,6 +4,7 @@ MTGJSON Card Class Container
 import contextvars
 import json
 import logging
+import re
 from typing import Any, Callable, Dict, Iterator, KeysView, List, Optional, Tuple
 import uuid
 
@@ -250,7 +251,19 @@ class MTGJSONCard:
             )
         )
 
-    def clean_up_watermark(self, watermark: Optional[str]) -> Optional[str]:
+    @staticmethod
+    def cleanup_planeswalker_costs(card_text: str) -> str:
+        """
+        Planeswalker abilities have a cost. We distinguish this
+        cost via [COST]: to give the end user a better breakdown
+        of what the card is doing. Ex: "-2:" becomes "[-2]:"
+        :param card_text: Un-formatted text
+        :return: Re-formatted text for planeswalkers
+        """
+        # Most PWs use the correct dash, but include minus just in case
+        return re.sub(r"([+−-]?[0-9]+):", r"[\1]:", card_text)
+
+    def cleanup_watermark(self, watermark: str) -> Optional[str]:
         """
         Scryfall (currently) doesn't provide what set watermarks
         are of, only "set" so we will add it ourselves using

--- a/mtgjson4/provider/wizards.py
+++ b/mtgjson4/provider/wizards.py
@@ -8,11 +8,11 @@ import time
 from typing import Any, Dict, List, Match, Optional, Tuple
 
 import bs4
-import unidecode
 
 import mtgjson4
 from mtgjson4 import util
 from mtgjson4.provider import gamepedia, scryfall
+import unidecode
 
 TRANSLATION_URL: str = "https://magic.wizards.com/{}/products/card-set-archive"
 COMP_RULES: str = "https://magic.wizards.com/en/game-info/gameplay/rules-and-formats/rules"


### PR DESCRIPTION
Fix #400

Change Planeswalker abilities from `+2: ...` to `[+2]: ...`  Seems to be a popular approach from my github users.

[DOM.json.txt](https://github.com/mtgjson/mtgjson/files/3350853/DOM.json.txt)
[WAR.json.txt](https://github.com/mtgjson/mtgjson/files/3350854/WAR.json.txt)
