### PR TITLE
Support MultiverseBridge (AKA CardSphere) IDs & Prices

### DIFF
--- a/mtgjson5/classes/mtgjson_identifiers.py
+++ b/mtgjson5/classes/mtgjson_identifiers.py
@@ -14,9 +14,11 @@ class MtgjsonIdentifiersObject:
     card_kingdom_etched_id: Optional[str]
     card_kingdom_foil_id: Optional[str]
     card_kingdom_id: Optional[str]
+    cardsphere_id: Optional[str]
     mcm_id: Optional[str]
     mcm_meta_id: Optional[str]
     mtg_arena_id: Optional[str]
+    mtgjson_v4_id: Optional[str]
     mtgo_foil_id: Optional[str]
     mtgo_id: Optional[str]
     multiverse_id: Optional[str]
@@ -25,7 +27,6 @@ class MtgjsonIdentifiersObject:
     scryfall_oracle_id: Optional[str]
     tcgplayer_etched_product_id: Optional[str]
     tcgplayer_product_id: Optional[str]
-    mtgjson_v4_id: Optional[str]
 
     def __init__(self) -> None:
         """

--- a/mtgjson5/classes/mtgjson_set.py
+++ b/mtgjson5/classes/mtgjson_set.py
@@ -19,6 +19,7 @@ class MtgjsonSetObject:
     block: str
     booster: Optional[Dict[str, Any]]
     cards: List[MtgjsonCardObject]
+    cardsphere_set_id: Optional[int]
     code: str
     code_v3: str
     is_foreign_only: bool

--- a/mtgjson5/price_builder.py
+++ b/mtgjson5/price_builder.py
@@ -20,6 +20,7 @@ from .providers import (
     CardHoarderProvider,
     CardKingdomProvider,
     CardMarketProvider,
+    MultiverseBridgeProvider,
     TCGPlayerProvider,
 )
 
@@ -74,9 +75,12 @@ def build_today_prices() -> Dict[str, Any]:
     tcgplayer = _generate_prices(TCGPlayerProvider())
     card_market = _generate_prices(CardMarketProvider())
     card_kingdom = _generate_prices(CardKingdomProvider())
+    cardsphere = _generate_prices(MultiverseBridgeProvider())
 
     final_results: Dict[str, Any] = {}
-    mergedeep.merge(final_results, card_hoarder, tcgplayer, card_market, card_kingdom)
+    mergedeep.merge(
+        final_results, card_hoarder, tcgplayer, card_market, card_kingdom, cardsphere
+    )
 
     return final_results
 

--- a/mtgjson5/providers/__init__.py
+++ b/mtgjson5/providers/__init__.py
@@ -10,6 +10,7 @@ from .github_boosters import GitHubBoostersProvider
 from .github_decks import GitHubDecksProvider
 from .github_mtgsqlite import GitHubMTGSqliteProvider
 from .mtgban import MTGBanProvider
+from .multiversebridge import MultiverseBridgeProvider
 from .scryfall import ScryfallProvider
 from .tcgplayer import TCGPlayerProvider
 from .whats_in_standard import WhatsInStandardProvider

--- a/mtgjson5/providers/cardhoarder.py
+++ b/mtgjson5/providers/cardhoarder.py
@@ -127,6 +127,7 @@ class CardHoarderProvider(AbstractProvider):
 
         db_contents: Dict[str, MtgjsonPricesObject] = {}
 
+        LOGGER.info("Building CardHoarder retail data")
         self._construct_for_cards(db_contents, normal_cards, True)
         self._construct_for_cards(db_contents, foil_cards)
         return db_contents

--- a/mtgjson5/providers/cardmarket.py
+++ b/mtgjson5/providers/cardmarket.py
@@ -97,6 +97,7 @@ class CardMarketProvider(AbstractProvider):
             all_printings_path, ("identifiers", "mcmId"), ("uuid",)
         )
 
+        LOGGER.info("Building CardMarket retail data")
         price_data: pandas.DataFrame = pandas.read_csv(self._get_card_market_data())
         data_frame_columns = list(price_data.columns)
 

--- a/mtgjson5/providers/multiversebridge.py
+++ b/mtgjson5/providers/multiversebridge.py
@@ -1,0 +1,114 @@
+"""
+MultiverseBridge 3rd party provider
+"""
+import logging
+import pathlib
+import time
+from typing import Any, Dict, List, Set, Union
+
+from singleton_decorator import singleton
+
+from ..classes import MtgjsonPricesObject
+from ..providers.abstract import AbstractProvider
+from ..utils import generate_card_mapping, retryable_session
+
+LOGGER = logging.getLogger(__name__)
+
+
+@singleton
+class MultiverseBridgeProvider(AbstractProvider):
+    """
+    MultiverseBridge container
+    """
+
+    class_id: str = "mb"
+
+    ROSETTA_STONE_CARDS_URL = "https://www.multiversebridge.com/api/v1/cards"
+    ROSETTA_STONE_SETS_URL = "https://www.multiversebridge.com/api/v1/sets"
+    ROSETTA_STONE_PRICES_URL = "https://cdn.multiversebridge.com/mtgjson_build.json"
+    rosetta_stone_cards: Dict[str, Any]
+    rosetta_stone_sets: Dict[str, int]
+
+    def __init__(self) -> None:
+        super().__init__(self._build_http_header())
+        self.rosetta_stone_cards = {}
+        self.rosetta_stone_sets = {}
+
+    def _build_http_header(self) -> Dict[str, str]:
+        return {}
+
+    def download(self, url: str, params: Dict[str, Union[str, int]] = None) -> Any:
+        session = retryable_session()
+        session.headers.update(self.session_header)
+        response = session.get(url)
+        self.log_download(response)
+        if not response.ok:
+            LOGGER.error(
+                f"MultiverseBridge Download Error ({response.status_code}): {response.content.decode()}"
+            )
+            time.sleep(5)
+            return self.download(url, params)
+        return response.json()
+
+    def parse_rosetta_stone_cards(self, rosetta_rows: Dict[str, Any]) -> None:
+        """
+        Convert Rosetta Stone Card data into an index-able hashmap
+        :param rosetta_rows: Rows from the API
+        """
+        for rosetta_row in rosetta_rows["cards"]:
+            self.rosetta_stone_cards[rosetta_row["scryfall_id"]] = rosetta_row
+
+    def parse_rosetta_stone_sets(self, rosetta_rows: List[Dict[str, Any]]) -> None:
+        """
+        Convert Rosetta Stone Set data into index-able hashmap
+        :param rosetta_rows: Rows from the API
+        """
+        for rosetta_row in rosetta_rows:
+            self.rosetta_stone_sets[rosetta_row["mtgjson_code"]] = rosetta_row["cs_id"]
+
+    def get_rosetta_stone_cards(self) -> Dict[str, Any]:
+        """
+        Cache a copy of the Rosetta Stone from MB and give it back when needed
+        :return Rosetta Stone of Card IDs
+        """
+        if not self.rosetta_stone_cards:
+            self.parse_rosetta_stone_cards(self.download(self.ROSETTA_STONE_CARDS_URL))
+        return self.rosetta_stone_cards
+
+    def get_rosetta_stone_sets(self) -> Dict[str, int]:
+        """
+        Cache a copy of the Rosetta Stone's Set IDs from MB and give it back when needed
+        :return Rosetta Stone of Set IDs
+        """
+        if not self.rosetta_stone_sets:
+            self.parse_rosetta_stone_sets(self.download(self.ROSETTA_STONE_SETS_URL))
+        return self.rosetta_stone_sets
+
+    def generate_today_price_dict(
+        self, all_printings_path: pathlib.Path
+    ) -> Dict[str, MtgjsonPricesObject]:
+        """
+        Generate a single-day price structure for Paper from CardSphere
+        :return MTGJSON prices single day structure
+        """
+        request_api_response: List[Dict[str, Any]] = self.download(
+            self.ROSETTA_STONE_PRICES_URL
+        )
+
+        cardsphere_id_to_mtgjson: Dict[str, Set[Any]] = generate_card_mapping(
+            all_printings_path, ("identifiers", "cardsphereId"), ("uuid",)
+        )
+
+        default_prices_obj = MtgjsonPricesObject(
+            "paper", "cardsphere", self.today_date, "USD"
+        )
+
+        LOGGER.info("Building CardSphere retail data")
+        return super().generic_generate_today_price_dict(
+            third_party_to_mtgjson=cardsphere_id_to_mtgjson,
+            price_data_rows=request_api_response,
+            card_platform_id_key="cs_id",
+            default_prices_object=default_prices_obj,
+            foil_key="is_foil",
+            retail_key="price",
+        )

--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -26,6 +26,7 @@ from .providers import (
     GathererProvider,
     GitHubBoostersProvider,
     MTGBanProvider,
+    MultiverseBridgeProvider,
     ScryfallProvider,
     TCGPlayerProvider,
     WhatsInStandardProvider,
@@ -456,6 +457,8 @@ def build_mtgjson_set(set_code: str) -> Optional[MtgjsonSetObject]:
     add_sealed_uuid(mtgjson_set)
     add_sealed_purchase_url(mtgjson_set)
     add_token_signatures(mtgjson_set)
+
+    add_multiverse_bridge_ids(mtgjson_set)
 
     mark_duel_decks(set_code, mtgjson_set.cards)
 
@@ -1268,6 +1271,30 @@ def add_token_signatures(mtgjson_set: MtgjsonSetObject) -> None:
                     add_signature(mtgjson_card, signature)
 
     LOGGER.info(f"Finished adding signatures to cards for {mtgjson_set.code}")
+
+
+def add_multiverse_bridge_ids(mtgjson_set: MtgjsonSetObject) -> None:
+    """
+    There are extra IDs that can be useful for the community to have
+    knowledge of. This step will incorporate all of those IDs
+    """
+    LOGGER.info(f"Adding MultiverseBridge details for {mtgjson_set.code}")
+    rosetta_stone_cards = MultiverseBridgeProvider().get_rosetta_stone_cards()
+    for mtgjson_card in mtgjson_set.cards:
+        if mtgjson_card.identifiers.scryfall_id not in rosetta_stone_cards:
+            LOGGER.warning(
+                f"MultiverseBridge missing {mtgjson_card.name} in {mtgjson_card.set_code}"
+            )
+            continue
+        mtgjson_card.identifiers.cardsphere_id = str(
+            rosetta_stone_cards[mtgjson_card.identifiers.scryfall_id]["cs_id"]
+        )
+
+    mtgjson_set.cardsphere_set_id = (
+        MultiverseBridgeProvider()
+        .get_rosetta_stone_sets()
+        .get(mtgjson_set.code.upper())
+    )
 
 
 def add_mcm_details(mtgjson_set: MtgjsonSetObject) -> None:


### PR DESCRIPTION
Also abstract away part of how prices are generated for providers, since it's a lot of duplicated code.
(Will work more towards converting other price builders to use the generic method if possible.)

ADD card.identifiers.cardsphere_id -- Optional String
ADD set.cardsphere_set_id -- Optional Integer
ADD CardSphere to prices file under paper category with USD -- Retail only, No Buylist

