### PR TITLE
Use upstream mcm_id if applicable, start of a fix towards #624

### DIFF
--- a/mtgjson5/providers/wizards.py
+++ b/mtgjson5/providers/wizards.py
@@ -229,8 +229,9 @@ class WizardsProvider(AbstractProvider):
             set_name_fixes = json.load(f)
 
         for key, value in set_name_fixes.items():
-            table[value] = table[key]
-            del table[key]
+            if key in table:
+                table[value] = table[key]
+                del table[key]
 
         # Build new table with set codes instead of set names
         new_table = parallel_call(

--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -675,6 +675,9 @@ def build_mtgjson_card(
     mtgjson_card.is_textless = scryfall_object.get("textless")
     mtgjson_card.life = scryfall_object.get("life_modifier")
 
+    mtgjson_card.identifiers.mcm_id = get_str_or_none(
+        scryfall_object.get("cardmarket_id")
+    )
     mtgjson_card.identifiers.mtg_arena_id = get_str_or_none(
         scryfall_object.get("arena_id")
     )
@@ -1041,7 +1044,10 @@ def add_mcm_details(mtgjson_set: MtgjsonSetObject) -> None:
         if delete_key:
             del mkm_cards[card_key]
 
-        mtgjson_card.identifiers.mcm_id = str(mkm_obj["idProduct"])
+        # This value is set by an upstream provider by default
+        if not mtgjson_card.identifiers.mcm_id:
+            mtgjson_card.identifiers.mcm_id = str(mkm_obj["idProduct"])
+
         mtgjson_card.identifiers.mcm_meta_id = str(mkm_obj["idMetaproduct"])
 
         mtgjson_card.purchase_urls.cardmarket = url_keygen(


### PR DESCRIPTION
This starts a fix for #624 by using upstream as a default, with our method as a backup. I'd still like to do more work on the backend ops to better hash and determine IDs ourself. We'll still need to do our own metaIds, so we're not ending our relationship with the SDK at this time