### PR TITLE
Fix #668 added AllTcgSkus to compiled outputs 

### DIFF
--- a/mtgjson5/compiled_classes/__init__.py
+++ b/mtgjson5/compiled_classes/__init__.py
@@ -4,7 +4,7 @@ MTGJSON Compiled Outputs Dispatcher
 
 from .mtgjson_all_identifiers import MtgjsonAllIdentifiersObject
 from .mtgjson_all_printings import MtgjsonAllPrintingsObject
-from .mtgjson_all_tcg_skus import MtgjsonAllTcgSkusObject
+from .mtgjson_all_tcg_skus import MtgjsonAllTcgplayerSkusObject
 from .mtgjson_atomic_cards import MtgjsonAtomicCardsObject
 from .mtgjson_card_types import MtgjsonCardTypesObject
 from .mtgjson_compiled_list import MtgjsonCompiledListObject

--- a/mtgjson5/compiled_classes/__init__.py
+++ b/mtgjson5/compiled_classes/__init__.py
@@ -4,6 +4,7 @@ MTGJSON Compiled Outputs Dispatcher
 
 from .mtgjson_all_identifiers import MtgjsonAllIdentifiersObject
 from .mtgjson_all_printings import MtgjsonAllPrintingsObject
+from .mtgjson_all_tcg_skus import MtgjsonAllTcgSkusObject
 from .mtgjson_atomic_cards import MtgjsonAtomicCardsObject
 from .mtgjson_card_types import MtgjsonCardTypesObject
 from .mtgjson_compiled_list import MtgjsonCompiledListObject

--- a/mtgjson5/compiled_classes/__init__.py
+++ b/mtgjson5/compiled_classes/__init__.py
@@ -4,7 +4,6 @@ MTGJSON Compiled Outputs Dispatcher
 
 from .mtgjson_all_identifiers import MtgjsonAllIdentifiersObject
 from .mtgjson_all_printings import MtgjsonAllPrintingsObject
-from .mtgjson_all_tcg_skus import MtgjsonAllTcgplayerSkusObject
 from .mtgjson_atomic_cards import MtgjsonAtomicCardsObject
 from .mtgjson_card_types import MtgjsonCardTypesObject
 from .mtgjson_compiled_list import MtgjsonCompiledListObject
@@ -13,3 +12,4 @@ from .mtgjson_enum_values import MtgjsonEnumValuesObject
 from .mtgjson_keywords import MtgjsonKeywordsObject
 from .mtgjson_set_list import MtgjsonSetListObject
 from .mtgjson_structures import MtgjsonStructuresObject
+from .mtgjson_tcgplayer_skus import MtgjsonTcgplayerSkusObject

--- a/mtgjson5/compiled_classes/mtgjson_all_tcg_skus.py
+++ b/mtgjson5/compiled_classes/mtgjson_all_tcg_skus.py
@@ -1,0 +1,48 @@
+"""
+MTGJSON AllTcgSkus Object
+"""
+
+import logging
+import pathlib
+
+from typing import Dict, Any
+
+from mtgjson5.providers import TCGPlayerProvider
+from mtgjson5.providers.tcgplayer import get_tcgplayer_sku_data, get_tcgplayer_sku_map
+from mtgjson5.utils import generate_card_mapping
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MtgjsonAllTcgSkus:
+    """
+    MTGJSON AllTcgSkus Object
+    """
+
+    all_tcg_skus_dict: Dict[str, Dict[str, int]]
+
+    def __init__(self, all_printings_path: pathlib.Path) -> None:
+
+        self.all_tcg_skus_dict = {}
+
+        ids_and_names = TCGPlayerProvider().get_tcgplayer_magic_set_ids()
+
+        tcg_to_mtgjson_map = generate_card_mapping(
+            all_printings_path, ("identifiers", "tcgplayerProductId"), ("uuid",)
+        )
+        for group in ids_and_names:
+            tcgplayer_sku_data = get_tcgplayer_sku_data(group)
+            for product in tcgplayer_sku_data:
+                product_id = str(product["productId"])
+                key = tcg_to_mtgjson_map.get(product_id)
+                if not key:
+                    continue
+
+                self.all_tcg_skus_dict[key] = product["skus"]
+
+    def to_json(self) -> Dict[str, Dict[str, int]]:
+        """
+        Support json.dump()
+        :return: JSON serialized object
+        """
+        return self.all_identifiers_dict

