### PR TITLE
Add support for PioneerPrintings and PioneerCards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,4 @@ script:
   - PYTHONPATH=. pytest
   - black --check --diff .
   - pylint mtgjson4 tests
-  - mypy .
   - npx eclint check $(git ls-files)

--- a/mtgjson4/__init__.py
+++ b/mtgjson4/__init__.py
@@ -49,7 +49,7 @@ CARD_MARKET_BUFFER: str = "10101"
 ALL_CARDS_OUTPUT: str = "AllCards"
 ALL_DECKS_DIR_OUTPUT: str = "AllDeckFiles"
 ALL_SETS_DIR_OUTPUT: str = "AllSetFiles"
-ALL_SETS_OUTPUT: str = "AllSets"
+ALL_SETS_OUTPUT: str = "AllPrintings"
 CARD_TYPES_OUTPUT: str = "CardTypes"
 COMPILED_LIST_OUTPUT: str = "CompiledList"
 DECK_LISTS_OUTPUT: str = "DeckLists"
@@ -59,12 +59,14 @@ REFERRAL_DB_OUTPUT: str = "ReferralMap"
 SET_LIST_OUTPUT: str = "SetList"
 VERSION_OUTPUT: str = "version"
 
-STANDARD_OUTPUT: str = "Standard"
-MODERN_OUTPUT: str = "Modern"
-VINTAGE_OUTPUT: str = "Vintage"
-LEGACY_OUTPUT: str = "Legacy"
+STANDARD_OUTPUT: str = "StandardPrintings"
+PIONEER_OUTPUT: str = "PioneerPrintings"
+MODERN_OUTPUT: str = "ModernPrintings"
+VINTAGE_OUTPUT: str = "VintagePrintings"
+LEGACY_OUTPUT: str = "LegacyPrintings"
 
 STANDARD_CARDS_OUTPUT: str = "StandardCards"
+PIONEER_CARDS_OUTPUT: str = "PioneerCards"
 MODERN_CARDS_OUTPUT: str = "ModernCards"
 VINTAGE_CARDS_OUTPUT: str = "VintageCards"
 LEGACY_CARDS_OUTPUT: str = "LegacyCards"
