### PR TITLE
Handle frame effects

### DIFF
--- a/mtgjson4/compile_mtg.py
+++ b/mtgjson4/compile_mtg.py
@@ -725,7 +725,8 @@ def build_mtgjson_card(
             "colorIdentity": sf_card.get("color_identity"),
             "convertedManaCost": sf_card.get("cmc"),
             "edhrecRank": sf_card.get("edhrec_rank"),
-            "frameEffect": sf_card.get("frame_effect"),
+            "frameEffect": sf_card.get("frame_effects", [""])[0],  # REMOVE IN 4.7.0
+            "frameEffects": sf_card.get("frame_effects"),
             "frameVersion": sf_card.get("frame"),
             "hand": sf_card.get("hand_modifier"),
             "hasFoil": sf_card.get("foil"),

--- a/mtgjson4/mtgjson_card.py
+++ b/mtgjson4/mtgjson_card.py
@@ -341,7 +341,8 @@ class MTGJSONCard:
         Remove invalid field entries to shrink JSON output size
         """
         remove_field_if_false: List[str] = [
-            "frameEffect",
+            "frameEffect",  # REMOVE IN 4.7.0
+            "frameEffects",
             "isFullArt",
             "isOnlineOnly",
             "isOversized",

--- a/mtgjson4/outputter.py
+++ b/mtgjson4/outputter.py
@@ -125,7 +125,8 @@ def create_all_cards(files_to_ignore: List[str]) -> Dict[str, Any]:
                 card.pop("borderColor", None)
                 card.pop("duelDeck", None)
                 card.pop("flavorText", None)
-                card.pop("frameEffect", None)
+                card.pop("frameEffect", None)  # REMOVE IN 4.7.0
+                card.pop("frameEffects", None)
                 card.pop("frameVersion", None)
                 card.pop("hasFoil", None)
                 card.pop("hasNonFoil", None)


### PR DESCRIPTION
Fix #463 
SF removed frame_effect, so I'll have to do this same at some point. Backwards support kept until 4.7.0, but marking as deprecated. (cc: @staghouse )

This ADDS `frameEffects` which is an array(str) that contains any and all frame effects taking place.

DEPRECATED `frameEffect` for removal in 4.7.0, but has support until then in full.