### PR TITLE
Tcg 79 enhance tcgplayer pricing field

### DIFF
--- a/mtgjson5/classes/mtgjson_prices.py
+++ b/mtgjson5/classes/mtgjson_prices.py
@@ -23,6 +23,20 @@ class MtgjsonPricesObject(JsonObject):
     sell_normal: Optional[float]
     sell_foil: Optional[float]
     sell_etched: Optional[float]
+    
+    # Enhanced TCGPlayer pricing fields
+    sell_normal_low: Optional[float]
+    sell_normal_mid: Optional[float]
+    sell_normal_high: Optional[float]
+    sell_normal_direct_low: Optional[float]
+    sell_foil_low: Optional[float]
+    sell_foil_mid: Optional[float]
+    sell_foil_high: Optional[float]
+    sell_foil_direct_low: Optional[float]
+    sell_etched_low: Optional[float]
+    sell_etched_mid: Optional[float]
+    sell_etched_high: Optional[float]
+    sell_etched_direct_low: Optional[float]
 
     def __init__(
         self,
@@ -36,6 +50,19 @@ class MtgjsonPricesObject(JsonObject):
         sell_normal: Optional[float] = None,
         sell_foil: Optional[float] = None,
         sell_etched: Optional[float] = None,
+        # Enhanced TCGPlayer pricing fields
+        sell_normal_low: Optional[float] = None,
+        sell_normal_mid: Optional[float] = None,
+        sell_normal_high: Optional[float] = None,
+        sell_normal_direct_low: Optional[float] = None,
+        sell_foil_low: Optional[float] = None,
+        sell_foil_mid: Optional[float] = None,
+        sell_foil_high: Optional[float] = None,
+        sell_foil_direct_low: Optional[float] = None,
+        sell_etched_low: Optional[float] = None,
+        sell_etched_mid: Optional[float] = None,
+        sell_etched_high: Optional[float] = None,
+        sell_etched_direct_low: Optional[float] = None,
     ) -> None:
         """
         Initializer for Pricing Container
@@ -50,6 +77,20 @@ class MtgjsonPricesObject(JsonObject):
         self.sell_normal = sell_normal
         self.sell_foil = sell_foil
         self.sell_etched = sell_etched
+        
+        # Enhanced TCGPlayer pricing fields
+        self.sell_normal_low = sell_normal_low
+        self.sell_normal_mid = sell_normal_mid
+        self.sell_normal_high = sell_normal_high
+        self.sell_normal_direct_low = sell_normal_direct_low
+        self.sell_foil_low = sell_foil_low
+        self.sell_foil_mid = sell_foil_mid
+        self.sell_foil_high = sell_foil_high
+        self.sell_foil_direct_low = sell_foil_direct_low
+        self.sell_etched_low = sell_etched_low
+        self.sell_etched_mid = sell_etched_mid
+        self.sell_etched_high = sell_etched_high
+        self.sell_etched_direct_low = sell_etched_direct_low
 
     def items(self) -> List[Tuple[str, Optional[float]]]:
         """
@@ -85,5 +126,45 @@ class MtgjsonPricesObject(JsonObject):
             buy_sell_option["retail"]["foil"][self.date] = self.sell_foil
         if self.sell_etched is not None:
             buy_sell_option["retail"]["etched"][self.date] = self.sell_etched
+        
+        # Add enhanced pricing fields if any are present
+        has_enhanced_pricing = any([
+            self.sell_normal_low, self.sell_normal_mid, self.sell_normal_high, self.sell_normal_direct_low,
+            self.sell_foil_low, self.sell_foil_mid, self.sell_foil_high, self.sell_foil_direct_low,
+            self.sell_etched_low, self.sell_etched_mid, self.sell_etched_high, self.sell_etched_direct_low
+        ])
+        
+        if has_enhanced_pricing:
+            buy_sell_option["retail_enhanced"] = defaultdict(lambda: defaultdict(dict))
+            
+            # Normal enhanced pricing
+            if self.sell_normal_low is not None:
+                buy_sell_option["retail_enhanced"]["normal"]["low"][self.date] = self.sell_normal_low
+            if self.sell_normal_mid is not None:
+                buy_sell_option["retail_enhanced"]["normal"]["mid"][self.date] = self.sell_normal_mid
+            if self.sell_normal_high is not None:
+                buy_sell_option["retail_enhanced"]["normal"]["high"][self.date] = self.sell_normal_high
+            if self.sell_normal_direct_low is not None:
+                buy_sell_option["retail_enhanced"]["normal"]["direct_low"][self.date] = self.sell_normal_direct_low
+            
+            # Foil enhanced pricing
+            if self.sell_foil_low is not None:
+                buy_sell_option["retail_enhanced"]["foil"]["low"][self.date] = self.sell_foil_low
+            if self.sell_foil_mid is not None:
+                buy_sell_option["retail_enhanced"]["foil"]["mid"][self.date] = self.sell_foil_mid
+            if self.sell_foil_high is not None:
+                buy_sell_option["retail_enhanced"]["foil"]["high"][self.date] = self.sell_foil_high
+            if self.sell_foil_direct_low is not None:
+                buy_sell_option["retail_enhanced"]["foil"]["direct_low"][self.date] = self.sell_foil_direct_low
+            
+            # Etched enhanced pricing
+            if self.sell_etched_low is not None:
+                buy_sell_option["retail_enhanced"]["etched"]["low"][self.date] = self.sell_etched_low
+            if self.sell_etched_mid is not None:
+                buy_sell_option["retail_enhanced"]["etched"]["mid"][self.date] = self.sell_etched_mid
+            if self.sell_etched_high is not None:
+                buy_sell_option["retail_enhanced"]["etched"]["high"][self.date] = self.sell_etched_high
+            if self.sell_etched_direct_low is not None:
+                buy_sell_option["retail_enhanced"]["etched"]["direct_low"][self.date] = self.sell_etched_direct_low
 
         return {self.source: {self.provider: buy_sell_option}}

