### PR TITLE
Pricing split to separate file

### DIFF
--- a/mtgjson4/__init__.py
+++ b/mtgjson4/__init__.py
@@ -54,6 +54,7 @@ CARD_TYPES_OUTPUT: str = "CardTypes"
 COMPILED_LIST_OUTPUT: str = "CompiledList"
 DECK_LISTS_OUTPUT: str = "DeckLists"
 KEY_WORDS_OUTPUT: str = "Keywords"
+PRICES_OUTPUT: str = "Prices"
 REFERRAL_DB_OUTPUT: str = "ReferralMap"
 SET_LIST_OUTPUT: str = "SetList"
 VERSION_OUTPUT: str = "version"
@@ -99,6 +100,7 @@ OUTPUT_FILES: List[str] = [
     VINTAGE_CARDS_OUTPUT,
     LEGACY_CARDS_OUTPUT,
     PAUPER_CARDS_OUTPUT,
+    PRICES_OUTPUT,
 ]
 
 # Provider tags

--- a/mtgjson4/__main__.py
+++ b/mtgjson4/__main__.py
@@ -9,8 +9,9 @@ from typing import Any, Dict, List
 
 import mtgjson4
 from mtgjson4 import compile_mtg, compressor, outputter
+from mtgjson4.compile_prices import MtgjsonPrice
 from mtgjson4.mtgjson_card import MTGJSONCard
-from mtgjson4.provider import scryfall
+from mtgjson4.provider import scryfall, mtgstocks
 import mtgjson4.util
 
 LOGGER = logging.getLogger(__name__)
@@ -87,6 +88,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--skip-sets", metavar="SET", nargs="*", type=str)
     parser.add_argument("--skip-cache", action="store_true")
     parser.add_argument("-p", "--pretty-output", action="store_true")
+    parser.add_argument("--pricing", action="store_true")
 
     # Ensure there are args
     if len(sys.argv) < 2:
@@ -139,6 +141,16 @@ def main() -> None:
         LOGGER.warning(
             f"No properties file found at {mtgjson4.CONFIG_PATH}. Will download without authentication"
         )
+
+    # Are we only rebuilding pricing?
+    if args.pricing:
+        mtgjson4.COMPILED_OUTPUT_DIR.mkdir(exist_ok=True)
+        LOGGER.info(f"Rebuilding price data for {mtgjson4.COMPILED_OUTPUT_DIR.name}")
+        prices = MtgjsonPrice(
+            mtgjson4.COMPILED_OUTPUT_DIR.joinpath(mtgjson4.ALL_SETS_OUTPUT + ".json")
+        )
+        outputter.output_price_file(prices)
+        return
 
     # Determine set(s) to build
     args_s = args.s if args.s else []

--- a/mtgjson4/__main__.py
+++ b/mtgjson4/__main__.py
@@ -11,7 +11,7 @@ import mtgjson4
 from mtgjson4 import compile_mtg, compressor, outputter
 from mtgjson4.compile_prices import MtgjsonPrice
 from mtgjson4.mtgjson_card import MTGJSONCard
-from mtgjson4.provider import scryfall, mtgstocks
+from mtgjson4.provider import scryfall
 import mtgjson4.util
 
 LOGGER = logging.getLogger(__name__)

--- a/mtgjson4/compile_prices.py
+++ b/mtgjson4/compile_prices.py
@@ -1,0 +1,108 @@
+"""
+Tool to generate prices from all sources
+"""
+import json
+import logging
+import multiprocessing
+import pathlib
+from typing import Any, Dict, List, Tuple, Union
+
+import mtgjson4
+from mtgjson4.provider import cardhoader, mtgstocks
+
+LOGGER = logging.getLogger(__name__)
+
+
+def build_price_data(card: Dict[str, Any]) -> Tuple[str, Dict[str, Dict[str, str]]]:
+    """
+    Build up price info for a single card and add it to global index
+    :param card: Card to get price data of
+    :return Card object
+    """
+    LOGGER.info(f"Building price for {card['name']}")
+    paper_pricing = mtgstocks.get_card_data(card.get("tcgplayerProductId", -1))
+    digital_pricing = cardhoader.get_card_data(card["uuid"])
+
+    return (
+        card["uuid"],
+        {
+            "prices": {
+                "paper": paper_pricing.get("paper", {}),
+                "paperFoil": paper_pricing.get("foil", {}),
+                "mtgo": digital_pricing.get("mtgo", {}),
+                "mtgoFoil": digital_pricing.get("mtgoFoil", {}),
+            }
+        },
+    )
+
+
+class MtgjsonPrice:
+    """
+    Class to construct MTGJSON Pricing data for additional download files.
+    """
+
+    def __init__(self, all_sets_path: Union[str, pathlib.Path]) -> None:
+        """
+        Initializer to load in cards and establish pricing database
+        :param all_sets_path: Path to AllSets.json
+        """
+        self.mtgjson_cards: List[Dict[str, Any]] = []
+        self.prices_output: Dict[str, Dict[str, Dict[str, str]]] = {}
+
+        self.all_sets_path = pathlib.Path(all_sets_path).expanduser()
+        if not self.all_sets_path.exists():
+            LOGGER.error(f"Pricing can't find AllSets at {self.all_sets_path}")
+            return
+
+        self.__load_mtgjson_cards_from_file()
+        self.__collate_pricing()
+
+    def __bool__(self) -> bool:
+        """
+        See if the class has been properly initialized
+        :return: Class initialization status
+        """
+        return bool(self.prices_output)
+
+    def get_price_database(self) -> str:
+        """
+        Get price data dumps for output files
+        :return: Price database
+        """
+        return json.dumps(
+            self.prices_output, sort_keys=True, indent=mtgjson4.PRETTY_OUTPUT.get()
+        )
+
+    def __load_mtgjson_cards_from_file(self) -> None:
+        """
+        Load in all MTGJSON cards from AllSets.json file
+        """
+        with self.all_sets_path.expanduser().open() as file:
+            all_sets = json.load(file)
+
+        for set_content in all_sets.values():
+            self.mtgjson_cards.extend(set_content.get("cards", []))
+
+    @staticmethod
+    def __prime_databases() -> None:
+        """
+        Prime price databases before multiprocessing iterations
+        """
+        mtgstocks.get_card_data(0)
+        cardhoader.get_card_data("")
+
+    def __collate_pricing(self) -> None:
+        """
+        Build up price databases in parallel
+        """
+        LOGGER.info("Priming Database")
+        self.__prime_databases()
+
+        LOGGER.info("Starting Pool")
+        with multiprocessing.Pool(multiprocessing.cpu_count()) as pool:
+            futures = pool.map_async(build_price_data, self.mtgjson_cards)
+            pool.close()
+            pool.join()
+
+        for card_price in futures.get():
+            self.prices_output[card_price[0]] = card_price[1]

