### PR TITLE
Support combining of entities with etched/glossy/foil/non status.

### DIFF
--- a/mtgjson5/classes/mtgjson_card.py
+++ b/mtgjson5/classes/mtgjson_card.py
@@ -34,6 +34,7 @@ class MtgjsonCardObject:
     edhrec_rank: Optional[int]
     face_converted_mana_cost: float
     face_name: Optional[str]
+    finishes: List[str]
     flavor_name: Optional[str]
     flavor_text: Optional[str]
     foreign_data: List[MtgjsonForeignDataObject]
@@ -42,8 +43,8 @@ class MtgjsonCardObject:
     hand: Optional[str]
     has_alternative_deck_limit: Optional[bool]
     has_content_warning: Optional[bool]
-    has_foil: Optional[bool]
-    has_non_foil: Optional[bool]
+    has_foil: Optional[bool]  # Deprecated - Remove in 5.3.0
+    has_non_foil: Optional[bool]  # Deprecated - Remove in 5.3.0
     identifiers: MtgjsonIdentifiersObject
     is_alternative: Optional[bool]
     is_full_art: Optional[bool]

--- a/mtgjson5/classes/mtgjson_identifiers.py
+++ b/mtgjson5/classes/mtgjson_identifiers.py
@@ -22,6 +22,7 @@ class MtgjsonIdentifiersObject:
     scryfall_id: Optional[str]
     scryfall_illustration_id: Optional[str]
     scryfall_oracle_id: Optional[str]
+    tcgplayer_etched_product_id: Optional[str]
     tcgplayer_product_id: Optional[str]
     mtgjson_v4_id: Optional[str]
 

--- a/mtgjson5/classes/mtgjson_purchase_urls.py
+++ b/mtgjson5/classes/mtgjson_purchase_urls.py
@@ -15,6 +15,7 @@ class MtgjsonPurchaseUrlsObject:
     card_kingdom_foil: str
     cardmarket: str
     tcgplayer: str
+    tcgplayer_etched: str
 
     def build_keys_to_skip(self) -> Set[str]:
         """

--- a/mtgjson5/providers/tcgplayer.py
+++ b/mtgjson5/providers/tcgplayer.py
@@ -257,9 +257,7 @@ class TCGPlayerProvider(AbstractProvider):
                 sealed_product.release_date = sealed_product.release_date[0:10]
             sealed_product.raw_purchase_urls[
                 "tcgplayer"
-            ] = "https://shop.tcgplayer.com/product/productsearch?id={}&utm_campaign=affiliate&utm_medium=api&utm_source=mtgjson".format(
-                sealed_product.identifiers.tcgplayer_product_id
-            )
+            ] = f"https://shop.tcgplayer.com/product/productsearch?id={sealed_product.identifiers.tcgplayer_product_id}&utm_campaign=affiliate&utm_medium=api&utm_source=mtgjson"
             mtgjson_sealed_products.append(sealed_product)
 
         return mtgjson_sealed_products

--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -713,12 +713,14 @@ def build_mtgjson_card(
     mtgjson_card.color_identity = scryfall_object.get("color_identity", "")
     mtgjson_card.converted_mana_cost = scryfall_object.get("cmc", "")
     mtgjson_card.edhrec_rank = scryfall_object.get("edhrec_rank")
+    mtgjson_card.finishes = scryfall_object.get("finishes", "")
     mtgjson_card.frame_effects = scryfall_object.get("frame_effects", "")
     mtgjson_card.frame_version = scryfall_object.get("frame", "")
     mtgjson_card.hand = scryfall_object.get("hand_modifier")
-    mtgjson_card.has_foil = scryfall_object.get("foil")
-    mtgjson_card.has_non_foil = scryfall_object.get("nonfoil")
-
+    mtgjson_card.has_foil = any(
+        finish in scryfall_object.get("finishes", []) for finish in ("foil", "glossy")
+    )
+    mtgjson_card.has_non_foil = "nonfoil" in scryfall_object.get("finishes", [])
     mtgjson_card.has_content_warning = scryfall_object.get("content_warning")
     mtgjson_card.is_full_art = scryfall_object.get("full_art")
     mtgjson_card.is_online_only = scryfall_object.get("digital")
@@ -940,6 +942,17 @@ def build_mtgjson_card(
         mtgjson_card.purchase_urls.tcgplayer = url_keygen(
             mtgjson_card.identifiers.tcgplayer_product_id + mtgjson_card.uuid
         )
+    if "tcgplayer_etched_id" in scryfall_object:
+        mtgjson_card.identifiers.tcgplayer_etched_product_id = str(
+            scryfall_object["tcgplayer_etched_id"]
+        )
+        mtgjson_card.purchase_urls.tcgplayer_etched = url_keygen(
+            mtgjson_card.identifiers.tcgplayer_etched_product_id + mtgjson_card.uuid
+        )
+        # Have to manually insert
+        mtgjson_card.raw_purchase_urls[
+            "tcgplayerEtched"
+        ] = f"https://shop.tcgplayer.com/product/productsearch?id={mtgjson_card.identifiers.tcgplayer_etched_product_id}&utm_campaign=affiliate&utm_medium=api&utm_source=mtgjson"
 
     if is_token:
         reverse_related: List[str] = []


### PR DESCRIPTION
This will reduce the number of duplicate entries, and help simplify the card model. This also adds referral URL support.

ADD
- card.finishes
- card.identifiers.tcgplayer_etched_product_id
- card.purchase_urls.tcgplayer_etched

DEPRECATE
- has_foil (Will be removed in 5.2.0)
- has_non_foil (Will be removed in 5.2.0)

[CMR.json.txt](https://github.com/mtgjson/mtgjson/files/7132572/CMR.json.txt)
[H1R.json.txt](https://github.com/mtgjson/mtgjson/files/7132561/H1R.json.txt)
