### PR TITLE
Fix #901 - AtomicCards Dungeons missing MV/CMC

### DIFF
--- a/mtgjson5/compiled_classes/mtgjson_atomic_cards.py
+++ b/mtgjson5/compiled_classes/mtgjson_atomic_cards.py
@@ -59,6 +59,10 @@ class MtgjsonAtomicCardsObject:
                 for token in file_content.get("data", {}).get("tokens", [])
                 if token.get("type") == "Dungeon"
             ]
+            for dungeon in dungeons:
+                dungeon["manaValue"] = 0.0
+                dungeon["convertedManaCost"] = 0.0
+
             valid_cards.extend(dungeons)
 
             self.update_global_card_list(


### PR DESCRIPTION
Support manaValue/convertedManaCost for Dungeons within the Atomic* files.
[AtomicCards.json.txt](https://github.com/mtgjson/mtgjson/files/8051610/AtomicCards.json.txt)

