### PR TITLE
Adds flake8 import style plugin for MTGJSON

### DIFF
--- a/flake8-style/pyproject.toml
+++ b/flake8-style/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "flake8-mtgjson-style"
+version = "1.0.0"
+description = "Flake8 import style plugin for MTGJSON"
+requires-python = ">=3.9"
+
+[project.entry-points."flake8.extension"]
+IMP = "style_plugin:ImportStyleChecker"
+
+[tool.setuptools]
+py-modules = ["style_plugin"]

--- a/flake8-style/style_plugin.py
+++ b/flake8-style/style_plugin.py
@@ -1,0 +1,83 @@
+"""Style plugin for Flake8 to enforce import styles within MTGJSON project.
+# Disallows:
+# from mkmsdk.api_map import _API_MAP   # BAD
+# from uuid import UUID                 # BAD
+# 
+# allows:
+# import requests.exceptions            # OK
+# import urllib.parse                   # OK
+# 
+# from typing import Any                # OK (whitelisted)
+# from .foo import bar                  # OK (relative)
+"""
+import ast
+from typing import Iterator, Tuple, Type
+
+# Modules allowed to use "from ... import ..."
+ALLOWED_FROM_IMPORTS = {
+    # Special
+    "__future__",
+    
+    # Self
+    "mtgjson5",
+    
+    # typing
+    "typing",
+    "typing_extensions",
+    
+    # pydantic
+    "pydantic",
+    
+    # Decorators/singletons
+    "singleton_decorator",
+    
+    # Standard library commonly imported this way
+    "abc",
+    "collections",
+    "concurrent",
+    "contextlib",
+    "dataclasses",
+    "datetime",
+    "enum",
+    "functools",
+    "itertools",
+    "pathlib",
+    "re",
+    "os",
+    "sys",
+}
+
+
+class ImportStyleChecker:
+    """
+    Flake8 plugin to enforce import style rules:
+    - IMP001: Ban 'from x import y' unless whitelisted.
+    """
+
+    name = "import-style"
+    version = "1.0.0"
+
+    def __init__(self, tree: ast.AST) -> None:
+        self.tree = tree
+
+    def run(self) -> Iterator[Tuple[int, int, str, Type]]:
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.ImportFrom):
+                # Relative imports are allowed
+                if node.level > 0:
+                    continue
+                
+                module = node.module or ""
+                module_root = module.split(".")[0]
+                
+                # Allow whitelisted modules
+                if module_root in ALLOWED_FROM_IMPORTS:
+                    continue
+
+                names = ", ".join(a.name for a in node.names)
+                yield (
+                    node.lineno,
+                    node.col_offset,
+                    f"IMP001: Instead of 'from {module} import {names}', we prefer you use 'import {module}'",
+                    type(self),
+                )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[tool.black]
+line-length = 88
+target-version = ["py39",
+"py310",
+"py311",
+"py312",
+"py313"]
+
+[tool.isort]
+profile = "black"
+
+
+# 501 - line too long
+# E402 - module level import not at top of file
+# W503 - line break before binary operator
+# W293 - blank line contains whitespace
+# E302 - expected 2 blank lines, found N
+# W291 - trailing whitespace
+[tool.flake8]
+extend-ignore = [
+    "E501",
+    "E402",
+    "W503",
+    "W293",
+    "E302",
+    "W291"
+]
+# F401 in __init__.py - imported but unused
+per-file-ignores = ["__init__.py:F401"]

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist = isort-inplace, black-inplace, mypy, lint, unit
 [testenv]
 setenv = PYTHONPATH = {toxinidir}
 deps = 
-	-r {toxinidir}/requirements.txt
-	-r {toxinidir}/requirements_test.txt
+    -r {toxinidir}/requirements.txt
+    -r {toxinidir}/requirements_test.txt
 
 [testenv:isort-inplace]
 description = Sort imports
@@ -30,6 +30,14 @@ commands = mypy {posargs:mtgjson5/}
 [testenv:lint]
 description = Run linting tools
 commands = pylint mtgjson5/ --rcfile=.pylintrc
+
+[testenv:flake8]
+description = Run flake8 style checks
+deps =
+    flake8
+    flake8-pyproject
+    {toxinidir}/flake8-style
+commands = flake8 mtgjson5/
 
 [testenv:unit]
 description = Run unit tests with coverage and mypy type checking


### PR DESCRIPTION
Introduces a custom flake8 plugin to enforce consistent import
style patterns across the codebase, allowing only whitelisted modules for 'from ... import ...' statements.
Updates configuration files to integrate plugin with existing linting workflow for improved code quality and cause honestly, i'm never gonna remember
