### PR TITLE
Fix extended arts mcmIds

### DIFF
--- a/mtgjson5/classes/mtgjson_set.py
+++ b/mtgjson5/classes/mtgjson_set.py
@@ -26,6 +26,7 @@ class MtgjsonSetObject:
     is_partial_preview: bool
     keyrune_code: str
     mcm_id: Optional[int]
+    mcm_id_extras: Optional[int]
     mcm_name: Optional[str]
     mtgo_code: str
     name: str

--- a/mtgjson5/compiled_classes/mtgjson_atomic_cards.py
+++ b/mtgjson5/compiled_classes/mtgjson_atomic_cards.py
@@ -29,9 +29,7 @@ class MtgjsonAtomicCardsObject:
         )
 
     def iterate_all_cards(
-        self,
-        files_to_ignore: List[str],
-        cards_to_load: List[Dict[str, Any]] = None,
+        self, files_to_ignore: List[str], cards_to_load: List[Dict[str, Any]] = None,
     ) -> None:
         """
         Iterate and all all MTGJSON sets to the dictionary

--- a/mtgjson5/compress_generator.py
+++ b/mtgjson5/compress_generator.py
@@ -84,14 +84,7 @@ def _compress_mtgjson_directory(
     LOGGER.info(f"Compressing {output_file}")
 
     compression_commands: List[List[Union[str, pathlib.Path]]] = [
-        [
-            "tar",
-            "-jcf",
-            f"{temp_dir}.tar.bz2",
-            "-C",
-            temp_dir.parent,
-            temp_dir.name,
-        ],
+        ["tar", "-jcf", f"{temp_dir}.tar.bz2", "-C", temp_dir.parent, temp_dir.name,],
         ["tar", "-Jcf", f"{temp_dir}.tar.xz", "-C", temp_dir.parent, temp_dir.name],
         ["tar", "-zcf", f"{temp_dir}.tar.gz", "-C", temp_dir.parent, temp_dir.name],
         ["zip", "-rj", f"{temp_dir}.zip", temp_dir],

--- a/mtgjson5/output_generator.py
+++ b/mtgjson5/output_generator.py
@@ -62,9 +62,7 @@ def generate_compiled_prices_output(
     :param pretty_print: Pretty or minimal
     """
     create_compiled_output(
-        MtgjsonStructuresObject().all_prices,
-        price_data,
-        pretty_print,
+        MtgjsonStructuresObject().all_prices, price_data, pretty_print,
     )
 
 
@@ -239,23 +237,17 @@ def generate_compiled_output_files(pretty_print: bool) -> None:
 
     # Keywords.json
     create_compiled_output(
-        MtgjsonStructuresObject().key_words,
-        MtgjsonKeywordsObject(),
-        pretty_print,
+        MtgjsonStructuresObject().key_words, MtgjsonKeywordsObject(), pretty_print,
     )
 
     # CardTypes.json
     create_compiled_output(
-        MtgjsonStructuresObject().card_types,
-        MtgjsonCardTypesObject(),
-        pretty_print,
+        MtgjsonStructuresObject().card_types, MtgjsonCardTypesObject(), pretty_print,
     )
 
     # Meta.json (Formerly version.json)
     create_compiled_output(
-        MtgjsonStructuresObject().version,
-        MtgjsonMetaObject(),
-        pretty_print,
+        MtgjsonStructuresObject().version, MtgjsonMetaObject(), pretty_print,
     )
 
     # SetList.json
@@ -293,9 +285,7 @@ def generate_compiled_output_files(pretty_print: bool) -> None:
 
     # EnumValues.json - Depends on Keywords & Decks
     create_compiled_output(
-        MtgjsonStructuresObject().enum_values,
-        MtgjsonEnumValuesObject(),
-        pretty_print,
+        MtgjsonStructuresObject().enum_values, MtgjsonEnumValuesObject(), pretty_print,
     )
 
 

--- a/mtgjson5/providers/cardmarket.py
+++ b/mtgjson5/providers/cardmarket.py
@@ -175,7 +175,7 @@ class CardMarketProvider(AbstractProvider):
         if not self.__keys_found:
             return None
 
