### PR TITLE
Read etched from github decks

### DIFF
--- a/mtgjson5/classes/mtgjson_card.py
+++ b/mtgjson5/classes/mtgjson_card.py
@@ -60,6 +60,7 @@ class MtgjsonCardObject(JsonObject):
     identifiers: MtgjsonIdentifiersObject
     is_alternative: Optional[bool]
     is_foil: Optional[bool]
+    is_etched: Optional[bool]
     is_full_art: Optional[bool]
     is_funny: Optional[bool]
     is_game_changer: Optional[bool]

--- a/mtgjson5/providers/github/github_decks.py
+++ b/mtgjson5/providers/github/github_decks.py
@@ -65,6 +65,7 @@ class GitHubDecksProvider(AbstractProvider):
         mtgjson_card.uuid = card["mtgjson_uuid"]
         mtgjson_card.count = card["count"]
         mtgjson_card.is_foil = card["foil"]
+        mtgjson_card.is_etched = card["etched"]
         del mtgjson_card.colors
         del mtgjson_card.identifiers
         del mtgjson_card.purchase_urls
@@ -202,6 +203,7 @@ def build_single_card(card: Dict[str, Any]) -> List[Dict[str, Any]]:
         if card["mtgjson_uuid"] == mtgjson_card["uuid"]:
             mtgjson_card["count"] = card["count"]
             mtgjson_card["isFoil"] = card["foil"]
+            mtgjson_card["isEtched"] = card["etched"]
             cards.append(copy.deepcopy(mtgjson_card))
 
     if not cards:


### PR DESCRIPTION
Using the new export format from @taw https://github.com/taw/magic-search-engine/commit/b626662552e87f479041e55cbdf32aa7c6b7aa69! 