--- a/mtgjson5/compiled_classes/mtgjson_all_tcg_skus.py
+++ b/mtgjson5/compiled_classes/mtgjson_all_tcg_skus.py
@@ -13,7 +13,7 @@ from ..utils import generate_card_mapping
 LOGGER = logging.getLogger(__name__)
 
 
-class MtgjsonAllTcgSkusObject:
+class MtgjsonAllTcgplayerSkusObject:
     """
     MTGJSON AllTcgSkus Object
     """

--- a/mtgjson5/compiled_classes/mtgjson_all_tcg_skus.py
+++ b/mtgjson5/compiled_classes/mtgjson_all_tcg_skus.py
@@ -6,9 +6,9 @@ import logging
 import pathlib
 from typing import Dict
 
-from mtgjson5.providers import TCGPlayerProvider
-from mtgjson5.providers.tcgplayer import get_tcgplayer_sku_data
-from mtgjson5.utils import generate_card_mapping
+from ..providers import TCGPlayerProvider
+from ..providers.tcgplayer import get_tcgplayer_sku_data
+from ..utils import generate_card_mapping
 
 LOGGER = logging.getLogger(__name__)
 

--- a/mtgjson5/compiled_classes/mtgjson_all_tcg_skus.py
+++ b/mtgjson5/compiled_classes/mtgjson_all_tcg_skus.py
@@ -4,11 +4,10 @@ MTGJSON AllTcgSkus Object
 
 import logging
 import pathlib
-
-from typing import Dict, Any
+from typing import Dict
 
 from mtgjson5.providers import TCGPlayerProvider
-from mtgjson5.providers.tcgplayer import get_tcgplayer_sku_data, get_tcgplayer_sku_map
+from mtgjson5.providers.tcgplayer import get_tcgplayer_sku_data
 from mtgjson5.utils import generate_card_mapping
 
 LOGGER = logging.getLogger(__name__)
@@ -45,4 +44,4 @@ class MtgjsonAllTcgSkus:
         Support json.dump()
         :return: JSON serialized object
         """
-        return self.all_identifiers_dict
+        return self.all_tcg_skus_dict

--- a/mtgjson5/compiled_classes/mtgjson_all_tcg_skus.py
+++ b/mtgjson5/compiled_classes/mtgjson_all_tcg_skus.py
@@ -4,10 +4,10 @@ MTGJSON AllTcgSkus Object
 
 import logging
 import pathlib
-from typing import Dict
+from typing import Dict, List
 
 from ..providers import TCGPlayerProvider
-from ..providers.tcgplayer import get_tcgplayer_sku_data
+from ..providers.tcgplayer import convert_sku_data_enum, get_tcgplayer_sku_data
 from ..utils import generate_card_mapping
 
 LOGGER = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ class MtgjsonAllTcgplayerSkusObject:
     MTGJSON AllTcgSkus Object
     """
 
-    all_tcg_skus_dict: Dict[str, Dict[str, int]]
+    all_tcg_skus_dict: Dict[str, List[Dict[str, str]]]
 
     def __init__(self, all_printings_path: pathlib.Path) -> None:
 
@@ -37,9 +37,11 @@ class MtgjsonAllTcgplayerSkusObject:
                 if not key:
                     continue
 
-                self.all_tcg_skus_dict[key] = product["skus"]
+                self.all_tcg_skus_dict[key] = [
+                    convert_sku_data_enum(sku) for sku in product["skus"]
+                ]
 