--- a/mtgjson4/outputter.py
+++ b/mtgjson4/outputter.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Set
 
 import mtgjson4
 from mtgjson4 import SUPPORTED_FORMAT_OUTPUTS, util
+from mtgjson4.compile_prices import MtgjsonPrice
 from mtgjson4.mtgjson_card import MTGJSONCard
 from mtgjson4.provider import magic_precons, scryfall, wizards
 
@@ -419,6 +420,24 @@ def create_set_centric_outputs(sets: Dict[str, Any]) -> None:
     write_to_file(
         mtgjson4.VINTAGE_OUTPUT, create_vintage_only_output(mtgjson4.OUTPUT_FILES)
     )
+
+    # Prices.json
+    output_price_file(
+        MtgjsonPrice(mtgjson4.COMPILED_OUTPUT_DIR.joinpath(mtgjson4.ALL_SETS_OUTPUT))
+    )
+
+
+def output_price_file(pricing_data: MtgjsonPrice) -> None:
+    """
+    Write out MTGJSON price data
+    :param pricing_data: Data object to dump
+    :return:
+    """
+    if pricing_data:
+        with mtgjson4.COMPILED_OUTPUT_DIR.joinpath(
+            mtgjson4.PRICES_OUTPUT + ".json"
+        ).open("w", encoding="utf-8") as f:
+            f.write(pricing_data.get_price_database())
 
 
 def create_card_centric_outputs(cards: Dict[str, Any]) -> None:

--- a/mtgjson4/provider/cardhoader.py
+++ b/mtgjson4/provider/cardhoader.py
@@ -93,7 +93,8 @@ def __get_ch_data() -> Dict[str, Dict[str, str]]:
         __get_session()
         if not SESSION_TOKEN.get(""):
             LOGGER.warning("No CardHoarder token found, skipping...")
-            return {}
+            CH_PRICE_DATA = {"Empty": {}}
+            return CH_PRICE_DATA
 
         today_date = datetime.datetime.today().strftime("%Y-%m-%d")
 

--- a/mtgjson4/provider/mtgstocks.py
+++ b/mtgjson4/provider/mtgstocks.py
@@ -70,7 +70,8 @@ def __get_stocks_data() -> Dict[str, Any]:
             session = __get_session()
             if not SESSION_TOKEN.get(""):
                 LOGGER.warning("No MTGStocks token found, skipping...")
-                return {}
+                STOCKS_DATA.set({})
+                return dict(STOCKS_DATA.get())
 
             response: Any = session.get(
                 url=MTG_STOCKS_API_URL.format(SESSION_TOKEN.get("")), timeout=5.0
@@ -99,3 +100,22 @@ def get_card_data(tcgplayer_id: int) -> Dict[str, Any]:
     :return: MTGStocks map
     """
     return __get_stocks_data().get(str(tcgplayer_id), {})
+
+
+def get_latest_card_data(tcgplayer_id: int) -> Dict[str, Any]:
+    """
+    Only get the last value from the card data (should be last date)
+    :param tcgplayer_id: ID to find card by
+    :return: MTGStocks map w/ 1 entry max
+    """
+    full_data = get_card_data(tcgplayer_id)
+    if full_data:
+        if full_data["paper"]:
+            resp = max(full_data["paper"].items(), key=lambda x: x[0])
+            full_data["paper"] = {resp[0]: resp[1]}
+
+        if full_data["foil"]:
+            resp = max(full_data["foil"].items(), key=lambda x: x[0])
+            full_data["foil"] = {resp[0]: resp[1]}
+
+    return full_data


### PR DESCRIPTION
This is the start of file splitting. We will update smaller chunks of MTGJSON on a daily basis and provide those as separate download options.

The main MTGJSON dump will be stripped of most price data. We will continue to server the same key/values as expected, but will only have up to one entry per field (i.e. the latest price on mtgo and in paper, foil/not-foil).

The new `Prices.json` file will be updated daily and is index-able by MTGJSON uuids. That will return a prices array that can be pulled from to enhance an application, if necessary. This cuts down on the download size for most people who may not care about pricing, and gives enhanced options for us to rebuild the system in a cost-effective manner.

Tagging @omfgitsmark for handling SQLite/MySQL changes, as I'm not sure of the logistics on that front currently.

Tagging @staghouse for handling of website related changes.