### PR TITLE
Prevent aliasing sealed subtype with Core Set editions

### DIFF
--- a/mtgjson5/providers/tcgplayer.py
+++ b/mtgjson5/providers/tcgplayer.py
@@ -447,6 +447,10 @@ class TCGPlayerProvider(AbstractProvider):
             ):
                 continue
 
+            # Prevent assigning 'set' or 'draft_set' to Core Set editions
+            if "core set" in product_name and "set" in subtype.value:
+                continue
+
             # Prevent assigning 'set' (for set boosters) to unrelated categories
             if subtype is MtgjsonSealedProductSubtype.SET and (
                 category is not MtgjsonSealedProductCategory.BOOSTER_PACK


### PR DESCRIPTION
otherwise all M21/M20 etc products get the 'set' subtype