### PR TITLE
Add FWB as an empty set to capture sealed product

### DIFF
--- a/mtgjson5/resources/additional_sets.json
+++ b/mtgjson5/resources/additional_sets.json
@@ -88,5 +88,18 @@
         "nonfoil_only": true,
         "foil_only": false,
         "search_uri": "https://api.scryfall.com/cards/search?include_extras=true&include_variations=true&order=set&q=e%3Amb1&unique=prints"
+    },
+    "FWB": {
+        "name": "Foreign White Border",
+        "code": "FWB",
+        "released_at": "1994-04-11",
+        "set_type": "core",
+        "parent_set_code": "3ed",
+        "digital": false,
+        "nonfoil_only": true,
+        "foil_only": false,
+        "block_code": "lea",
+        "block": "Core Set",
+        "icon_svg_uri": "https://svgs.scryfall.io/sets/3ed.svg?1731301200"
     }
 }


### PR DESCRIPTION
Foreign White Border products are typically tracked separately from the Foreign Black Border products and should have their own page.

https://www.cardmarket.com/en/Magic/Expansions/Foreign-White-Bordered