### PR TITLE
Manual Support of Meld Cards

### DIFF
--- a/mtgjson5/providers/mtgwiki/secret_lair.py
+++ b/mtgjson5/providers/mtgwiki/secret_lair.py
@@ -72,7 +72,15 @@ class MtgWikiProviderSecretLair(AbstractProvider):
         return sum(
             (
                 (
-                    list(range(*[int(j) + k for k, j in enumerate(i.split("-")) if len(j) > 0]))
+                    list(
+                        range(
+                            *[
+                                int(j) + k
+                                for k, j in enumerate(i.split("-"))
+                                if len(j) > 0
+                            ]
+                        )
+                    )
                     if "-" in i
                     else [int(i)]
                 )

--- a/mtgjson5/resources/manual_overrides.json
+++ b/mtgjson5/resources/manual_overrides.json
@@ -1,0 +1,158 @@
+{
+    "2a5b16d1-88c5-59d5-b1fb-f077ba0d1e60": {
+        "__metadata": {
+            "name": "Vanille, Cheerful l'Cie",
+            "setCode": "FIN",
+            "number": "211",
+            "comments": "Regular"
+        },
+        "other_face_ids": [
+            "2a5b16d1-88c5-59d5-b1fb-f077ba0d1e60",
+            "37352d29-3bab-5fef-8b0d-8cc80e5d3b2e",
+            "e831d957-15cf-5d61-bcd7-87d9c5c77429"
+        ]
+    },
+    "37352d29-3bab-5fef-8b0d-8cc80e5d3b2e": {
+        "__metadata": {
+            "name": "Fang, Fearless l'Cie",
+            "setCode": "FIN",
+            "number": "99",
+            "comments": "Regular"
+        },
+        "other_face_ids": [
+            "2a5b16d1-88c5-59d5-b1fb-f077ba0d1e60",
+            "37352d29-3bab-5fef-8b0d-8cc80e5d3b2e",
+            "e831d957-15cf-5d61-bcd7-87d9c5c77429"
+        ]
+    },
+    "e831d957-15cf-5d61-bcd7-87d9c5c77429": {
+        "__metadata": {
+            "name": "Ragnarok, Divine Deliverance",
+            "setCode": "FIN",
+            "number": "99b",
+            "comments": "Regular"
+        },
+        "other_face_ids": [
+            "2a5b16d1-88c5-59d5-b1fb-f077ba0d1e60",
+            "37352d29-3bab-5fef-8b0d-8cc80e5d3b2e",
+            "e831d957-15cf-5d61-bcd7-87d9c5c77429"
+        ]
+    },
+    "523b97de-7744-5ca1-adef-818ff02528d1": {
+        "__metadata": {
+            "name": "Vanille, Cheerful l'Cie",
+            "setCode": "FIN",
+            "number": "392",
+            "comments": "Full Art"
+        },
+        "other_face_ids": [
+            "523b97de-7744-5ca1-adef-818ff02528d1",
+            "14d87a06-22b6-575d-8963-9d9868ba3521",
+            "3b656422-c867-58ea-8c4d-960317d5712f"
+        ]
+    },
+    "14d87a06-22b6-575d-8963-9d9868ba3521": {
+        "__metadata": {
+            "name": "Fang, Fearless l'Cie",
+            "setCode": "FIN",
+            "number": "381",
+            "comments": "Full Art"
+        },
+        "other_face_ids": [
+            "523b97de-7744-5ca1-adef-818ff02528d1",
+            "14d87a06-22b6-575d-8963-9d9868ba3521",
+            "3b656422-c867-58ea-8c4d-960317d5712f"
+        ]
+    },
+    "3b656422-c867-58ea-8c4d-960317d5712f": {
+        "__metadata": {
+            "name": "Ragnarok, Divine Deliverance",
+            "setCode": "FIN",
+            "number": "381b",
+            "comments": "Full Art"
+        },
+        "other_face_ids": [
+            "523b97de-7744-5ca1-adef-818ff02528d1",
+            "14d87a06-22b6-575d-8963-9d9868ba3521",
+            "3b656422-c867-58ea-8c4d-960317d5712f"
+        ]
+    },
+    "10e5f45a-743f-514b-9846-297fb997f534": {
+        "__metadata": {
+            "name": "Vanille, Cheerful l'Cie",
+            "setCode": "FIN",
+            "number": "475",
+            "comments": "Borderless"
+        },
+        "other_face_ids": [
+            "10e5f45a-743f-514b-9846-297fb997f534",
+            "5af57b16-2554-552f-98f5-ad8ed0a51beb",
+            "d870de05-4e42-532a-95d9-4e9d5980dfc2"
+        ]
+    },
+    "5af57b16-2554-552f-98f5-ad8ed0a51beb": {
+        "__metadata": {
+            "name": "Fang, Fearless l'Cie",
+            "setCode": "FIN",
+            "number": "446",
+            "comments": "Borderless"
+        },
+        "other_face_ids": [
+            "10e5f45a-743f-514b-9846-297fb997f534",
+            "5af57b16-2554-552f-98f5-ad8ed0a51beb",
+            "d870de05-4e42-532a-95d9-4e9d5980dfc2"
+        ]
+    },
+    "d870de05-4e42-532a-95d9-4e9d5980dfc2": {
+        "__metadata": {
+            "name": "Ragnarok, Divine Deliverance",
+            "setCode": "FIN",
+            "number": "446b",
+            "comments": "Borderless"
+        },
+        "other_face_ids": [
+            "10e5f45a-743f-514b-9846-297fb997f534",
+            "5af57b16-2554-552f-98f5-ad8ed0a51beb",
+            "d870de05-4e42-532a-95d9-4e9d5980dfc2"
+        ]
+    },
+    "aed50dfb-16cd-54d4-9b02-3daeab2e606a": {
+        "__metadata": {
+            "name": "Vanille, Cheerful l'Cie",
+            "setCode": "FIN",
+            "number": "537",
+            "comments": "Surge Foil"
+        },
+        "other_face_ids": [
+            "aed50dfb-16cd-54d4-9b02-3daeab2e606a",
+            "f73959fe-4ed2-5a27-b218-d0979d6b1b75",
+            "bd42102d-9ec8-5ddc-81cd-f2ee99c9d5e8"
+        ]
+    },
+    "f73959fe-4ed2-5a27-b218-d0979d6b1b75": {
+        "__metadata": {
+            "name": "Fang, Fearless l'Cie",
+            "setCode": "FIN",
+            "number": "526",
+            "comments": "Surge Foil"
+        },
+        "other_face_ids": [
+            "aed50dfb-16cd-54d4-9b02-3daeab2e606a",
+            "f73959fe-4ed2-5a27-b218-d0979d6b1b75",
+            "bd42102d-9ec8-5ddc-81cd-f2ee99c9d5e8"
+        ]
+    },
+    "bd42102d-9ec8-5ddc-81cd-f2ee99c9d5e8": {
+        "__metadata": {
+            "name": "Ragnarok, Divine Deliverance",
+            "setCode": "FIN",
+            "number": "526b",
+            "comments": "Surge Foil"
+        },
+        "other_face_ids": [
+            "aed50dfb-16cd-54d4-9b02-3daeab2e606a",
+            "f73959fe-4ed2-5a27-b218-d0979d6b1b75",
+            "bd42102d-9ec8-5ddc-81cd-f2ee99c9d5e8"
+        ]
+    }
+}

--- a/mtgjson5/resources/meld_triplets.json
+++ b/mtgjson5/resources/meld_triplets.json
@@ -1,0 +1,9 @@
+[
+  ["Titania, Voice of Gaea", "Argoth, Sanctum of Nature", "Titania, Gaea Incarnate"],
+  ["Gisela, the Broken Blade", "Bruna, the Fading Light", "Brisela, Voice of Nightmares"],
+  ["Graf Rats", "Midnight Scavengers", "Chittering Host"],
+  ["Vanille, Cheerful l'Cie", "Fang, Fearless l'Cie", "Ragnarok, Divine Deliverance"],
+  ["Hanweir Battlements", "Hanweir Garrison", "Hanweir, the Writhing Township"],
+  ["Mishra, Claimed by Gix", "Phyrexian Dragon Engine", "Mishra, Lost to Phyrexia"],
+  ["Urza, Lord Protector", "The Mightstone and Weakstone", "Urza, Planeswalker"]
+]

--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -1099,7 +1099,6 @@ def build_mtgjson_card(
 
     # Handle Meld components, as well as tokens
     if "all_parts" in scryfall_object.keys():
-        # meld_object = []
         mtgjson_card.set_names(None)
         for a_part in sorted(
             scryfall_object["all_parts"], key=lambda part: part["component"]
@@ -1109,7 +1108,6 @@ def build_mtgjson_card(
 
             # This is a meld only-fix, so we ignore tokens/combo pieces
             if a_part["component"].startswith("meld"):
-                # meld_object.append(a_part["component"])
                 mtgjson_card.append_names(a_part.get("name"))
                 continue
 


### PR DESCRIPTION
Fix #1266 

---

Meld cards have always been a pain for MTGJSON. This change will now rely on manual mode for these pairs to support the proper pairings of CardA (Top), CardB (Bottom) MeldC (Backend).

There will be some slight renaming for any pairs that were incorrectly associated as CardA//CardB or CardB//CardA. They are all now correct as CardA//MeldC, CardB//MeldC, MeldC.