### PR TITLE
Handle excessive printings for foreignData

### DIFF
--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -60,12 +60,12 @@ def parse_foreign(
     # Add information to get all languages
     sf_prints_url = sf_prints_url.replace("&unique=prints", "+lang%3Aany&unique=prints")
 
-    prints_api_json: Dict[str, Any] = ScryfallProvider().download(sf_prints_url)
-    if prints_api_json["object"] == "error":
+    prints_api_json = ScryfallProvider().download_all_pages(sf_prints_url)
+    if not prints_api_json:
         LOGGER.error(f"No data found for {sf_prints_url}: {prints_api_json}")
         return []
 
-    for foreign_card in prints_api_json["data"]:
+    for foreign_card in prints_api_json:
         if (
             set_name != foreign_card["set"]
             or card_number != foreign_card["collector_number"]


### PR DESCRIPTION
Fix #837

Fixed missing foreignData fields for cards that have so many printings we ran out of space. We now will iterate API responses to ensure all entries are grabbed to allow the best chance of success. Some refactoring to handle duplicate code

[M21.json.txt](https://github.com/mtgjson/mtgjson/files/7181214/M21.json.txt)