-        extras_set_name = set_name.lower() + ": extras"
+        extras_set_name = f"{set_name.lower()}: extras"
         if extras_set_name in self.set_map.keys():
             return int(self.set_map[extras_set_name]["mcmId"])
         return None

--- a/mtgjson5/providers/cardmarket.py
+++ b/mtgjson5/providers/cardmarket.py
@@ -165,6 +165,21 @@ class CardMarketProvider(AbstractProvider):
             return int(self.set_map[set_name.lower()]["mcmId"])
         return None
 
+    def get_extras_set_id(self, set_name: str) -> Optional[int]:
+        """
+        Get "Extras" MKM Set ID from pre-generated map
+        For "Throne of Eldraine" it will return the mcmId for "Throne of Eldraine: Extras"
+        :param set_name: Set to get ID from
+        :return: Set ID
+        """
+        if not self.__keys_found:
+            return None
+
+        extras_set_name = set_name.lower() + ": extras"
+        if extras_set_name in self.set_map.keys():
+            return int(self.set_map[extras_set_name]["mcmId"])
+        return None
+
     def get_set_name(self, set_name: str) -> Optional[str]:
         """
         Get MKM Set Name from pre-generated map

--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -1041,7 +1041,7 @@ def add_mcm_details(mtgjson_set: MtgjsonSetObject) -> None:
     for mtgjson_card in mtgjson_set.cards:
         delete_key = False
 
-        if "extendedart" in mtgjson_card.frame_effects and extras_cards:
+        if "boosterfun" in mtgjson_card.promo_types and extras_cards:
             # It is an extended art, search in the "Extras" set instead
             search_cards = extras_cards
         else:

--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -1041,8 +1041,9 @@ def add_mcm_details(mtgjson_set: MtgjsonSetObject) -> None:
     for mtgjson_card in mtgjson_set.cards:
         delete_key = False
 
+        # "boosterfun" is an alias for frame_effects=showcase, frame_effects=extendedart, and border_color=borderless
         if "boosterfun" in mtgjson_card.promo_types and extras_cards:
-            # It is an extended art, search in the "Extras" set instead
+            # It is an extended art, showcase, or borderless, search in the "Extras" set instead
             search_cards = extras_cards
         else:
             search_cards = mkm_cards

--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -510,9 +510,8 @@ def add_leadership_skills(mtgjson_card: MtgjsonCardObject) -> None:
 
     is_oathbreaker_legal = "Planeswalker" in mtgjson_card.type
 
-    is_brawl_legal = (
-        mtgjson_card.set_code.upper() in WhatsInStandardProvider().set_codes
-        and (is_oathbreaker_legal or is_commander_legal)
+    is_brawl_legal = mtgjson_card.set_code.upper() in WhatsInStandardProvider().set_codes and (
+        is_oathbreaker_legal or is_commander_legal
     )
 
     if is_commander_legal or is_oathbreaker_legal or is_brawl_legal:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,4 +4,5 @@ mypy==0.790
 pylint==2.6.0
 pytest==5.4.3
 pytest-cov==2.10.1
+pytest-mock==3.3.1
 tox==3.20.1

--- a/tests/mtgjson5/providers/test_cardmarket.py
+++ b/tests/mtgjson5/providers/test_cardmarket.py
@@ -1,4 +1,4 @@
-"""Test the cardmarket provider."""
+"""Test the CardMarket provider."""
 
 import pytest_mock
 import pytest
@@ -8,14 +8,13 @@ from mtgjson5.providers.cardmarket import CardMarketProvider
 from typing import Dict
 from singleton_decorator import singleton
 
-
 testdata = [
     pytest.param(
         True,
         {
-        "throne of eldraine": {"mcmId": 1111},
-        "throne of eldraine: extras": {"mcmId": 2222},
-        "throne of eldraine: promos": {"mcmId": 3333},
+            "throne of eldraine": {"mcmId": 1111},
+            "throne of eldraine: extras": {"mcmId": 2222},
+            "throne of eldraine: promos": {"mcmId": 3333},
         },
         2222,
         id="Extras set available",
@@ -23,8 +22,8 @@ testdata = [
     pytest.param(
         True,
         {
-        "throne of eldraine": {"mcmId": 1111},
-        "throne of eldraine: promos": {"mcmId": 3333},
+            "throne of eldraine": {"mcmId": 1111},
+            "throne of eldraine: promos": {"mcmId": 3333},
         },
         None,
         id="Extras set not available",
@@ -32,14 +31,15 @@ testdata = [
     pytest.param(
         False,
         {
-        "throne of eldraine": {"mcmId": 1111},
-        "throne of eldraine: extras": {"mcmId": 2222},
-        "throne of eldraine: promos": {"mcmId": 3333},
+            "throne of eldraine": {"mcmId": 1111},
+            "throne of eldraine: extras": {"mcmId": 2222},
+            "throne of eldraine: promos": {"mcmId": 3333},
         },
         None,
         id="Extras set available but no mcm keys",
     ),
 ]
+
 
 @pytest.mark.parametrize("keys_found,set_map,expected", testdata)
 def test_get_extras_set_id(keys_found, set_map, expected, mocker):

--- a/tests/mtgjson5/providers/test_cardmarket.py
+++ b/tests/mtgjson5/providers/test_cardmarket.py
@@ -1,0 +1,53 @@
+"""Test the cardmarket provider."""
+
+import pytest_mock
+import pytest
+
+from mtgjson5.arg_parser import parse_args
+from mtgjson5.providers.cardmarket import CardMarketProvider
+from typing import Dict
+from singleton_decorator import singleton
+
+
+testdata = [
+    pytest.param(
+        True,
+        {
+        "throne of eldraine": {"mcmId": 1111},
+        "throne of eldraine: extras": {"mcmId": 2222},
+        "throne of eldraine: promos": {"mcmId": 3333},
+        },
+        2222,
+        id="Extras set available",
+    ),
+    pytest.param(
+        True,
+        {
+        "throne of eldraine": {"mcmId": 1111},
+        "throne of eldraine: promos": {"mcmId": 3333},
+        },
+        None,
+        id="Extras set not available",
+    ),
+    pytest.param(
+        False,
+        {
+        "throne of eldraine": {"mcmId": 1111},
+        "throne of eldraine: extras": {"mcmId": 2222},
+        "throne of eldraine: promos": {"mcmId": 3333},
+        },
+        None,
+        id="Extras set available but no mcm keys",
+    ),
+]
+
+@pytest.mark.parametrize("keys_found,set_map,expected", testdata)
+def test_get_extras_set_id(keys_found, set_map, expected, mocker):
+    """Test if it finds sets with ": extras"."""
+    # provider = ProviderMock()
+    obj = mocker.MagicMock()
+    # Trick name mangling which will convert "__keys_found" to "_CardMarketProvider__keys_found"
+    obj._CardMarketProvider__keys_found = keys_found
+    obj.set_map = set_map
+    actual = CardMarketProvider.__wrapped__.get_extras_set_id(obj, "throne of eldraine")
+    assert actual == expected


### PR DESCRIPTION
Hey,

This intends to improve the mcmId matching regarding extendedart.
MCM uses set names suffixed with ": Extras" to store them.
When adding the mcm_details I get a second set, the extras_set and match for each card if we should use the regular or the extras set.
I did a quick comparison using ELD and see only mcmIds and purchaseUrls have changed. Attaching the files here.
[pr_mtgjson_fix_extended_arts.zip](https://github.com/mtgjson/mtgjson/files/5359043/pr_mtgjson_fix_extended_arts.zip)
A before/after test of 10E showed both JSONs to be identical.

I just have seen that you have opened #699 
If that conflicts in any way and your change will fix the extendedarts too, that would be also great.

Question: I am not sure how to test every set, don't wanna run the whole build at once and only have mcm credentials available.
If you could assist in any way checking if that change does have any side effects that would be great.