### PR TITLE
Add manavalue/faceManaValue & Fix WhatsInStandard

### DIFF
--- a/mtgjson5/classes/mtgjson_card.py
+++ b/mtgjson5/classes/mtgjson_card.py
@@ -33,6 +33,7 @@ class MtgjsonCardObject:
     duel_deck: Optional[str]
     edhrec_rank: Optional[int]
     face_converted_mana_cost: float
+    face_mana_value: float
     face_name: Optional[str]
     finishes: List[str]
     flavor_name: Optional[str]
@@ -64,6 +65,7 @@ class MtgjsonCardObject:
     life: Optional[str]
     loyalty: Optional[str]
     mana_cost: str
+    mana_value: float
     name: str
     number: str
     original_release_date: Optional[str]
@@ -107,7 +109,9 @@ class MtgjsonCardObject:
         "colors",
         "rulings",
         "converted_mana_cost",
+        "mana_value",
         "face_converted_mana_cost",
+        "face_mana_value",
         "foreign_data",
         "reverse_related",
     }
@@ -119,6 +123,7 @@ class MtgjsonCardObject:
         "purchase_urls",
         "printings",
         "converted_mana_cost",
+        "mana_value",
         "foreign_data",
         "legalities",
         "leadership_skills",
@@ -135,6 +140,7 @@ class MtgjsonCardObject:
         "count",
         "edhrec_rank",
         "face_converted_mana_cost",
+        "face_mana_value",
         "face_name",
         "foreign_data",
         "hand",
@@ -148,6 +154,7 @@ class MtgjsonCardObject:
         "life",
         "loyalty",
         "mana_cost",
+        "mana_value",
         "name",
         "power",
         "printings",

--- a/mtgjson5/providers/whats_in_standard.py
+++ b/mtgjson5/providers/whats_in_standard.py
@@ -69,7 +69,7 @@ class WhatsInStandardProvider(AbstractProvider):
         api_response = self.download(self.API_ENDPOINT)
 
         standard_set_codes = {
-            set_object.get("code", "").upper()
+            str(set_object.get("code")).upper()
             for set_object in api_response["sets"]
             if (
                 dateutil.parser.parse(set_object["enterDate"]["exact"] or "9999")

--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -675,6 +675,10 @@ def build_mtgjson_card(
             mtgjson_card.colors = get_card_colors(
                 scryfall_object["mana_cost"].split("//")[face_id]
             )
+            mtgjson_card.face_mana_value = get_card_cmc(
+                scryfall_object["mana_cost"].split("//")[face_id]
+            )
+            # Deprecated - Remove in 6.0.0
             mtgjson_card.face_converted_mana_cost = get_card_cmc(
                 scryfall_object["mana_cost"].split("//")[face_id]
             )
@@ -684,6 +688,8 @@ def build_mtgjson_card(
             "aftermath",
             "adventure",
         }:
+            mtgjson_card.face_mana_value = get_card_cmc(face_data.get("mana_cost", "0"))
+            # Deprecated - Remove in 6.0.0
             mtgjson_card.face_converted_mana_cost = get_card_cmc(
                 face_data.get("mana_cost", "0")
             )
@@ -718,6 +724,8 @@ def build_mtgjson_card(
 
     mtgjson_card.border_color = scryfall_object.get("border_color", "")
     mtgjson_card.color_identity = scryfall_object.get("color_identity", "")
+    mtgjson_card.mana_value = scryfall_object.get("cmc", "")
+    # Deprecated - Remove in 6.0.0
     mtgjson_card.converted_mana_cost = scryfall_object.get("cmc", "")
     mtgjson_card.edhrec_rank = scryfall_object.get("edhrec_rank")
     mtgjson_card.finishes = scryfall_object.get("finishes", "")


### PR DESCRIPTION
Fix #793

Support manaValue and faceManaValue for newer clients, as the name changed officially. Also fix small issue with WhatsInStandard API response type changing slightly. Deprecated cmc for 6.0.0.

ADD
card manaValue
card faceManaValue

DEPRECATE
card cmc (Removal in v6.0.0)

<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
