### PR TITLE
Support vehicles and spacecraft as commander

### DIFF
--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -663,7 +663,17 @@ def add_leadership_skills(mtgjson_card: MtgjsonCardObject) -> None:
         mtgjson_card.name in override_cards
         or (
             "Legendary" in mtgjson_card.type
-            and "Creature" in mtgjson_card.type
+            and (
+                "Creature" in mtgjson_card.type
+                or (
+                    (
+                        "Vehicle" in mtgjson_card.type
+                        or "Spacecraft" in mtgjson_card.type
+                    )
+                    and mtgjson_card.toughness
+                    and mtgjson_card.power
+                )
+            )
             # Exclude Flip cards
             and mtgjson_card.type not in {"flip"}
             # Exclude Melded cards and backside of Transform cards


### PR DESCRIPTION
<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
As of Edge of Eternities, legendary vehicles and spacecraft with a power/toughness box can now be a commander. This change updates the commander leadership skill as such.