-    def to_json(self) -> Dict[str, Dict[str, int]]:
+    def to_json(self) -> Dict[str, List[Dict[str, str]]]:
         """
         Support json.dump()
         :return: JSON serialized object

--- a/mtgjson5/compiled_classes/mtgjson_all_tcg_skus.py
+++ b/mtgjson5/compiled_classes/mtgjson_all_tcg_skus.py
@@ -13,7 +13,7 @@ from mtgjson5.utils import generate_card_mapping
 LOGGER = logging.getLogger(__name__)
 
 
-class MtgjsonAllTcgSkus:
+class MtgjsonAllTcgSkusObject:
     """
     MTGJSON AllTcgSkus Object
     """

--- a/mtgjson5/compiled_classes/mtgjson_structures.py
+++ b/mtgjson5/compiled_classes/mtgjson_structures.py
@@ -68,7 +68,7 @@ class MtgjsonStructuresObject:
         self.referral_database = "ReferralMap"
         self.version = "Meta"
         self.all_identifiers = "AllIdentifiers"
-        self.all_tcg_skus = "AllTcgSkus"
+        self.all_tcg_skus = "TcgplayerSkus"
         self.all_printings_standard = "Standard"
         self.all_printings_pioneer = "Pioneer"
         self.all_printings_modern = "Modern"

--- a/mtgjson5/compiled_classes/mtgjson_structures.py
+++ b/mtgjson5/compiled_classes/mtgjson_structures.py
@@ -34,7 +34,7 @@ class MtgjsonStructuresObject:
 
     all_identifiers: str
 
-    all_tcg_skus: str
+    all_tcgplayer_skus: str
 
     all_printings_standard: str
     all_printings_pioneer: str
@@ -68,7 +68,7 @@ class MtgjsonStructuresObject:
         self.referral_database = "ReferralMap"
         self.version = "Meta"
         self.all_identifiers = "AllIdentifiers"
-        self.all_tcg_skus = "TcgplayerSkus"
+        self.all_tcgplayer_skus = "TcgplayerSkus"
         self.all_printings_standard = "Standard"
         self.all_printings_pioneer = "Pioneer"
         self.all_printings_modern = "Modern"

--- a/mtgjson5/compiled_classes/mtgjson_structures.py
+++ b/mtgjson5/compiled_classes/mtgjson_structures.py
@@ -34,6 +34,8 @@ class MtgjsonStructuresObject:
 
     all_identifiers: str
 
+    all_tcg_skus: str
+
     all_printings_standard: str
     all_printings_pioneer: str
     all_printings_modern: str
@@ -66,6 +68,7 @@ class MtgjsonStructuresObject:
         self.referral_database = "ReferralMap"
         self.version = "Meta"
         self.all_identifiers = "AllIdentifiers"
+        self.all_tcg_skus = "AllTcgSkus"
         self.all_printings_standard = "Standard"
         self.all_printings_pioneer = "Pioneer"
         self.all_printings_modern = "Modern"

--- a/mtgjson5/compiled_classes/mtgjson_tcgplayer_skus.py
+++ b/mtgjson5/compiled_classes/mtgjson_tcgplayer_skus.py
@@ -1,10 +1,10 @@
 """
-MTGJSON AllTcgSkus Object
+MTGJSON TcgplayerSkus Object
 """
 
 import logging
 import pathlib
-from typing import Dict, List
+from typing import Dict, List, Union
 
 from ..providers import TCGPlayerProvider
 from ..providers.tcgplayer import convert_sku_data_enum, get_tcgplayer_sku_data
@@ -13,37 +13,35 @@ from ..utils import generate_card_mapping
 LOGGER = logging.getLogger(__name__)
 
 
-class MtgjsonAllTcgplayerSkusObject:
+class MtgjsonTcgplayerSkusObject:
     """