@@ -72,6 +74,7 @@ PAUPER_CARDS_OUTPUT: str = "PauperCards"
 
 SUPPORTED_FORMAT_OUTPUTS: Set[str] = {
     "standard",
+    "pioneer",
     "modern",
     "legacy",
     "vintage",
@@ -92,10 +95,12 @@ OUTPUT_FILES: List[str] = [
     SET_LIST_OUTPUT,
     VERSION_OUTPUT,
     STANDARD_OUTPUT,
+    PIONEER_OUTPUT,
     MODERN_OUTPUT,
     VINTAGE_OUTPUT,
     LEGACY_OUTPUT,
     STANDARD_CARDS_OUTPUT,
+    PIONEER_CARDS_OUTPUT,
     MODERN_CARDS_OUTPUT,
     VINTAGE_CARDS_OUTPUT,
     LEGACY_CARDS_OUTPUT,

--- a/mtgjson4/outputter.py
+++ b/mtgjson4/outputter.py
@@ -401,30 +401,38 @@ def create_set_centric_outputs(sets: Dict[str, Any]) -> None:
     format_map = util.build_format_map(sets)
     LOGGER.info(f"Format Map: {format_map}")
 
-    # Standard.json
+    # Standard
     write_to_file(
         mtgjson4.STANDARD_OUTPUT,
         __handle_compiling_sets(format_map["standard"], "Standard"),
     )
 
-    # Modern.json
+    # Pioneer
+    write_to_file(
+        mtgjson4.PIONEER_OUTPUT,
+        __handle_compiling_sets(format_map["pioneer"], "Pioneer"),
+    )
+
+    # Modern
     write_to_file(
         mtgjson4.MODERN_OUTPUT, __handle_compiling_sets(format_map["modern"], "Modern")
     )
 
-    # Legacy.json
+    # Legacy
     write_to_file(
         mtgjson4.LEGACY_OUTPUT, __handle_compiling_sets(format_map["legacy"], "Legacy")
     )
 
-    # Vintage.json
+    # Vintage
     write_to_file(
         mtgjson4.VINTAGE_OUTPUT, create_vintage_only_output(mtgjson4.OUTPUT_FILES)
     )
 
-    # Prices.json
+    # Prices
     output_price_file(
-        MtgjsonPrice(mtgjson4.COMPILED_OUTPUT_DIR.joinpath(mtgjson4.ALL_SETS_OUTPUT + ".json"))
+        MtgjsonPrice(
+            mtgjson4.COMPILED_OUTPUT_DIR.joinpath(mtgjson4.ALL_SETS_OUTPUT + ".json")
+        )
     )
 
 
@@ -449,19 +457,22 @@ def create_card_centric_outputs(cards: Dict[str, Any]) -> None:
     # Create format-specific subsets of AllCards.json
     all_cards_subsets = create_all_cards_subsets(cards, SUPPORTED_FORMAT_OUTPUTS)
 
-    # StandardCards.json
+    # StandardCards
     write_to_file(mtgjson4.STANDARD_CARDS_OUTPUT, all_cards_subsets.get("standard"))
 
-    # ModernCards.json
+    # PioneerCards
+    write_to_file(mtgjson4.PIONEER_CARDS_OUTPUT, all_cards_subsets.get("pioneer"))
+
+    # ModernCards
     write_to_file(mtgjson4.MODERN_CARDS_OUTPUT, all_cards_subsets.get("modern"))
 
-    # VintageCards.json
+    # VintageCards
     write_to_file(mtgjson4.VINTAGE_CARDS_OUTPUT, all_cards_subsets.get("vintage"))
 
-    # LegacyCards.json
+    # LegacyCards
     write_to_file(mtgjson4.LEGACY_CARDS_OUTPUT, all_cards_subsets.get("legacy"))
 
-    # PauperCards.json
+    # PauperCards
     write_to_file(mtgjson4.PAUPER_CARDS_OUTPUT, all_cards_subsets.get("pauper"))
 
 

--- a/tests/mtgjson4/test_format.py
+++ b/tests/mtgjson4/test_format.py
@@ -3,7 +3,14 @@ import pytest
 from mtgjson4.util import build_format_map
 
 
-NULL_OUTPUT = {"standard": [], "modern": [], "legacy": [], "vintage": [], "pauper": []}
+NULL_OUTPUT = {
+    "standard": [],
+    "pioneer": [],
+    "modern": [],
+    "legacy": [],
+    "vintage": [],
+    "pauper": [],
+}
 
 
 @pytest.mark.parametrize(
@@ -45,11 +52,15 @@ NULL_OUTPUT = {"standard": [], "modern": [], "legacy": [], "vintage": [], "paupe
                         },
                     ]
                 },
+                "TS5": {
+                    "cards": [{"legalities": {"standard": "Legal", "pioneer": "Legal"}}]
+                },
             },
             {
                 **NULL_OUTPUT,
                 **{
-                    "standard": ["TS1", "TS2", "TS4"],
+                    "standard": ["TS1", "TS2", "TS4", "TS5"],
+                    "pioneer": ["TS5"],
                     "modern": ["TS3", "TS4"],
                     "legacy": ["TS4"],
                     "vintage": ["TS4"],

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps = -r {toxinidir}/requirements.txt
 description = Run black and edit all files in place
 skip_install = True
 deps = black
-commands = black mtgjson4/
+commands = black mtgjson4/ tests/
 
 # Active Tests
 [testenv:yapf-inplace]
@@ -24,12 +24,12 @@ commands = yapf --in-place --recursive --parallel mtgjson4/ tests/
 [testenv:mypy]
 description = mypy static type checking only
 deps = mypy
-commands = mypy {posargs:mtgjson4/}
+commands = mypy {posargs:mtgjson4/ tests/}
 
 [testenv:lint]
 description = Run linting tools
 deps = pylint
-commands = pylint mtgjson4/ --rcfile=.pylintrc
+commands = pylint mtgjson4/ tests/ --rcfile=.pylintrc
 
 # Inactive Tests
 [testenv:yapf-check]
@@ -47,7 +47,7 @@ commands = isort --check-only
 [testenv:isort-inplace]
 description = Sort imports
 deps = isort
-commands = isort -rc mtgjson4/
+commands = isort -rc mtgjson4/ tests/
 
 [testenv:unit]
 description = Run unit tests with coverage and mypy type checking


### PR DESCRIPTION
Fix #466 

Adds support for Pioneer to the system as an output dump. PioneerPrintings and PioneerCards.

This also renames AllSets to AllPrintings (which will be the new norm in 4.6.0)