--- a/mtgjson5/providers/tcgplayer.py
+++ b/mtgjson5/providers/tcgplayer.py
@@ -549,7 +549,13 @@ def get_tcgplayer_prices_map(
             continue
 
         is_non_foil = tcgplayer_object["subTypeName"] == "Normal"
-        card_price = tcgplayer_object["marketPrice"]
+        
+        # Extract all available pricing data points
+        market_price = tcgplayer_object["marketPrice"]
+        low_price = tcgplayer_object.get("lowPrice")
+        mid_price = tcgplayer_object.get("midPrice")
+        high_price = tcgplayer_object.get("highPrice")
+        direct_low_price = tcgplayer_object.get("directLowPrice")
 
         for key in keys:
             if key not in prices_map:
@@ -558,10 +564,40 @@ def get_tcgplayer_prices_map(
                 )
 
             if is_non_foil:
-                prices_map[key].sell_normal = card_price
+                # Market price (existing behavior)
+                prices_map[key].sell_normal = market_price
+                # Enhanced pricing fields
+                if low_price is not None:
+                    prices_map[key].sell_normal_low = low_price
+                if mid_price is not None:
+                    prices_map[key].sell_normal_mid = mid_price
+                if high_price is not None:
+                    prices_map[key].sell_normal_high = high_price
+                if direct_low_price is not None:
+                    prices_map[key].sell_normal_direct_low = direct_low_price
             elif keys_are_etched:
-                prices_map[key].sell_etched = card_price
+                # Market price (existing behavior)
+                prices_map[key].sell_etched = market_price
+                # Enhanced pricing fields
+                if low_price is not None:
+                    prices_map[key].sell_etched_low = low_price
+                if mid_price is not None:
+                    prices_map[key].sell_etched_mid = mid_price
+                if high_price is not None:
+                    prices_map[key].sell_etched_high = high_price
+                if direct_low_price is not None:
+                    prices_map[key].sell_etched_direct_low = direct_low_price
             else:
-                prices_map[key].sell_foil = card_price
+                # Market price (existing behavior)
+                prices_map[key].sell_foil = market_price
+                # Enhanced pricing fields
+                if low_price is not None:
+                    prices_map[key].sell_foil_low = low_price
+                if mid_price is not None:
+                    prices_map[key].sell_foil_mid = mid_price
+                if high_price is not None:
+                    prices_map[key].sell_foil_high = high_price
+                if direct_low_price is not None:
+                    prices_map[key].sell_foil_direct_low = direct_low_price
 
     return prices_map

--- a/tests/mtgjson5/test_today_price_builder.py
+++ b/tests/mtgjson5/test_today_price_builder.py
@@ -198,6 +198,15 @@ def test_tcgplayer_build_today_prices():
             111.01,
             222.01,
             None,
+            # Enhanced pricing fields from test data
+            sell_normal_low=0.01,
+            sell_normal_mid=0.02,
+            sell_normal_high=0.03,
+            sell_normal_direct_low=0.04,
+            sell_foil_low=0.01,
+            sell_foil_mid=0.02,
+            sell_foil_high=0.03,
+            sell_foil_direct_low=0.04,
         ),
         MtgjsonPricesObject(
             "paper",
@@ -210,6 +219,11 @@ def test_tcgplayer_build_today_prices():
             None,
             None,
             333.01,
+            # Enhanced pricing fields for etched
+            sell_etched_low=0.01,
+            sell_etched_mid=0.02,
+            sell_etched_high=0.03,
+            sell_etched_direct_low=0.04,
         ),
     ]
 


### PR DESCRIPTION
1. Complete pricing data capture from TCGPlayer API
2. Closes pricing gaps without relying on tcgcsv (as mentioned in Linear ticket)
3. Parity with enhanced pricing model similar to TCGCSV integration
4. No breaking changes for existing MTGJSON consumers
5. Production ready - just needs TCGPlayer API credentials to activate