-    MTGJSON AllTcgSkus Object
+    MTGJSON TcgplayerSkus Object
     """
 
-    all_tcg_skus_dict: Dict[str, List[Dict[str, str]]]
+    enhanced_tcgplayer_skus: Dict[str, List[Dict[str, Union[int, str]]]]
 
     def __init__(self, all_printings_path: pathlib.Path) -> None:
-
-        self.all_tcg_skus_dict = {}
-
-        ids_and_names = TCGPlayerProvider().get_tcgplayer_magic_set_ids()
+        self.enhanced_tcgplayer_skus = {}
 
         tcg_to_mtgjson_map = generate_card_mapping(
             all_printings_path, ("identifiers", "tcgplayerProductId"), ("uuid",)
         )
-        for group in ids_and_names:
+        for group in TCGPlayerProvider().get_tcgplayer_magic_set_ids():
             tcgplayer_sku_data = get_tcgplayer_sku_data(group)
             for product in tcgplayer_sku_data:
                 product_id = str(product["productId"])
                 key = tcg_to_mtgjson_map.get(product_id)
                 if not key:
+                    LOGGER.debug(f"Unable to translate TCGPlayer product {product_id}")
                     continue
 
-                self.all_tcg_skus_dict[key] = [
+                self.enhanced_tcgplayer_skus[key] = [
                     convert_sku_data_enum(sku) for sku in product["skus"]
                 ]
 
-    def to_json(self) -> Dict[str, List[Dict[str, str]]]:
+    def to_json(self) -> Dict[str, List[Dict[str, Union[int, str]]]]:
         """
         Support json.dump()
         :return: JSON serialized object
         """
-        return self.all_tcg_skus_dict
+        return self.enhanced_tcgplayer_skus

--- a/mtgjson5/output_generator.py
+++ b/mtgjson5/output_generator.py
@@ -10,7 +10,6 @@ from .classes import MtgjsonDeckHeaderObject, MtgjsonMetaObject, MtgjsonSetObjec
 from .compiled_classes import (
     MtgjsonAllIdentifiersObject,
     MtgjsonAllPrintingsObject,
-    MtgjsonAllTcgplayerSkusObject,
     MtgjsonAtomicCardsObject,
     MtgjsonCardTypesObject,
     MtgjsonCompiledListObject,
@@ -19,6 +18,7 @@ from .compiled_classes import (
     MtgjsonKeywordsObject,
     MtgjsonSetListObject,
     MtgjsonStructuresObject,
+    MtgjsonTcgplayerSkusObject,
 )
 from .consts import (
     HASH_TO_GENERATE,
@@ -218,15 +218,15 @@ def generate_compiled_output_files(pretty_print: bool) -> None:
     # AllPrintings, <FORMAT>, & AllIdentifiers
     build_all_printings_files(pretty_print)
 
-    # AllPrices.json
-    build_price_specific_files(pretty_print)
-
-    # AllTcgSkus.json
+    # AllTcgplayerSkus.json
     create_compiled_output(
-        MtgjsonStructuresObject().all_tcg_skus,
-        MtgjsonAllTcgplayerSkusObject(OUTPUT_PATH.joinpath("AllPrintings.json")),
+        MtgjsonStructuresObject().all_tcgplayer_skus,
+        MtgjsonTcgplayerSkusObject(OUTPUT_PATH.joinpath("AllPrintings.json")),
         pretty_print,
     )
+
+    # AllPrices.json
+    build_price_specific_files(pretty_print)
 
     # CompiledList.json
     create_compiled_output(

--- a/mtgjson5/output_generator.py
+++ b/mtgjson5/output_generator.py
@@ -10,6 +10,7 @@ from .classes import MtgjsonDeckHeaderObject, MtgjsonMetaObject, MtgjsonSetObjec
 from .compiled_classes import (
     MtgjsonAllIdentifiersObject,
     MtgjsonAllPrintingsObject,
+    MtgjsonAllTcgSkusObject,
     MtgjsonAtomicCardsObject,
     MtgjsonCardTypesObject,
     MtgjsonCompiledListObject,
@@ -19,7 +20,6 @@ from .compiled_classes import (
     MtgjsonSetListObject,
     MtgjsonStructuresObject,
 )
-from .compiled_classes.mtgjson_all_tcg_skus import MtgjsonAllTcgSkusObject
 from .consts import (
     HASH_TO_GENERATE,
     OUTPUT_PATH,

--- a/mtgjson5/output_generator.py
+++ b/mtgjson5/output_generator.py
@@ -54,7 +54,7 @@ def write_set_file(mtgjson_set_object: MtgjsonSetObject, pretty_print: bool) -> 
 
 
 def generate_compiled_prices_output(
-        price_data: Dict[str, Dict[str, float]], pretty_print: bool
+    price_data: Dict[str, Dict[str, float]], pretty_print: bool
 ) -> None:
     """
     Dump AllPrices to a file
