### PR TITLE
Fix sigsev on Python 3.8 (#689)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ While MTGJSON will work on Windows, Mac, and Linux, we prefer working within the
 
 #### Install Python3
 MTGJSON is built on and tested against a wide range of Python3 verisons. Currently, we maintain support for the following versions:
-- Python 3.6
+
 - Python 3.7
 - Python 3.8
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.9.1
-gevent==20.6.2
+gevent==20.9.0
 GitPython==3.1.3
 mkmsdk==0.5.3
 pandas==1.0.5

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setuptools.setup(
         "Operating System :: Microsoft :: Windows :: Windows 10",
         "Operating System :: Unix",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python",


### PR DESCRIPTION
This also drops support for Python 3.6, as the latest versions of Gevent/Greenlet upstreams are not binary compatible with 3.6.

The other solution is to pin Greenlet's version, but that's just kicking the entire issue down the road.

[pep-0494]: https://www.python.org/dev/peps/pep-0494