### PR TITLE
ADD MCM Identifiers for Tokens

### DIFF
--- a/mtgjson5/providers/cardmarket/monolith.py
+++ b/mtgjson5/providers/cardmarket/monolith.py
@@ -274,6 +274,8 @@ class CardMarketProvider(AbstractProvider):
             # Split cards get two entries
             for name in set_content["enName"].split("//"):
                 name_no_special_chars = name.strip().lower()
+                if "token" in name_no_special_chars:
+                    name_no_special_chars = name_no_special_chars.split(" (", 1)
                 set_in_progress[name_no_special_chars] = set_content
 
         return set_in_progress


### PR DESCRIPTION
- Fix #1081
- token.identifiers.mcmId - token.identifiers.mcmMetaId
- Also adds prelim support for CK IDs when available

<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
