### PR TITLE
Scryfall rate limit is 10 req/s

### DIFF
--- a/mtgjson5/providers/scryfall/monolith.py
+++ b/mtgjson5/providers/scryfall/monolith.py
@@ -97,7 +97,7 @@ class ScryfallProvider(AbstractProvider):
         return all_cards
 
     @ratelimit.sleep_and_retry
-    @ratelimit.limits(calls=15, period=1)
+    @ratelimit.limits(calls=10, period=1)
     def download(
         self,
         url: str,


### PR DESCRIPTION
See https://scryfall.com/docs/api#rate-limits-and-good-citizenship

Fixes #1330

<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
