### PR TITLE
Enable dependabot tracking and automated updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Configuration options: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Directory must be set to "/" to check for workflow files in .github/workflows
+    directory: "/"
+    # Check for updates to GitHub Actions once a week
+    schedule:
+      interval: "weekly"
+    # Limit the amout of open PR's (default = 5, disabled = 0, security updates are not impacted)
+    open-pull-requests-limit: 2


### PR DESCRIPTION
Enable tracking and updating of used action versions.
Takes care of and automates e.g. #1163

This is a basic configuration which checks weekly and maintains PR's for two outdated actions at a time.