@@ -67,7 +67,7 @@ def generate_compiled_prices_output(
 
 
 def build_format_specific_files(
-        all_printings: MtgjsonAllPrintingsObject, pretty_print: bool
+    all_printings: MtgjsonAllPrintingsObject, pretty_print: bool
 ) -> None:
     """
     Compile *Printings files based on AllPrintings
@@ -290,7 +290,7 @@ def generate_compiled_output_files(pretty_print: bool) -> None:
 
 
 def create_compiled_output(
-        compiled_name: str, compiled_object: Any, pretty_print: bool
+    compiled_name: str, compiled_object: Any, pretty_print: bool
 ) -> None:
     """
     Log and write out a compiled output file
@@ -304,7 +304,7 @@ def create_compiled_output(
 
 
 def write_compiled_output_to_file(
-        file_name: str, file_contents: Any, pretty_print: bool
+    file_name: str, file_contents: Any, pretty_print: bool
 ) -> None:
     """
     Dump content to a file in the outputs directory
@@ -327,10 +327,10 @@ def write_compiled_output_to_file(
 
 
 def construct_format_map(
-        all_printings_path: pathlib.Path = OUTPUT_PATH.joinpath(
-            f"{MtgjsonStructuresObject().all_printings}.json"
-        ),
-        normal_sets_only: bool = True,
+    all_printings_path: pathlib.Path = OUTPUT_PATH.joinpath(
+        f"{MtgjsonStructuresObject().all_printings}.json"
+    ),
+    normal_sets_only: bool = True,
 ) -> Dict[str, List[str]]:
     """
     For each set in AllPrintings, determine what format(s) the set is
@@ -367,9 +367,9 @@ def construct_format_map(
 
 
 def construct_atomic_cards_format_map(
-        all_printings_path: pathlib.Path = OUTPUT_PATH.joinpath(
-            f"{MtgjsonStructuresObject().all_printings}.json"
-        ),
+    all_printings_path: pathlib.Path = OUTPUT_PATH.joinpath(
+        f"{MtgjsonStructuresObject().all_printings}.json"
+    ),
 ) -> Dict[str, Any]:
     """
     Construct a format map for cards instead of sets,
@@ -418,6 +418,6 @@ def generate_output_file_hashes(directory: pathlib.Path) -> None:
 
         hash_file_name = f"{file.name}.{HASH_TO_GENERATE.name}"
         with file.parent.joinpath(hash_file_name).open(
-                "w", encoding="utf-8"
+            "w", encoding="utf-8"
         ) as hash_file:
             hash_file.write(generated_hash)

--- a/mtgjson5/output_generator.py
+++ b/mtgjson5/output_generator.py
@@ -10,7 +10,7 @@ from .classes import MtgjsonDeckHeaderObject, MtgjsonMetaObject, MtgjsonSetObjec
 from .compiled_classes import (
     MtgjsonAllIdentifiersObject,
     MtgjsonAllPrintingsObject,
-    MtgjsonAllTcgSkusObject,
+    MtgjsonAllTcgplayerSkusObject,
     MtgjsonAtomicCardsObject,
     MtgjsonCardTypesObject,
     MtgjsonCompiledListObject,
@@ -224,7 +224,7 @@ def generate_compiled_output_files(pretty_print: bool) -> None:
     # AllTcgSkus.json
     create_compiled_output(
         MtgjsonStructuresObject().all_tcg_skus,
-        MtgjsonAllTcgSkusObject(OUTPUT_PATH.joinpath("AllPrintings.json")),
+        MtgjsonAllTcgplayerSkusObject(OUTPUT_PATH.joinpath("AllPrintings.json")),
         pretty_print,
     )
 

--- a/mtgjson5/output_generator.py
+++ b/mtgjson5/output_generator.py
@@ -54,7 +54,7 @@ def write_set_file(mtgjson_set_object: MtgjsonSetObject, pretty_print: bool) -> 
 
 
 def generate_compiled_prices_output(
-    price_data: Dict[str, Dict[str, float]], pretty_print: bool
+        price_data: Dict[str, Dict[str, float]], pretty_print: bool
 ) -> None:
     """
     Dump AllPrices to a file
@@ -67,7 +67,7 @@ def generate_compiled_prices_output(
 
 
 def build_format_specific_files(
-    all_printings: MtgjsonAllPrintingsObject, pretty_print: bool
+        all_printings: MtgjsonAllPrintingsObject, pretty_print: bool
 ) -> None:
     """
     Compile *Printings files based on AllPrintings
@@ -207,13 +207,6 @@ def build_all_printings_files(pretty_print: bool) -> None:
         pretty_print,
     )
 
-    # AllTcgSkus.json
-    create_compiled_output(
-        MtgjsonStructuresObject().all_tcg_skus,
-        MtgjsonAllTcgSkusObject(OUTPUT_PATH.joinpath("AllPrintings.json")),
-        pretty_print,
-    )
-
 
 def generate_compiled_output_files(pretty_print: bool) -> None:
     """
@@ -227,6 +220,13 @@ def generate_compiled_output_files(pretty_print: bool) -> None:
 
     # AllPrices.json
     build_price_specific_files(pretty_print)
+
+    # AllTcgSkus.json
+    create_compiled_output(
+        MtgjsonStructuresObject().all_tcg_skus,
+        MtgjsonAllTcgSkusObject(OUTPUT_PATH.joinpath("AllPrintings.json")),
+        pretty_print,
+    )
 
     # CompiledList.json
     create_compiled_output(
@@ -290,7 +290,7 @@ def generate_compiled_output_files(pretty_print: bool) -> None:
 
 
 def create_compiled_output(
-    compiled_name: str, compiled_object: Any, pretty_print: bool
+        compiled_name: str, compiled_object: Any, pretty_print: bool
 ) -> None:
     """
     Log and write out a compiled output file
@@ -304,7 +304,7 @@ def create_compiled_output(
 
 
 def write_compiled_output_to_file(
-    file_name: str, file_contents: Any, pretty_print: bool
+        file_name: str, file_contents: Any, pretty_print: bool
 ) -> None:
     """
     Dump content to a file in the outputs directory
@@ -327,10 +327,10 @@ def write_compiled_output_to_file(
 
 
 def construct_format_map(
-    all_printings_path: pathlib.Path = OUTPUT_PATH.joinpath(
-        f"{MtgjsonStructuresObject().all_printings}.json"
-    ),
-    normal_sets_only: bool = True,
+        all_printings_path: pathlib.Path = OUTPUT_PATH.joinpath(
+            f"{MtgjsonStructuresObject().all_printings}.json"
+        ),
+        normal_sets_only: bool = True,
 ) -> Dict[str, List[str]]:
     """
     For each set in AllPrintings, determine what format(s) the set is
@@ -367,9 +367,9 @@ def construct_format_map(
 
 
 def construct_atomic_cards_format_map(
-    all_printings_path: pathlib.Path = OUTPUT_PATH.joinpath(
-        f"{MtgjsonStructuresObject().all_printings}.json"
-    ),
+        all_printings_path: pathlib.Path = OUTPUT_PATH.joinpath(
+            f"{MtgjsonStructuresObject().all_printings}.json"
+        ),
 ) -> Dict[str, Any]:
     """
     Construct a format map for cards instead of sets,
@@ -418,6 +418,6 @@ def generate_output_file_hashes(directory: pathlib.Path) -> None:
 
         hash_file_name = f"{file.name}.{HASH_TO_GENERATE.name}"
         with file.parent.joinpath(hash_file_name).open(
-            "w", encoding="utf-8"
+                "w", encoding="utf-8"
         ) as hash_file:
             hash_file.write(generated_hash)

--- a/mtgjson5/output_generator.py
+++ b/mtgjson5/output_generator.py
@@ -19,6 +19,7 @@ from .compiled_classes import (
     MtgjsonSetListObject,
     MtgjsonStructuresObject,
 )
+from .compiled_classes.mtgjson_all_tcg_skus import MtgjsonAllTcgSkusObject
 from .consts import (
     HASH_TO_GENERATE,
     OUTPUT_PATH,
@@ -203,6 +204,13 @@ def build_all_printings_files(pretty_print: bool) -> None:
     create_compiled_output(
         MtgjsonStructuresObject().all_identifiers,
         MtgjsonAllIdentifiersObject(all_printings.to_json()),
+        pretty_print,
+    )
+
+    # AllTcgSkus.json
+    create_compiled_output(
+        MtgjsonStructuresObject().all_tcg_skus,
+        MtgjsonAllTcgSkusObject(OUTPUT_PATH.joinpath("AllPrintings.json")),
         pretty_print,
     )
 

--- a/mtgjson5/providers/tcgplayer.py
+++ b/mtgjson5/providers/tcgplayer.py
@@ -65,6 +65,28 @@ class TCGPlayerProvider(AbstractProvider):
 
     api_version: str = ""
     tcg_to_mtgjson_map: Dict[str, str]
+    language_map: Dict[int, str] = {
+        1: "English",
+        2: "Chinese Simplified",
+        3: "Chinese Traditional",
+        4: "French",
+        5: "German",
+        6: "Italian",
+        7: "Japanese",
+        8: "Korean",
+        9: "Portuguese",
+        10: "Russian",
+        11: "Spanish",
+    }
+    printing_map: Dict[int, str] = {1: "Normal", 2: "Foil"}
+    condition_map: Dict[int, str] = {
+        1: "Near Mint",
+        2: "Lightly Played",
+        3: "Moderately Played",
+        4: "Heavily Played",
+        5: "Damaged",
+        6: "Unopened",
+    }
     __keys_found: bool
 
     def __init__(self) -> None:
@@ -379,3 +401,19 @@ def get_tcgplayer_prices_map(
             prices_map[key].sell_foil = card_price
 
     return prices_map
+
+
+def convert_sku_data_enum(sku: Dict[str, int]) -> Dict[str, str]:
+    """
+    Converts a tcgplayer sku from ids to names of conditions, languages and printings
+    :param sku: a tcgplayer sku dict
+    :return: a converted tcgplayer sku dict
+    """
+    converted_sku: Dict[str, str] = {
+        "skuId": str(sku["skuId"]),
+        "productId": str(sku["productId"]),
+        "language": TCGPlayerProvider().language_map[sku["languageId"]],
+        "printing": TCGPlayerProvider().printing_map[sku["printingId"]],
+        "condition": TCGPlayerProvider().condition_map[sku["conditionId"]],
+    }
+    return converted_sku

--- a/mtgjson5/providers/tcgplayer.py
+++ b/mtgjson5/providers/tcgplayer.py
@@ -65,28 +65,6 @@ class TCGPlayerProvider(AbstractProvider):
 
     api_version: str = ""
     tcg_to_mtgjson_map: Dict[str, str]
-    language_map: Dict[int, str] = {
-        1: "English",
-        2: "Chinese Simplified",
-        3: "Chinese Traditional",
-        4: "French",
-        5: "German",
-        6: "Italian",
-        7: "Japanese",
-        8: "Korean",
-        9: "Portuguese",
-        10: "Russian",
-        11: "Spanish",
-    }
-    printing_map: Dict[int, str] = {1: "Normal", 2: "Foil"}
-    condition_map: Dict[int, str] = {
-        1: "Near Mint",
-        2: "Lightly Played",
-        3: "Moderately Played",
-        4: "Heavily Played",
-        5: "Damaged",
-        6: "Unopened",
-    }
     __keys_found: bool
 
     def __init__(self) -> None:
@@ -403,17 +381,16 @@ def get_tcgplayer_prices_map(
     return prices_map
 
 
-def convert_sku_data_enum(sku: Dict[str, int]) -> Dict[str, str]:
+def convert_sku_data_enum(sku: Dict[str, int]) -> Dict[str, Union[int, str]]:
     """
-    Converts a tcgplayer sku from ids to names of conditions, languages and printings
-    :param sku: a tcgplayer sku dict
-    :return: a converted tcgplayer sku dict
+    Converts a TCGPlayer SKU from IDs to components
+    :param sku: TCGPlayer SKU component
+    :return: Enhanced TCGPlayer SKU dict
     """
-    converted_sku: Dict[str, str] = {
-        "skuId": str(sku["skuId"]),
-        "productId": str(sku["productId"]),
-        "language": TCGPlayerProvider().language_map[sku["languageId"]],
-        "printing": TCGPlayerProvider().printing_map[sku["printingId"]],
-        "condition": TCGPlayerProvider().condition_map[sku["conditionId"]],
+    return {
+        "skuId": sku["skuId"],
+        "productId": sku["productId"],
+        "language": CardLanguage(sku["languageId"]).name.replace("_", " "),
+        "printing": CardPrinting(sku["printingId"]).name.replace("_", " "),
+        "condition": CardCondition(sku["conditionId"]).name.replace("_", " "),
     }
-    return converted_sku

--- a/mtgjson5/providers/tcgplayer.py
+++ b/mtgjson5/providers/tcgplayer.py
@@ -317,7 +317,7 @@ def get_tcgplayer_buylist_prices_map(
 
         for sku in buylist_data["skus"]:
             if not sku["prices"]["high"]:
-                # We only want to deal with the buyer paying the most for NM
+                # We want the buylist high price, not buylist market price
                 continue
 
             if not sku_map.get(product_id):


### PR DESCRIPTION
I wrote a new class to build a compiled output that maps a UUID to the TCGPlayer sku data for that card. This class may need some tweaking to better mirror how AllIdentifiers handles the usage of AllPrintings. If this pull request gets approved, the way TCGPlayer buylist data is compiled could be reworked to be more efficient. 
