### PR TITLE
Basic MTGJSON Sealed Product Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,7 +123,7 @@ compiled_outputs/
 /trace.html
 /tests/test_*.yaml
 /test_results/*.xml
-mtgjson.properties
+mtgjson5/resources/mtgjson.properties
 *.sqlite
 set_translations.json
 stocks_data.json

--- a/.gitignore
+++ b/.gitignore
@@ -123,7 +123,7 @@ compiled_outputs/
 /trace.html
 /tests/test_*.yaml
 /test_results/*.xml
-mtgjson5/resources/mtgjson.properties
+mtgjson.properties
 *.sqlite
 set_translations.json
 stocks_data.json

--- a/mtgjson5/classes/__init__.py
+++ b/mtgjson5/classes/__init__.py
@@ -14,5 +14,6 @@ from .mtgjson_meta import MtgjsonMetaObject
 from .mtgjson_prices import MtgjsonPricesObject
 from .mtgjson_purchase_urls import MtgjsonPurchaseUrlsObject
 from .mtgjson_rulings import MtgjsonRulingObject
+from .mtgjson_sealed_product import MtgjsonSealedProductObject
 from .mtgjson_set import MtgjsonSetObject
 from .mtgjson_translations import MtgjsonTranslationsObject

--- a/mtgjson5/classes/mtgjson_sealed_product.py
+++ b/mtgjson5/classes/mtgjson_sealed_product.py
@@ -25,8 +25,6 @@ class MtgjsonSealedProductObject:
         self.purchase_urls = MtgjsonPurchaseUrlsObject()
         self.raw_purchase_urls = {}
 
-
-
     def to_json(self) -> Dict[str, Any]:
         """
         Support json.dump()

--- a/mtgjson5/classes/mtgjson_sealed_product.py
+++ b/mtgjson5/classes/mtgjson_sealed_product.py
@@ -1,0 +1,38 @@
+"""
+MTGJSON Singular Sealed Product Object
+"""
+from typing import Any, Dict
+
+from mtgjson5.utils import to_camel_case
+
+from .mtgjson_purchase_urls import MtgjsonPurchaseUrlsObject
+from .mtgjson_identifiers import MtgjsonIdentifiersObject
+
+
+class MtgjsonSealedProductObject:
+    """
+    MTGJSON Singular Sealed Product Object
+    """
+
+    name: str
+    uuid: str
+    identifiers: MtgjsonIdentifiersObject
+    purchase_urls: MtgjsonPurchaseUrlsObject
+    raw_purchase_urls: Dict[str, str]
+    release_date: str
+
+    def __init__(self) -> None:
+        self.purchase_urls = MtgjsonPurchaseUrlsObject()
+        self.raw_purchase_urls = {}
+
+    def to_json(self) -> Dict[str, Any]:
+        """
+        Support json.dump()
+        :return: JSON serialized object
+        """
+
+        return {
+            to_camel_case(key): value
+            for key, value in self.__dict__.items()
+            if "__" not in key and not callable(value)
+        }

--- a/mtgjson5/classes/mtgjson_sealed_product.py
+++ b/mtgjson5/classes/mtgjson_sealed_product.py
@@ -4,7 +4,6 @@ MTGJSON Singular Sealed Product Object
 from typing import Any, Dict
 
 from ..utils import to_camel_case
-
 from .mtgjson_identifiers import MtgjsonIdentifiersObject
 from .mtgjson_purchase_urls import MtgjsonPurchaseUrlsObject
 

--- a/mtgjson5/classes/mtgjson_sealed_product.py
+++ b/mtgjson5/classes/mtgjson_sealed_product.py
@@ -1,7 +1,7 @@
 """
 MTGJSON Singular Sealed Product Object
 """
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from ..utils import to_camel_case
 from .mtgjson_identifiers import MtgjsonIdentifiersObject
@@ -18,7 +18,10 @@ class MtgjsonSealedProductObject:
     identifiers: MtgjsonIdentifiersObject
     purchase_urls: MtgjsonPurchaseUrlsObject
     raw_purchase_urls: Dict[str, str]
-    release_date: str
+    release_date: Optional[str]
+    __skip_keys = [
+        "raw_purchase_urls",
+    ]
 
     def __init__(self) -> None:
         self.identifiers = MtgjsonIdentifiersObject()
@@ -30,9 +33,10 @@ class MtgjsonSealedProductObject:
         Support json.dump()
         :return: JSON serialized object
         """
+        skip_keys = self.__skip_keys
 
         return {
             to_camel_case(key): value
             for key, value in self.__dict__.items()
-            if "__" not in key and not callable(value)
+            if "__" not in key and not callable(value) and key not in skip_keys
         }

--- a/mtgjson5/classes/mtgjson_sealed_product.py
+++ b/mtgjson5/classes/mtgjson_sealed_product.py
@@ -21,9 +21,11 @@ class MtgjsonSealedProductObject:
     release_date: str
 
     def __init__(self) -> None:
+        self.identifiers = MtgjsonIdentifiersObject()
         self.purchase_urls = MtgjsonPurchaseUrlsObject()
         self.raw_purchase_urls = {}
-        self.identifiers = MtgjsonIdentifiersObject()
+
+
 
     def to_json(self) -> Dict[str, Any]:
         """

--- a/mtgjson5/classes/mtgjson_sealed_product.py
+++ b/mtgjson5/classes/mtgjson_sealed_product.py
@@ -5,8 +5,8 @@ from typing import Any, Dict
 
 from mtgjson5.utils import to_camel_case
 
-from .mtgjson_purchase_urls import MtgjsonPurchaseUrlsObject
 from .mtgjson_identifiers import MtgjsonIdentifiersObject
+from .mtgjson_purchase_urls import MtgjsonPurchaseUrlsObject
 
 
 class MtgjsonSealedProductObject:

--- a/mtgjson5/classes/mtgjson_sealed_product.py
+++ b/mtgjson5/classes/mtgjson_sealed_product.py
@@ -18,7 +18,6 @@ class MtgjsonSealedProductObject:
     identifiers: MtgjsonIdentifiersObject
     purchase_urls: MtgjsonPurchaseUrlsObject
     raw_purchase_urls: Dict[str, str]
-    release_date: str
 
     def __init__(self) -> None:
         self.identifiers = MtgjsonIdentifiersObject()

--- a/mtgjson5/classes/mtgjson_sealed_product.py
+++ b/mtgjson5/classes/mtgjson_sealed_product.py
@@ -3,7 +3,7 @@ MTGJSON Singular Sealed Product Object
 """
 from typing import Any, Dict
 
-from mtgjson5.utils import to_camel_case
+from ..utils import to_camel_case
 
 from .mtgjson_identifiers import MtgjsonIdentifiersObject
 from .mtgjson_purchase_urls import MtgjsonPurchaseUrlsObject

--- a/mtgjson5/classes/mtgjson_sealed_product.py
+++ b/mtgjson5/classes/mtgjson_sealed_product.py
@@ -24,6 +24,7 @@ class MtgjsonSealedProductObject:
     def __init__(self) -> None:
         self.purchase_urls = MtgjsonPurchaseUrlsObject()
         self.raw_purchase_urls = {}
+        self.identifiers = MtgjsonIdentifiersObject()
 
     def to_json(self) -> Dict[str, Any]:
         """

--- a/mtgjson5/classes/mtgjson_sealed_product.py
+++ b/mtgjson5/classes/mtgjson_sealed_product.py
@@ -18,6 +18,7 @@ class MtgjsonSealedProductObject:
     identifiers: MtgjsonIdentifiersObject
     purchase_urls: MtgjsonPurchaseUrlsObject
     raw_purchase_urls: Dict[str, str]
+    release_date: str
 
     def __init__(self) -> None:
         self.identifiers = MtgjsonIdentifiersObject()

--- a/mtgjson5/classes/mtgjson_sealed_product.py
+++ b/mtgjson5/classes/mtgjson_sealed_product.py
@@ -33,10 +33,9 @@ class MtgjsonSealedProductObject:
         Support json.dump()
         :return: JSON serialized object
         """
-        skip_keys = self.__skip_keys
 
         return {
             to_camel_case(key): value
             for key, value in self.__dict__.items()
-            if "__" not in key and not callable(value) and key not in skip_keys
+            if "__" not in key and not callable(value) and key not in self.__skip_keys
         }

--- a/mtgjson5/classes/mtgjson_set.py
+++ b/mtgjson5/classes/mtgjson_set.py
@@ -4,6 +4,7 @@ MTGJSON Singular Set Object
 from typing import Any, Dict, List, Optional, Set
 
 from ..classes.mtgjson_card import MtgjsonCardObject
+from ..classes.mtgjson_sealed_product import MtgjsonSealedProductObject
 from ..classes.mtgjson_translations import MtgjsonTranslationsObject
 from ..consts import BAD_FILE_NAMES
 from ..utils import to_camel_case
@@ -34,6 +35,7 @@ class MtgjsonSetObject:
     parent_code: str
     release_date: str
     tcgplayer_group_id: Optional[int]
+    sealed_product: List[MtgjsonSealedProductObject]
     tokens: List[MtgjsonCardObject]
     total_set_size: int
     translations: MtgjsonTranslationsObject

--- a/mtgjson5/providers/tcgplayer.py
+++ b/mtgjson5/providers/tcgplayer.py
@@ -10,8 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import requests
 from singleton_decorator import singleton
 
-from ..classes import MtgjsonPricesObject
-from ..classes.mtgjson_sealed_product import MtgjsonSealedProductObject
+from ..classes import MtgjsonPricesObject, MtgjsonSealedProductObject
 from ..providers.abstract import AbstractProvider
 from ..utils import generate_card_mapping, parallel_call, retryable_session
 

--- a/mtgjson5/providers/tcgplayer.py
+++ b/mtgjson5/providers/tcgplayer.py
@@ -5,7 +5,6 @@ import enum
 import json
 import logging
 import pathlib
-import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import requests
@@ -14,7 +13,7 @@ from singleton_decorator import singleton
 from ..classes import MtgjsonPricesObject
 from ..classes.mtgjson_sealed_product import MtgjsonSealedProductObject
 from ..providers.abstract import AbstractProvider
-from ..utils import generate_card_mapping, parallel_call, retryable_session, url_keygen
+from ..utils import generate_card_mapping, parallel_call, retryable_session
 
 LOGGER = logging.getLogger(__name__)
 
@@ -235,17 +234,13 @@ class TCGPlayerProvider(AbstractProvider):
             sealed_product = MtgjsonSealedProductObject()
             sealed_product.name = product["cleanName"]
             sealed_product.identifiers.tcgplayer_product_id = str(product["productId"])
-            sealed_product.uuid = str(
-                uuid.uuid5(uuid.NAMESPACE_DNS, sealed_product.name)
-            )
-            sealed_product.release_date = product["presaleInfo"]["releasedOn"]
+            sealed_product.release_date = product["presaleInfo"].get("releasedOn")
+            if sealed_product.release_date is not None:
+                sealed_product.release_date = sealed_product.release_date[0:10]
             sealed_product.raw_purchase_urls[
                 "tcgplayer"
             ] = "https://shop.tcgplayer.com/product/productsearch?id={}&utm_campaign=affiliate&utm_medium=api&utm_source=mtgjson".format(
                 sealed_product.identifiers.tcgplayer_product_id
-            )
-            sealed_product.purchase_urls.tcgplayer = url_keygen(
-                sealed_product.identifiers.tcgplayer_product_id + sealed_product.uuid
             )
             mtgjson_sealed_products.append(sealed_product)
 

--- a/mtgjson5/providers/tcgplayer.py
+++ b/mtgjson5/providers/tcgplayer.py
@@ -238,6 +238,7 @@ class TCGPlayerProvider(AbstractProvider):
             sealed_product.uuid = str(
                 uuid.uuid5(uuid.NAMESPACE_DNS, sealed_product.name)
             )
+            sealed_product.release_date = product["presaleInfo"]["releasedOn"]
             sealed_product.raw_purchase_urls[
                 "tcgplayer"
             ] = "https://shop.tcgplayer.com/product/productsearch?id={}&utm_campaign=affiliate&utm_medium=api&utm_source=mtgjson".format(

--- a/mtgjson5/providers/tcgplayer.py
+++ b/mtgjson5/providers/tcgplayer.py
@@ -238,7 +238,6 @@ class TCGPlayerProvider(AbstractProvider):
             sealed_product.uuid = str(
                 uuid.uuid5(uuid.NAMESPACE_DNS, sealed_product.name)
             )
-            sealed_product.release_date = product["presaleInfo"]["releasedOn"]
             sealed_product.raw_purchase_urls[
                 "tcgplayer"
             ] = "https://shop.tcgplayer.com/product/productsearch?id={}&utm_campaign=affiliate&utm_medium=api&utm_source=mtgjson".format(

--- a/mtgjson5/providers/tcgplayer.py
+++ b/mtgjson5/providers/tcgplayer.py
@@ -250,6 +250,45 @@ def get_tcgplayer_sku_data(group_id_and_name: Tuple[str, str]) -> List[Dict[str,
     return magic_set_product_data
 
 
+def get_tcgplayer_sealed_data(
+    group_id_and_name: Tuple[str, str]
+) -> List[Dict[str, Any]]:
+    """
+    Finds all sealed product for a given group
+    :param group_id_and_name: group id and name for the set to get data for
+    :return: sealed product data with extended fields
+    """
+    magic_set_sealed_data = []
+    api_offset = 0
+
+    while True:
+        api_response = TCGPlayerProvider().download(
+            "https://api.tcgplayer.com/catalog/products",
+            {
+                "offset": str(api_offset),
+                "limit": 100,
+                "categoryId": 1,
+                "getExtendedFields": True,
+                "groupId": group_id_and_name[0],
+                "productTypes": "Booster Box,Booster Pack,Sealed Products",
+            },
+        )
+
+        if not api_response:
+            # No more entries
+            break
+
+        response = json.loads(api_response)
+        if not response["results"]:
+            # Something went wrong
+            break
+
+        magic_set_sealed_data.extend(response["results"])
+        api_offset += len(response["results"])
+
+    return magic_set_sealed_data
+
+
 def get_tcgplayer_sku_map(
     tcgplayer_set_sku_data: List[Dict[str, Any]],
 ) -> Dict[str, Dict[str, Optional[int]]]:

--- a/mtgjson5/providers/tcgplayer.py
+++ b/mtgjson5/providers/tcgplayer.py
@@ -215,7 +215,7 @@ class TCGPlayerProvider(AbstractProvider):
         return dict(combined_listings)
 
     def generate_mtgjson_sealed_product_objects(
-        self, group_id: Optional[Any]
+        self, group_id: Optional[int]
     ) -> List[MtgjsonSealedProductObject]:
         """
         Builds MTGJSON Sealed Product Objects from TCGPlayer data
@@ -283,7 +283,7 @@ def get_tcgplayer_sku_data(group_id_and_name: Tuple[str, str]) -> List[Dict[str,
     return magic_set_product_data
 
 
-def get_tcgplayer_sealed_data(group_id: Optional[Any]) -> List[Dict[str, Any]]:
+def get_tcgplayer_sealed_data(group_id: Optional[int]) -> List[Dict[str, Any]]:
     """
     Finds all sealed product for a given group
     :param group_id: group id for the set to get data for

--- a/mtgjson5/providers/tcgplayer.py
+++ b/mtgjson5/providers/tcgplayer.py
@@ -229,10 +229,10 @@ class TCGPlayerProvider(AbstractProvider):
 
         sealed_data = get_tcgplayer_sealed_data(group_id)
 
-        mtgjson_sealed_products: List[MtgjsonSealedProductObject] = []
+        mtgjson_sealed_products = []
 
         for product in sealed_data:
-            sealed_product: MtgjsonSealedProductObject = MtgjsonSealedProductObject()
+            sealed_product = MtgjsonSealedProductObject()
             sealed_product.name = product["cleanName"]
             sealed_product.raw_purchase_urls["tcgplayer"] = product["url"]
             sealed_product.identifiers.tcgplayer_product_id = product["productId"]

--- a/mtgjson5/providers/tcgplayer.py
+++ b/mtgjson5/providers/tcgplayer.py
@@ -229,7 +229,7 @@ class TCGPlayerProvider(AbstractProvider):
 
         sealed_data = get_tcgplayer_sealed_data(group_id)
 
-        mtgjson_sealed_products = []
+        mtgjson_sealed_products: List[MtgjsonSealedProductObject] = []
 
         for product in sealed_data:
             sealed_product: MtgjsonSealedProductObject = MtgjsonSealedProductObject()

--- a/mtgjson5/referral_builder.py
+++ b/mtgjson5/referral_builder.py
@@ -3,9 +3,10 @@ Referral Map builder operations
 """
 import logging
 import re
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
-from .classes import MtgjsonSetObject
+from .classes import MtgjsonCardObject, MtgjsonSetObject
+from .classes.mtgjson_sealed_product import MtgjsonSealedProductObject
 from .consts import OUTPUT_PATH
 
 LOGGER = logging.getLogger(__name__)
@@ -29,38 +30,36 @@ def build_referral_map(mtgjson_set: MtgjsonSetObject) -> List[Tuple[str, str]]:
     return_list = []
     string_regex = re.compile(re.escape("scryfall"), re.IGNORECASE)
     for mtgjson_card_object in mtgjson_set.cards:
-        for service, url in mtgjson_card_object.purchase_urls.to_json().items():
-            if service not in mtgjson_card_object.raw_purchase_urls:
-                LOGGER.info(
-                    f"Service {service} not found for {mtgjson_card_object.name}"
-                )
-                continue
-
-            return_list.append(
-                (
-                    url.split("/")[-1],
-                    string_regex.sub(
-                        "mtgjson", mtgjson_card_object.raw_purchase_urls[service]
-                    ),
-                )
-            )
+        return_list.extend(build_referral_map_helper(mtgjson_card_object, string_regex))
     for mtgjson_sealed_object in mtgjson_set.sealed_product:
-        for service, url in mtgjson_sealed_object.purchase_urls.to_json().items():
-            if service not in mtgjson_sealed_object.raw_purchase_urls:
-                LOGGER.info(
-                    f"Service {service} not found for {mtgjson_sealed_object.name}"
-                )
-                continue
+        return_list.extend(
+            build_referral_map_helper(mtgjson_sealed_object, string_regex)
+        )
+    return return_list
 
-            return_list.append(
-                (
-                    url.split("/")[-1],
-                    string_regex.sub(
-                        "mtgjson", mtgjson_sealed_object.raw_purchase_urls[service]
-                    ),
-                )
+
+def build_referral_map_helper(
+    mtgjson_object: Union[MtgjsonCardObject, MtgjsonSealedProductObject],
+    string_regex: re.Pattern,
+) -> List[Tuple[str, str]]:
+    """
+    Helps construct the referral map contents
+    :param mtgjson_object: MTGJSON Set or Card object
+    :param string_regex: compiled scryfall regex data
+    :return: tuple to append
+    """
+    return_list = []
+    for service, url in mtgjson_object.purchase_urls.to_json().items():
+        if service not in mtgjson_object.raw_purchase_urls:
+            LOGGER.info(f"Service {service} not found for {mtgjson_object.name}")
+            continue
+
+        return_list.append(
+            (
+                url.split("/")[-1],
+                string_regex.sub("mtgjson", mtgjson_object.raw_purchase_urls[service]),
             )
-
+        )
     return return_list
 
 

--- a/mtgjson5/referral_builder.py
+++ b/mtgjson5/referral_builder.py
@@ -44,6 +44,22 @@ def build_referral_map(mtgjson_set: MtgjsonSetObject) -> List[Tuple[str, str]]:
                     ),
                 )
             )
+    for mtgjson_sealed_object in mtgjson_set.sealed_product:
+        for service, url in mtgjson_sealed_object.purchase_urls.to_json().items():
+            if service not in mtgjson_sealed_object.raw_purchase_urls:
+                LOGGER.info(
+                    f"Service {service} not found for {mtgjson_sealed_object.name}"
+                )
+                continue
+
+            return_list.append(
+                (
+                    url.split("/")[-1],
+                    string_regex.sub(
+                        "mtgjson", mtgjson_sealed_object.raw_purchase_urls[service]
+                    ),
+                )
+            )
 
     return return_list
 

--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -34,6 +34,7 @@ from .providers import (
     GitHubBoostersProvider,
     MTGBanProvider,
     ScryfallProvider,
+    TCGPlayerProvider,
     WhatsInStandardProvider,
     WizardsProvider,
 )
@@ -411,6 +412,12 @@ def build_mtgjson_set(set_code: str) -> Optional[MtgjsonSetObject]:
 
     mtgjson_set.tcgplayer_group_id = set_data.get("tcgplayer_id")
     mtgjson_set.booster = GitHubBoostersProvider().get_set_booster_data(set_code)
+
+    mtgjson_set.sealed_product = (
+        TCGPlayerProvider().generate_mtgjson_sealed_product_objects(
+            mtgjson_set.tcgplayer_group_id
+        )
+    )
 
     mark_duel_decks(set_code, mtgjson_set.cards)
 

--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -18,9 +18,9 @@ from .classes import (
     MtgjsonLegalitiesObject,
     MtgjsonMetaObject,
     MtgjsonRulingObject,
+    MtgjsonSealedProductObject,
     MtgjsonSetObject,
 )
-from .classes.mtgjson_sealed_product import MtgjsonSealedProductObject
 from .consts import (
     BASIC_LAND_NAMES,
     CARD_MARKET_BUFFER,
@@ -459,7 +459,7 @@ def add_sealed_purchase_url(mtgjson_set: MtgjsonSetObject) -> None:
     :param mtgjson_set: the set to add purchase urls to
     """
     for sealed_product in mtgjson_set.sealed_product:
-        if sealed_product.identifiers.tcgplayer_product_id is not None:
+        if sealed_product.identifiers.tcgplayer_product_id:
             sealed_product.purchase_urls.tcgplayer = url_keygen(
                 sealed_product.identifiers.tcgplayer_product_id + sealed_product.uuid
             )


### PR DESCRIPTION
This is a basic implementation of how MTGJSON could add a sealed product class to the set data files. This new class heavily leans on the TCGPlayer API for data as there is already infrastructure within MTGJSON to get data from the TCGPlayer API based on the set. This data is then compiled into a new class called MtgjsonSealedProductObject which contains the name, UUID, identifiers, purchase URLs, and release date of sealed product stored on TCGPlayer. This data is currently very barebones and could greatly be expanded upon by adding a contents field and combing existing MTGJSON data about boosters and decks into the product data. I think the current data is solid but it definitely needs a way to parse raw purchase URLs to ones with MTGJSON referral codes as the current referral system leans on the card class. Overall I think this is a good starting point for the addition of sealed product data. I want to thank Koda for helping with some debugging and design ideas. I have also included the WAR set file that is created with this current fork. 

WAR MTGJSON File:
[WAR.zip](https://github.com/mtgjson/mtgjson/files/6079974/WAR.zip)