### PR TITLE
Fix #874 Source issue as Gatherer doesn't always provide line breaks

### DIFF
--- a/mtgjson5/providers/gatherer.py
+++ b/mtgjson5/providers/gatherer.py
@@ -142,14 +142,23 @@ class GathererProvider(AbstractProvider):
             ):
                 flavor_lines.append(flavor_box.getText(strip=True))
 
-        text_lines = []
+        original_text_lines = []
         if "Card Text" in label_to_values:
             for textbox in label_to_values["Card Text"].find_all(
                 "div", class_="cardtextbox"
             ):
-                text_lines.append(self._replace_symbols(textbox).getText().strip())
+                textbox_value = self._replace_symbols(textbox).getText().strip()
 
-        original_text: Optional[str] = "\n".join(text_lines).strip() or None
+                # Introduce line breaks when necessary, as Gatherer doesn't provide this all the time
+                textbox_line = textbox_value.replace(card_name, "(CN)")
+                textbox_line = re.sub(
+                    r"([^ ({\"\-−+/>A-Z])([A-Z])", r"\1\n\2", textbox_line
+                )
+                textbox_line = textbox_line.replace("(CN)", card_name)
+
+                original_text_lines.extend(textbox_line.split("\n"))
+
+        original_text: Optional[str] = "\n".join(original_text_lines).strip() or None
         if strip_parentheses and original_text:
             original_text = self.strip_parentheses_from_text(original_text)
 


### PR DESCRIPTION
…for its printed text... We instead take a bit of creative licensing and add line breaks if we see a capital letter after non-appropriate characters.

For phase 1, Open Paren, Open Bracket, Quote, Minus, Dash, Plus, Less Than, and other Capital Letters are allowed to precede a Capital Letter as that's what I saw to be problematic. It's possible more exceptions are needed, and we'll add them as necessary.

Tested with CMR, IMA, and BFZ. CMR and IMA saw no changes (as they should). BFZ changes below.

[BFZ.diff.txt](https://github.com/mtgjson/mtgjson/files/7737277/BFZ.diff.txt)

