### PR TITLE
Fix #679: DEPRECATE isStarter

### DIFF
--- a/mtgjson5/classes/mtgjson_card.py
+++ b/mtgjson5/classes/mtgjson_card.py
@@ -62,7 +62,7 @@ class MtgjsonCardObject:
     is_rebalanced: Optional[bool]
     is_reprint: Optional[bool]
     is_reserved: Optional[bool]
-    is_starter: Optional[bool]
+    is_starter: Optional[bool]  # Deprecated - Remove in 5.3.0
     is_story_spotlight: Optional[bool]
     is_textless: Optional[bool]
     is_timeshifted: Optional[bool]


### PR DESCRIPTION
- Removal in 5.3.0
- This field no longer has sufficient purpose

<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
