### PR TITLE
Prevent duplicate IDs in the ReferralMap, even if they have different…

### DIFF
--- a/mtgjson5/referral_builder.py
+++ b/mtgjson5/referral_builder.py
@@ -83,8 +83,8 @@ def fixup_referral_map() -> None:
     with MtgjsonConfig().output_path.joinpath("ReferralMap.json").open(
         encoding="utf-8"
     ) as file:
-        lines = list(set(file.readlines()))
-        lines = sorted(lines)
+        uniq_map = dict(line.split("\t", 1) for line in file.readlines())
+        lines = sorted([f"{key}\t{value}" for key, value in uniq_map.items()])
 
     with MtgjsonConfig().output_path.joinpath("ReferralMap.json").open(
         "w", encoding="utf-8"


### PR DESCRIPTION
… endpoint URLs.

Something's gone funky with TCGPlayer as 108 IDs in regard to Commander Legends Foil Etched singles.

<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
