### PR TITLE
Rename draft booster to default to match Booster type names

### DIFF
--- a/mtgjson5/classes/mtgjson_sealed_product.py
+++ b/mtgjson5/classes/mtgjson_sealed_product.py
@@ -72,7 +72,8 @@ class MtgjsonSealedProductSubtype(enum.Enum):
     UNKNOWN = ""
 
     # Typically for booster_box and booster_pack
-    DRAFT = "draft"
+    # These should match the booster values in Booster
+    DEFAULT = "default"
     SET = "set"
     COLLECTOR = "collector"
     JUMPSTART = "jumpstart"

--- a/mtgjson5/providers/tcgplayer.py
+++ b/mtgjson5/providers/tcgplayer.py
@@ -109,7 +109,7 @@ class TCGPlayerProvider(AbstractProvider):
     product_default_size = {
         "set": 30,
         "collector": 12,
-        "draft": 36,
+        "default": 36,
         "jumpstart": 18,
         "theme": 12,
     }
@@ -457,12 +457,12 @@ class TCGPlayerProvider(AbstractProvider):
             if subtype.value.replace("_", " ") in product_name:
                 return subtype
 
-        # Special handling because sometimes 'draft' is not tagged
+        # Special handling because sometimes 'default' is not tagged
         if category in [
             MtgjsonSealedProductCategory.BOOSTER_BOX,
             MtgjsonSealedProductCategory.BOOSTER_PACK,
         ]:
-            return MtgjsonSealedProductSubtype.DRAFT
+            return MtgjsonSealedProductSubtype.DEFAULT
         return MtgjsonSealedProductSubtype.UNKNOWN
 
     def generate_mtgjson_sealed_product_objects(

--- a/mtgjson5/resources/booster_box_size_overrides.json
+++ b/mtgjson5/resources/booster_box_size_overrides.json
@@ -1,5 +1,5 @@
 {
-    "draft": {
+    "default": {
         "ALL": 45,
         "CHR": 45,
         "ARN": 60,

--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -859,7 +859,7 @@ def build_mtgjson_card(
     # Future expansion to support set and collector booster types
     mtgjson_card.booster_types = []
     if scryfall_object.get("booster", False):
-        mtgjson_card.booster_types.append("draft")
+        mtgjson_card.booster_types.append("default")
     if any(
         deck_type in scryfall_object.get("promo_types", [])
         for deck_type in ("starterdeck", "planeswalkerdeck")


### PR DESCRIPTION
this will allow to use booster names directly with the map defined in Booster