### PR TITLE
Support Alchemy Cards Better (First Idea)

### DIFF
--- a/mtgjson5/classes/mtgjson_card.py
+++ b/mtgjson5/classes/mtgjson_card.py
@@ -55,6 +55,7 @@ class MtgjsonCardObject:
     is_online_only: Optional[bool]
     is_oversized: Optional[bool]
     is_promo: Optional[bool]
+    is_rebalanced: Optional[bool]
     is_reprint: Optional[bool]
     is_reserved: Optional[bool]
     is_starter: Optional[bool]
@@ -71,6 +72,7 @@ class MtgjsonCardObject:
     mana_value: float
     name: str
     number: str
+    original_printings: List[str]
     original_release_date: Optional[str]
     original_text: Optional[str]
     original_type: Optional[str]

--- a/mtgjson5/classes/mtgjson_card.py
+++ b/mtgjson5/classes/mtgjson_card.py
@@ -83,6 +83,7 @@ class MtgjsonCardObject:
     promo_types: List[str]
     purchase_urls: MtgjsonPurchaseUrlsObject
     rarity: str
+    rebalanced_printings: List[str]
     reverse_related: Optional[List[str]]
     rulings: List[MtgjsonRulingObject]
     security_stamp: Optional[str]

--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -293,6 +293,28 @@ def parse_rulings(rulings_url: str) -> List[MtgjsonRulingObject]:
     return sorted(mtgjson_rules, key=lambda ruling: ruling.date)
 
 
+def add_rebalanced_to_original_linkage(mtgjson_set: MtgjsonSetObject) -> None:
+    """
+    When Wizards rebalances a card, they break the link between
+    the new card and the original card. We will create a one-way
+    linkage back to the original card, should that prove useful
+    to the end user.
+    :param mtgjson_set MTGJSON Set object
+    """
+    LOGGER.info(f"Linking rebalanced cards for {mtgjson_set.code}")
+
+    for card in mtgjson_set.cards:
+        if getattr(card, "is_rebalanced", False):
+            original_card_name_to_find = card.name.replace("A-", "")
+
+            original_card_uuids = []
+            for inner_card in mtgjson_set.cards:
+                if inner_card.name == original_card_name_to_find:
+                    original_card_uuids.append(inner_card.uuid)
+
+            card.original_printings = original_card_uuids
+
+
 def relocate_miscellaneous_tokens(mtgjson_set: MtgjsonSetObject) -> None:
     """
     Sometimes tokens find their way into the main set. This will
@@ -404,6 +426,7 @@ def build_mtgjson_set(set_code: str) -> Optional[MtgjsonSetObject]:
         set_code, set_release_date=mtgjson_set.release_date
     )
     add_is_starter_option(set_code, mtgjson_set.search_uri, mtgjson_set.cards)
+    add_rebalanced_to_original_linkage(mtgjson_set)
     relocate_miscellaneous_tokens(mtgjson_set)
     add_mcm_details(mtgjson_set)
     add_card_kingdom_details(mtgjson_set)
@@ -930,6 +953,10 @@ def build_mtgjson_card(
     mtgjson_card.types = card_types[1]
     mtgjson_card.subtypes = card_types[2]
 
+    if mtgjson_card.name.startswith("A-"):
+        mtgjson_card.is_alternative = True
+        mtgjson_card.is_rebalanced = True
+
     if "Planeswalker" in mtgjson_card.types:
         mtgjson_card.text = re.sub(r"([+−-]?[0-9X]+):", r"[\1]:", mtgjson_card.text)
 
@@ -1324,7 +1351,10 @@ def get_base_and_total_set_sizes(mtgjson_set: MtgjsonSetObject) -> Tuple[int, in
 
             base_set_size = int(base_set_size_download.get("total_cards", 0))
 
-    return base_set_size, len(mtgjson_set.cards)
+    total_set_size = sum(
+        1 for card in mtgjson_set.cards if not getattr(card, "is_rebalanced", False)
+    )
+    return base_set_size, total_set_size
 
 
 def get_signature_from_number(mtgjson_card: MtgjsonCardObject) -> Optional[str]:

--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -296,9 +296,9 @@ def parse_rulings(rulings_url: str) -> List[MtgjsonRulingObject]:
 def add_rebalanced_to_original_linkage(mtgjson_set: MtgjsonSetObject) -> None:
     """
     When Wizards rebalances a card, they break the link between
-    the new card and the original card. We will create a one-way
-    linkage back to the original card, should that prove useful
-    to the end user.
+    the new card and the original card. We will create a two-way
+    linkage back to and from the original card,
+    should that prove useful to the end user.
     :param mtgjson_set MTGJSON Set object
     """
     LOGGER.info(f"Linking rebalanced cards for {mtgjson_set.code}")
@@ -310,7 +310,11 @@ def add_rebalanced_to_original_linkage(mtgjson_set: MtgjsonSetObject) -> None:
             original_card_uuids = []
             for inner_card in mtgjson_set.cards:
                 if inner_card.name == original_card_name_to_find:
+                    # Doubly link these cards
                     original_card_uuids.append(inner_card.uuid)
+                    if not hasattr(inner_card, "rebalanced_printings"):
+                        inner_card.rebalanced_printings = []
+                    inner_card.rebalanced_printings.append(card.uuid)
 
             card.original_printings = original_card_uuids
 


### PR DESCRIPTION
Fix #885 

This is a review-required PR to better support Alchemy cards. To start, I've added isRebalanced(bool) and originalPrintings(list[str]) to the card object.

For cards that have been rebalanced by Wizards, a new card entry will be put into the original set file that the card appeared in. This new card entry will have isRebalanced=True, isAlternative=True, and originalPrintings containing the UUID(s) of the card(s) in the same set file that were the "original" version. Alchemy cards will _not_ change the baseSetSize or totalSetSize of those sets, just simply add new values in.

Alchemy cards will be handled in AtomicCards as a new entry, which is fine. This doesn't handle the changing UUID of the card if they get re-re-balanced, so I'm scouting ideas on that.

My implementation files:
[KHM.json.txt](https://github.com/mtgjson/mtgjson/files/7733708/KHM.json.txt)
[diff.txt](https://github.com/mtgjson/mtgjson/files/7733707/diff.txt)

By setting isAlternative, we hopefully keep backwards compatibility that these cards are extra and can possibly be ignored. isRebalanced adds new struct giving users the ability to filter/use as they please.

This is just one idea I had on handling Alchemy better, but I'm open to alternative suggestions.

One alternative design I scouted was adding a new field to cards "rebalancedEntities(Dict[str, Any])" that contains a dict of all the keys changed and their new values. I like the concept, but I'd like to scout a few more ideas / feedback before committing to one.