### PR TITLE
Adds Scryfall bulk data support via Polars SQL

### DIFF
--- a/mtgjson5/models/schema/scryfall.py
+++ b/mtgjson5/models/schema/scryfall.py
@@ -1,0 +1,921 @@
+from enum import Enum
+from datetime import date
+from decimal import Decimal
+from typing import Literal, Optional
+from pydantic import BaseModel, Field, HttpUrl
+from uuid import UUID
+
+
+class Color(str, Enum):
+    """Magic color symbols."""
+    WHITE = "W"
+    BLUE = "U"
+    BLACK = "B"
+    RED = "R"
+    GREEN = "G"
+
+
+class Rarity(str, Enum):
+    """Card rarity levels."""
+    COMMON = "common"
+    UNCOMMON = "uncommon"
+    RARE = "rare"
+    MYTHIC = "mythic"
+    SPECIAL = "special"
+    BONUS = "bonus"
+
+
+class BorderColor(str, Enum):
+    """Physical card border colors."""
+    BLACK = "black"
+    WHITE = "white"
+    BORDERLESS = "borderless"
+    SILVER = "silver"
+    GOLD = "gold"
+
+
+class Layout(str, Enum):
+    """Card layout types determining face structure and rendering."""
+    NORMAL = "normal"
+    SPLIT = "split"
+    FLIP = "flip"
+    TRANSFORM = "transform"
+    MODAL_DFC = "modal_dfc"
+    MELD = "meld"
+    LEVELER = "leveler"
+    CLASS = "class"
+    CASE = "case"
+    SAGA = "saga"
+    ADVENTURE = "adventure"
+    MUTATE = "mutate"
+    PROTOTYPE = "prototype"
+    BATTLE = "battle"
+    PLANAR = "planar"
+    SCHEME = "scheme"
+    VANGUARD = "vanguard"
+    TOKEN = "token"
+    DOUBLE_FACED_TOKEN = "double_faced_token"
+    EMBLEM = "emblem"
+    AUGMENT = "augment"
+    HOST = "host"
+    ART_SERIES = "art_series"
+    REVERSIBLE_CARD = "reversible_card"
+
+
+class Frame(str, Enum):
+    """Card frame versions by year of introduction."""
+    FRAME_1993 = "1993"
+    FRAME_1997 = "1997"
+    FRAME_2003 = "2003"
+    FRAME_2015 = "2015"
+    FUTURE = "future"
+
+
+class SecurityStamp(str, Enum):
+    """Holographic security stamp shapes."""
+    OVAL = "oval"
+    TRIANGLE = "triangle"
+    ACORN = "acorn"
+    CIRCLE = "circle"
+    ARENA = "arena"
+    HEART = "heart"
+
+
+class ImageStatus(str, Enum):
+    """Scryfall image availability status."""
+    MISSING = "missing"
+    PLACEHOLDER = "placeholder"
+    LOWRES = "lowres"
+    HIGHRES_SCAN = "highres_scan"
+
+
+class Legality(str, Enum):
+    """Format legality status values."""
+    LEGAL = "legal"
+    NOT_LEGAL = "not_legal"
+    RESTRICTED = "restricted"
+    BANNED = "banned"
+
+
+class Finish(str, Enum):
+    """Physical card finish types."""
+    FOIL = "foil"
+    NONFOIL = "nonfoil"
+    ETCHED = "etched"
+
+
+class Game(str, Enum):
+    """Game platforms where a card exists."""
+    PAPER = "paper"
+    ARENA = "arena"
+    MTGO = "mtgo"
+
+
+class Component(str, Enum):
+    """Role a related card plays in a relationship."""
+    TOKEN = "token"
+    MELD_PART = "meld_part"
+    MELD_RESULT = "meld_result"
+    COMBO_PIECE = "combo_piece"
+
+
+class ImageUris(BaseModel):
+    """Available imagery for a card."""
+    
+    small: Optional[HttpUrl] = Field(
+        default=None,
+        description="A small full card image (146×204 pixels).",
+    )
+    normal: Optional[HttpUrl] = Field(
+        default=None,
+        description="A medium-sized full card image (488×680 pixels).",
+    )
+    large: Optional[HttpUrl] = Field(
+        default=None,
+        description="A large full card image (672×936 pixels).",
+    )
+    png: Optional[HttpUrl] = Field(
+        default=None,
+        description="A transparent PNG of the card (745×1040 pixels).",
+    )
+    art_crop: Optional[HttpUrl] = Field(
+        default=None,
+        description="A crop of the card art (variable dimensions).",
+    )
+    border_crop: Optional[HttpUrl] = Field(
+        default=None,
+        description="A crop of the card including border (480×680 pixels).",
+    )
+
+
+class Prices(BaseModel):
+    """Daily price information for a card."""
+    
+    usd: Optional[str] = Field(
+        default=None,
+        description="The price in US dollars.",
+    )
+    usd_foil: Optional[str] = Field(
+        default=None,
+        description="The foil price in US dollars.",
+    )
+    usd_etched: Optional[str] = Field(
+        default=None,
+        description="The etched foil price in US dollars.",
+    )
+    eur: Optional[str] = Field(
+        default=None,
+        description="The price in Euros.",
+    )
+    eur_foil: Optional[str] = Field(
+        default=None,
+        description="The foil price in Euros.",
+    )
+    eur_etched: Optional[str] = Field(
+        default=None,
+        description="The etched foil price in Euros.",
+    )
+    tix: Optional[str] = Field(
+        default=None,
+        description="The price in MTGO event tickets.",
+    )
+
+
+class Legalities(BaseModel):
+    """Legality of a card across play formats."""
+    
+    standard: Legality = Field(
+        description="Legality in Standard format.",
+    )
+    future: Legality = Field(
+        description="Legality in Future Standard format.",
+    )
+    historic: Legality = Field(
+        description="Legality in Historic format (Arena).",
+    )
+    timeless: Legality = Field(
+        description="Legality in Timeless format (Arena).",
+    )
+    gladiator: Legality = Field(
+        description="Legality in Gladiator format.",
+    )
+    pioneer: Legality = Field(
+        description="Legality in Pioneer format.",
+    )
+    explorer: Legality = Field(
+        description="Legality in Explorer format (Arena).",
+    )
+    modern: Legality = Field(
+        description="Legality in Modern format.",
+    )
+    legacy: Legality = Field(
+        description="Legality in Legacy format.",
+    )
+    pauper: Legality = Field(
+        description="Legality in Pauper format.",
+    )
+    vintage: Legality = Field(
+        description="Legality in Vintage format.",
+    )
+    penny: Legality = Field(
+        description="Legality in Penny Dreadful format.",
+    )
+    commander: Legality = Field(
+        description="Legality in Commander format.",
+    )
+    oathbreaker: Legality = Field(
+        description="Legality in Oathbreaker format.",
+    )
+    standardbrawl: Legality = Field(
+        description="Legality in Standard Brawl format.",
+    )
+    brawl: Legality = Field(
+        description="Legality in Brawl format.",
+    )
+    alchemy: Legality = Field(
+        description="Legality in Alchemy format (Arena).",
+    )
+    paupercommander: Legality = Field(
+        description="Legality in Pauper Commander format.",
+    )
+    duel: Legality = Field(
+        description="Legality in Duel Commander format.",
+    )
+    oldschool: Legality = Field(
+        description="Legality in Old School 93/94 format.",
+    )
+    premodern: Legality = Field(
+        description="Legality in Premodern format.",
+    )
+    predh: Legality = Field(
+        description="Legality in Pre-EDH format (Commander with pre-2012 rules).",
+    )
+
+
+class PurchaseUris(BaseModel):
+    """URIs to a card's listing on major marketplaces."""
+    
+    tcgplayer: Optional[HttpUrl] = Field(
+        default=None,
+        description="A link to purchase this card on TCGplayer.",
+    )
+    cardmarket: Optional[HttpUrl] = Field(
+        default=None,
+        description="A link to purchase this card on Cardmarket.",
+    )
+    cardhoarder: Optional[HttpUrl] = Field(
+        default=None,
+        description="A link to purchase this card on Cardhoarder.",
+    )
+
+
+class RelatedUris(BaseModel):
+    """URIs to a card's listing on other Magic resources."""
+    
+    gatherer: Optional[HttpUrl] = Field(
+        default=None,
+        description="A link to this card on Gatherer.",
+    )
+    tcgplayer_infinite_articles: Optional[HttpUrl] = Field(
+        default=None,
+        description="A link to TCGplayer Infinite articles about this card.",
+    )
+    tcgplayer_infinite_decks: Optional[HttpUrl] = Field(
+        default=None,
+        description="A link to TCGplayer Infinite decks featuring this card.",
+    )
+    edhrec: Optional[HttpUrl] = Field(
+        default=None,
+        description="A link to this card on EDHREC.",
+    )
+
+
+class Preview(BaseModel):
+    """Preview information for a newly spoiled card."""
+    
+    source: Optional[str] = Field(
+        default=None,
+        description="The name of the source that previewed this card.",
+    )
+    source_uri: Optional[HttpUrl] = Field(
+        default=None,
+        description="A link to the preview for this card.",
+    )
+    previewed_at: Optional[date] = Field(
+        default=None,
+        description="The date this card was previewed.",
+    )
+
+
+class CardFace(BaseModel):
+    """
+    A single face of a multiface card.
+    
+    Multiface cards have a card_faces property containing at least two
+    Card Face objects.
+    """
+    
+    object: Literal["card_face"] = Field(
+        default="card_face",
+        description="A content type for this object, always card_face.",
+    )
+    name: str = Field(
+        description="The name of this particular face.",
+    )
+    mana_cost: str = Field(
+        description=(
+            "The mana cost for this face. This value will be any empty string "
+            "if the cost is absent. Remember that per the game rules, a missing "
+            "mana cost and a mana cost of {0} are different values."
+        ),
+    )
+    type_line: Optional[str] = Field(
+        default=None,
+        description="The type line of this particular face, if the card is reversible.",
+    )
+    oracle_text: Optional[str] = Field(
+        default=None,
+        description="The Oracle text for this face, if any.",
+    )
+    colors: Optional[list[Color]] = Field(
+        default=None,
+        description=(
+            "This face's colors, if the game defines colors for the individual "
+            "face of this card."
+        ),
+    )
+    color_indicator: Optional[list[Color]] = Field(
+        default=None,
+        description="The colors in this face's color indicator, if any.",
+    )
+    power: Optional[str] = Field(
+        default=None,
+        description=(
+            "This face's power, if any. Note that some cards have powers that "
+            "are not numeric, such as *."
+        ),
+    )
+    toughness: Optional[str] = Field(
+        default=None,
+        description=(
+            "This face's toughness, if any. Note that some cards have toughnesses "
+            "that are not numeric, such as *."
+        ),
+    )
+    defense: Optional[str] = Field(
+        default=None,
+        description="This face's defense, if any.",
+    )
+    loyalty: Optional[str] = Field(
+        default=None,
+        description="This face's loyalty, if any.",
+    )
+    flavor_text: Optional[str] = Field(
+        default=None,
+        description="The flavor text printed on this face, if any.",
+    )
+    illustration_id: Optional[UUID] = Field(
+        default=None,
+        description=(
+            "A unique identifier for the card face artwork that remains consistent "
+            "across reprints. Newly spoiled cards may not have this field yet."
+        ),
+    )
+    image_uris: Optional[ImageUris] = Field(
+        default=None,
+        description=(
+            "An object providing URIs to imagery for this face, if this is a "
+            "double-sided card. If this card is not double-sided, then the "
+            "image_uris property will be part of the parent object instead."
+        ),
+    )
+    artist: Optional[str] = Field(
+        default=None,
+        description=(
+            "The name of the illustrator of this card face. Newly spoiled cards "
+            "may not have this field yet."
+        ),
+    )
+    artist_id: Optional[UUID] = Field(
+        default=None,
+        description=(
+            "The ID of the illustrator of this card face. Newly spoiled cards "
+            "may not have this field yet."
+        ),
+    )
+    watermark: Optional[str] = Field(
+        default=None,
+        description="The watermark on this particular card face, if any.",
+    )
+    printed_name: Optional[str] = Field(
+        default=None,
+        description="The localized name printed on this face, if any.",
+    )
+    printed_text: Optional[str] = Field(
+        default=None,
+        description="The localized text printed on this face, if any.",
+    )
+    printed_type_line: Optional[str] = Field(
+        default=None,
+        description="The localized type line printed on this face, if any.",
+    )
+    cmc: Optional[Decimal] = Field(
+        default=None,
+        description="The mana value of this particular face, if the card is reversible.",
+    )
+    oracle_id: Optional[UUID] = Field(
+        default=None,
+        description="The Oracle ID of this particular face, if the card is reversible.",
+    )
+    layout: Optional[Layout] = Field(
+        default=None,
+        description="The layout of this card face, if the card is reversible.",
+    )
+
+
+class RelatedCard(BaseModel):
+    """
+    A card closely related to another card.
+    
+    Cards that are closely related to other cards (because they call them by
+    name, or generate a token, or meld, etc) have an all_parts property that
+    contains Related Card objects.
+    """
+    
+    object: Literal["related_card"] = Field(
+        default="related_card",
+        description="A content type for this object, always related_card.",
+    )
+    id: UUID = Field(
+        description="A unique ID for this card in Scryfall's database.",
+    )
+    component: Component = Field(
+        description=(
+            "A field explaining what role this card plays in this relationship, "
+            "one of token, meld_part, meld_result, or combo_piece."
+        ),
+    )
+    name: str = Field(
+        description="The name of this particular related card.",
+    )
+    type_line: str = Field(
+        description="The type line of this card.",
+    )
+    uri: HttpUrl = Field(
+        description=(
+            "A URI where you can retrieve a full object describing this card "
+            "on Scryfall's API."
+        ),
+    )
+
+
+class ScryfallCard(BaseModel):
+    """
+    Scryfall Card object.
+    
+    Card objects represent individual Magic: The Gathering cards that players
+    could obtain and add to their collection. Cards are the API's most complex
+    object.
+    
+    Magic cards can have multiple faces or multiple cards printed on one card
+    stock. Scryfall represents multi-face cards as a single object with a
+    card_faces array describing the distinct faces.
+    """
+    # ─────────── Core Fields ──────────────
+    
+    object: Literal["card"] = Field(
+        default="card",
+        description="A content type for this object, always card.",
+    )
+    id: UUID = Field(
+        description="A unique ID for this card in Scryfall's database.",
+    )
+    oracle_id: Optional[UUID] = Field(
+        default=None,
+        description=(
+            "A unique ID for this card's oracle identity. This value is consistent "
+            "across reprinted card editions, and unique among different cards with "
+            "the same name (tokens, Unstable variants, etc). Always present except "
+            "for the reversible_card layout where it will be absent; oracle_id will "
+            "be found on each face instead."
+        ),
+    )
+    multiverse_ids: Optional[list[int]] = Field(
+        default=None,
+        description=(
+            "This card's multiverse IDs on Gatherer, if any, as an array of integers. "
+            "Note that Scryfall includes many promo cards, tokens, and other esoteric "
+            "objects that do not have these identifiers."
+        ),
+    )
+    mtgo_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "This card's Magic Online ID (also known as the Catalog ID), if any. "
+            "A large percentage of cards are not available on Magic Online and do "
+            "not have this ID."
+        ),
+    )
+    mtgo_foil_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "This card's foil Magic Online ID (also known as the Catalog ID), if any. "
+            "A large percentage of cards are not available on Magic Online and do "
+            "not have this ID."
+        ),
+    )
+    tcgplayer_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "This card's ID on TCGplayer's API, also known as the productId."
+        ),
+    )
+    tcgplayer_etched_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "This card's ID on TCGplayer's API, for its etched version if that "
+            "version is a separate product."
+        ),
+    )
+    cardmarket_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "This card's ID on Cardmarket's API, also known as the idProduct."
+        ),
+    )
+    arena_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "This card's Arena ID, if any. A large percentage of cards are not "
+            "available on Arena and do not have this ID."
+        ),
+    )
+    resource_id: Optional[str] = Field(
+        default=None,
+        description="This card's Resource ID on Gatherer, if any.",
+    )
+    lang: str = Field(
+        description="A language code for this printing.",
+    )
+    prints_search_uri: HttpUrl = Field(
+        description=(
+            "A link to where you can begin paginating all re/prints for this card "
+            "on Scryfall's API."
+        ),
+    )
+    rulings_uri: HttpUrl = Field(
+        description="A link to this card's rulings list on Scryfall's API.",
+    )
+    scryfall_uri: HttpUrl = Field(
+        description="A link to this card's permapage on Scryfall's website.",
+    )
+    uri: HttpUrl = Field(
+        description="A link to this card object on Scryfall's API.",
+    )
+    
+    # ────────────Gameplay Fields ──────────────────
+    all_parts: Optional[list[RelatedCard]] = Field(
+        default=None,
+        description=(
+            "If this card is closely related to other cards, this property will "
+            "be an array with Related Card Objects."
+        ),
+    )
+    card_faces: Optional[list[CardFace]] = Field(
+        default=None,
+        description="An array of Card Face objects, if this card is multifaced.",
+    )
+    cmc: Decimal = Field(
+        description=(
+            "The card's mana value. Note that some funny cards have fractional "
+            "mana costs."
+        ),
+    )
+    color_identity: list[Color] = Field(
+        description="This card's color identity.",
+    )
+    color_indicator: Optional[list[Color]] = Field(
+        default=None,
+        description=(
+            "The colors in this card's color indicator, if any. A null value for "
+            "this field indicates the card does not have one."
+        ),
+    )
+    colors: Optional[list[Color]] = Field(
+        default=None,
+        description=(
+            "This card's colors, if the overall card has colors defined by the rules. "
+            "Otherwise the colors will be on the card_faces objects."
+        ),
+    )
+    defense: Optional[str] = Field(
+        default=None,
+        description="This face's defense, if any.",
+    )
+    edhrec_rank: Optional[int] = Field(
+        default=None,
+        description=(
+            "This card's overall rank/popularity on EDHREC. Not all cards are ranked."
+        ),
+    )
+    game_changer: Optional[bool] = Field(
+        default=None,
+        description="True if this card is on the Commander Game Changer list.",
+    )
+    hand_modifier: Optional[str] = Field(
+        default=None,
+        description=(
+            "This card's hand modifier, if it is Vanguard card. This value will "
+            "contain a delta, such as -1."
+        ),
+    )
+    keywords: list[str] = Field(
+        description=(
+            "An array of keywords that this card uses, such as 'Flying' and "
+            "'Cumulative upkeep'."
+        ),
+    )
+    layout: Layout = Field(
+        description="A code for this card's layout.",
+    )
+    legalities: Legalities = Field(
+        description=(
+            "An object describing the legality of this card across play formats. "
+            "Possible legalities are legal, not_legal, restricted, and banned."
+        ),
+    )
+    life_modifier: Optional[str] = Field(
+        default=None,
+        description=(
+            "This card's life modifier, if it is Vanguard card. This value will "
+            "contain a delta, such as +2."
+        ),
+    )
+    loyalty: Optional[str] = Field(
+        default=None,
+        description=(
+            "This loyalty if any. Note that some cards have loyalties that are "
+            "not numeric, such as X."
+        ),
+    )
+    mana_cost: Optional[str] = Field(
+        default=None,
+        description=(
+            "The mana cost for this card. This value will be any empty string '' "
+            "if the cost is absent. Remember that per the game rules, a missing "
+            "mana cost and a mana cost of {0} are different values. Multi-faced "
+            "cards will report this value in card faces."
+        ),
+    )
+    name: str = Field(
+        description=(
+            "The name of this card. If this card has multiple faces, this field "
+            "will contain both names separated by ' // '."
+        ),
+    )
+    oracle_text: Optional[str] = Field(
+        default=None,
+        description="The Oracle text for this card, if any.",
+    )
+    penny_rank: Optional[int] = Field(
+        default=None,
+        description=(
+            "This card's rank/popularity on Penny Dreadful. Not all cards are ranked."
+        ),
+    )
+    power: Optional[str] = Field(
+        default=None,
+        description=(
+            "This card's power, if any. Note that some cards have powers that are "
+            "not numeric, such as *."
+        ),
+    )
+    produced_mana: Optional[list[Color]] = Field(
+        default=None,
+        description="Colors of mana that this card could produce.",
+    )
+    reserved: bool = Field(
+        description="True if this card is on the Reserved List.",
+    )
+    toughness: Optional[str] = Field(
+        default=None,
+        description=(
+            "This card's toughness, if any. Note that some cards have toughnesses "
+            "that are not numeric, such as *."
+        ),
+    )
+    type_line: str = Field(
+        description="The type line of this card.",
+    )
+    # ──────────────────── Print Fields ────────────────────────
+    artist: Optional[str] = Field(
+        default=None,
+        description=(
+            "The name of the illustrator of this card. Newly spoiled cards may "
+            "not have this field yet."
+        ),
+    )
+    artist_ids: Optional[list[UUID]] = Field(
+        default=None,
+        description=(
+            "The IDs of the artists that illustrated this card. Newly spoiled "
+            "cards may not have this field yet."
+        ),
+    )
+    attraction_lights: Optional[list[int]] = Field(
+        default=None,
+        description="The lit Unfinity attractions lights on this card, if any.",
+    )
+    booster: bool = Field(
+        description="Whether this card is found in boosters.",
+    )
+    border_color: BorderColor = Field(
+        description=(
+            "This card's border color: black, white, borderless, silver, or gold."
+        ),
+    )
+    card_back_id: UUID = Field(
+        description="The Scryfall ID for the card back design present on this card.",
+    )
+    collector_number: str = Field(
+        description=(
+            "This card's collector number. Note that collector numbers can contain "
+            "non-numeric characters, such as letters or ★."
+        ),
+    )
+    content_warning: Optional[bool] = Field(
+        default=None,
+        description=(
+            "True if you should consider avoiding use of this print downstream."
+        ),
+    )
+    digital: bool = Field(
+        description="True if this card was only released in a video game.",
+    )
+    finishes: list[Finish] = Field(
+        description=(
+            "An array of computer-readable flags that indicate if this card can "
+            "come in foil, nonfoil, or etched finishes."
+        ),
+    )
+    flavor_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "The just-for-fun name printed on the card (such as for Godzilla "
+            "series cards)."
+        ),
+    )
+    flavor_text: Optional[str] = Field(
+        default=None,
+        description="The flavor text, if any.",
+    )
+    frame_effects: Optional[list[str]] = Field(
+        default=None,
+        description="This card's frame effects, if any.",
+    )
+    frame: Frame = Field(
+        description="This card's frame layout.",
+    )
+    full_art: bool = Field(
+        description="True if this card's artwork is larger than normal.",
+    )
+    games: list[Game] = Field(
+        description=(
+            "A list of games that this card print is available in, paper, arena, "
+            "and/or mtgo."
+        ),
+    )
+    highres_image: bool = Field(
+        description="True if this card's imagery is high resolution.",
+    )
+    illustration_id: Optional[UUID] = Field(
+        default=None,
+        description=(
+            "A unique identifier for the card artwork that remains consistent "
+            "across reprints. Newly spoiled cards may not have this field yet."
+        ),
+    )
+    image_status: ImageStatus = Field(
+        description=(
+            "A computer-readable indicator for the state of this card's image, "
+            "one of missing, placeholder, lowres, or highres_scan."
+        ),
+    )
+    image_uris: Optional[ImageUris] = Field(
+        default=None,
+        description=(
+            "An object listing available imagery for this card. See the Card "
+            "Imagery article for more information."
+        ),
+    )
+    oversized: bool = Field(
+        description="True if this card is oversized.",
+    )
+    prices: Prices = Field(
+        description=(
+            "An object containing daily price information for this card, including "
+            "usd, usd_foil, usd_etched, eur, eur_foil, eur_etched, and tix prices, "
+            "as strings."
+        ),
+    )
+    printed_name: Optional[str] = Field(
+        default=None,
+        description="The localized name printed on this card, if any.",
+    )
+    printed_text: Optional[str] = Field(
+        default=None,
+        description="The localized text printed on this card, if any.",
+    )
+    printed_type_line: Optional[str] = Field(
+        default=None,
+        description="The localized type line printed on this card, if any.",
+    )
+    promo: bool = Field(
+        description="True if this card is a promotional print.",
+    )
+    promo_types: Optional[list[str]] = Field(
+        default=None,
+        description=(
+            "An array of strings describing what categories of promo cards this "
+            "card falls into."
+        ),
+    )
+    purchase_uris: Optional[PurchaseUris] = Field(
+        default=None,
+        description=(
+            "An object providing URIs to this card's listing on major marketplaces. "
+            "Omitted if the card is unpurchaseable."
+        ),
+    )
+    rarity: Rarity = Field(
+        description=(
+            "This card's rarity. One of common, uncommon, rare, special, mythic, "
+            "or bonus."
+        ),
+    )
+    related_uris: RelatedUris = Field(
+        description=(
+            "An object providing URIs to this card's listing on other Magic: The "
+            "Gathering online resources."
+        ),
+    )
+    released_at: date = Field(
+        description="The date this card was first released.",
+    )
+    reprint: bool = Field(
+        description="True if this card is a reprint.",
+    )
+    scryfall_set_uri: HttpUrl = Field(
+        description="A link to this card's set on Scryfall's website.",
+    )
+    set_name: str = Field(
+        description="This card's full set name.",
+    )
+    set_search_uri: HttpUrl = Field(
+        description=(
+            "A link to where you can begin paginating this card's set on the "
+            "Scryfall API."
+        ),
+    )
+    set_type: str = Field(
+        description="The type of set this printing is in.",
+    )
+    set_uri: HttpUrl = Field(
+        description="A link to this card's set object on Scryfall's API.",
+    )
+    set: str = Field(
+        description="This card's set code.",
+    )
+    set_id: UUID = Field(
+        description="This card's Set object UUID.",
+    )
+    story_spotlight: bool = Field(
+        description="True if this card is a Story Spotlight.",
+    )
+    textless: bool = Field(
+        description="True if the card is printed without text.",
+    )
+    variation: bool = Field(
+        description="Whether this card is a variation of another printing.",
+    )
+    variation_of: Optional[UUID] = Field(
+        default=None,
+        description=(
+            "The printing ID of the printing this card is a variation of."
+        ),
+    )
+    security_stamp: Optional[SecurityStamp] = Field(
+        default=None,
+        description=(
+            "The security stamp on this card, if any. One of oval, triangle, "
+            "acorn, circle, arena, or heart."
+        ),
+    )
+    watermark: Optional[str] = Field(
+        default=None,
+        description="This card's watermark, if any.",
+    )
+    preview: Optional[Preview] = Field(
+        default=None,
+        description="Preview information for this card, if it was previewed.",
+    )

--- a/mtgjson5/providers/scryfall/data_source.py
+++ b/mtgjson5/providers/scryfall/data_source.py
@@ -1,0 +1,680 @@
+"""
+Scryfall Data Source Abstraction.
+
+Provides a unified interface for accessing Scryfall card data from either:
+- Direct API calls (default behavior)
+- Bulk NDJSON files (--bulk-files flag)
+
+This module uses Polars SQL mode to translate Scryfall search syntax
+into SQL queries against the bulk data.
+"""
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+import polars as pl
+
+from ... import constants
+
+LOGGER = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Scryfall Query Parser -> SQL Translator
+# =============================================================================
+
+
+@dataclass
+class ParsedQuery:
+    """Parsed Scryfall search query components."""
+    set_code: Optional[str] = None
+    oracle_id: Optional[str] = None  # oracleid:{uuid} search
+    is_booster: bool = False
+    is_alchemy: bool = False
+    lang_any: bool = False  # lang:any - include all languages
+    oracle_regex: Optional[str] = None
+    oracle_contains: List[str] = field(default_factory=list)
+    oracle_or_groups: List[List[str]] = field(default_factory=list)  # For complex OR logic
+    spellbook_name: Optional[str] = None
+    include_extras: bool = False
+    include_variations: bool = False
+    unique: Optional[str] = None  # "prints", "art", "cards"
+    order: Optional[str] = None  # "set", "name", etc.
+
+
+def parse_scryfall_query(url: str) -> ParsedQuery:
+    """
+    Parse a Scryfall API URL into query components.
+
+    Supports the subset of Scryfall syntax used by MTGJSON:
+    - e:{set} or set:{set} - filter by set code
+    - is:booster - cards found in boosters
+    - is:alchemy - alchemy cards
+    - o:{text} - oracle text contains
+    - oracle:/{regex}/ - oracle text regex
+    - spellbook:"{name}" - cards in a spellbook
+    - unique=prints - unique printings
+    - include_extras=true - include extras
+    - include_variations=true - include variations
+    """
+    query = ParsedQuery()
+
+    # Extract URL parameters
+    if "include_extras=true" in url:
+        query.include_extras = True
+    if "include_variations=true" in url:
+        query.include_variations = True
+
+    # Extract unique parameter
+    unique_match = re.search(r"unique[=:](\w+)", url)
+    if unique_match:
+        query.unique = unique_match.group(1)
+
+    # Extract order parameter
+    order_match = re.search(r"order[=:](\w+)", url)
+    if order_match:
+        query.order = order_match.group(1)
+
+    # Extract the q= parameter (URL decoded)
+    q_match = re.search(r"[?&]q=([^&]+)", url)
+    if not q_match:
+        return query
+
+    q_value = q_match.group(1)
+    # URL decode common patterns
+    q_value = q_value.replace("%3A", ":").replace("%20", " ").replace("%22", '"')
+    q_value = q_value.replace("%27", "'").replace("%7C", "|")
+
+    # Parse e:{set} or set:{set}
+    set_match = re.search(r"(?:e|set):(\w+)", q_value, re.IGNORECASE)
+    if set_match:
+        query.set_code = set_match.group(1).upper()
+
+    # Parse oracleid:{uuid} - for printing lookups
+    oracle_id_match = re.search(r"oracleid[=:]([a-f0-9-]+)", q_value, re.IGNORECASE)
+    if oracle_id_match:
+        query.oracle_id = oracle_id_match.group(1).lower()
+
+    # Parse lang:any - include all languages (not just English)
+    if "lang:any" in q_value.lower() or "+lang%3aany" in url.lower():
+        query.lang_any = True
+
+    # Parse is:booster
+    if "is:booster" in q_value.lower():
+        query.is_booster = True
+
+    # Parse is:alchemy
+    if "is:alchemy" in q_value.lower():
+        query.is_alchemy = True
+
+    # Parse oracle regex: oracle:/{pattern}/
+    oracle_regex_match = re.search(r"oracle:/([^/]+)/", q_value)
+    if oracle_regex_match:
+        query.oracle_regex = oracle_regex_match.group(1)
+
+    # Parse complex OR groups: (o:word1 o:word2) or (o:word3 o:word4)
+    # This handles CARDS_WITHOUT_LIMITS_URL pattern
+    or_groups = re.findall(r"\(([^)]+)\)", q_value)
+    if or_groups:
+        for group in or_groups:
+            words = re.findall(r"o:(\w+)", group)
+            if words:
+                query.oracle_or_groups.append(words)
+    else:
+        # Simple o:word patterns (AND logic)
+        oracle_matches = re.findall(r"o:(\w+)", q_value)
+        if oracle_matches:
+            query.oracle_contains = oracle_matches
+
+    # Parse spellbook:"{name}"
+    spellbook_match = re.search(r'spellbook:"([^"]+)"', q_value)
+    if spellbook_match:
+        query.spellbook_name = spellbook_match.group(1)
+
+    return query
+
+
+def build_sql_query(query: ParsedQuery, table_name: str = "cards") -> str:
+    """
+    Convert a ParsedQuery into a SQL query string.
+
+    Returns a SQL SELECT statement that can be executed against the bulk data.
+    """
+    conditions = []
+
+    # Language filter - default to English unless lang:any specified
+    if not query.lang_any:
+        conditions.append("lang = 'en'")
+
+    # Oracle ID filter (most specific - for printings lookup)
+    if query.oracle_id:
+        conditions.append(f"oracle_id = '{query.oracle_id}'")
+
+    # Set code filter
+    if query.set_code:
+        conditions.append(f"UPPER(set) = '{query.set_code}'")
+
+    # is:booster - cards that appear in boosters
+    if query.is_booster:
+        conditions.append("booster = true")
+
+    # is:alchemy - alchemy format cards
+    if query.is_alchemy:
+        conditions.append("(set_type = 'alchemy' OR name LIKE 'A-%')")
+
+    # Oracle text regex (use SIMILAR TO or REGEXP depending on support)
+    if query.oracle_regex:
+        # Escape single quotes in regex
+        escaped_regex = query.oracle_regex.replace("'", "''")
+        conditions.append(f"COALESCE(oracle_text, '') LIKE '%{escaped_regex}%'")
+
+    # Oracle text contains - simple AND logic
+    if query.oracle_contains:
+        for word in query.oracle_contains:
+            escaped_word = word.replace("'", "''").lower()
+            conditions.append(f"LOWER(COALESCE(oracle_text, '')) LIKE '%{escaped_word}%'")
+
+    # Oracle OR groups - complex (group1 AND words) OR (group2 AND words)
+    if query.oracle_or_groups:
+        or_clauses = []
+        for group in query.oracle_or_groups:
+            and_clauses = []
+            for word in group:
+                escaped_word = word.replace("'", "''").lower()
+                and_clauses.append(f"LOWER(COALESCE(oracle_text, '')) LIKE '%{escaped_word}%'")
+            if and_clauses:
+                or_clauses.append(f"({' AND '.join(and_clauses)})")
+        if or_clauses:
+            conditions.append(f"({' OR '.join(or_clauses)})")
+
+    # Spellbook filter - requires join with spellbook data
+    if query.spellbook_name:
+        # This would need a subquery or join - log warning for now
+        LOGGER.warning(
+            f"Spellbook search '{query.spellbook_name}' requires spellbook table join"
+        )
+
+    # Build WHERE clause
+    where_clause = " AND ".join(conditions) if conditions else "1=1"
+
+    # Build ORDER BY clause
+    order_clause = ""
+    if query.order == "set":
+        order_clause = "ORDER BY set, collector_number"
+    elif query.order == "name":
+        order_clause = "ORDER BY name"
+    elif query.order == "released":
+        order_clause = "ORDER BY released_at DESC"
+
+    # Build the full query
+    sql = f"SELECT * FROM {table_name} WHERE {where_clause}"
+    if order_clause:
+        sql += f" {order_clause}"
+
+    return sql
+
+
+# =============================================================================
+# Type Coercion (Polars NDJSON reads numbers as strings)
+# =============================================================================
+
+# Fields that should be float but Polars may read as strings from NDJSON
+FLOAT_FIELDS = {"cmc"}
+
+# Fields that should be int but Polars may read as strings from NDJSON
+INT_FIELDS = {"edhrec_rank", "penny_rank", "mtgo_id", "mtgo_foil_id",
+              "tcgplayer_id", "tcgplayer_etched_id", "cardmarket_id", "arena_id"}
+
+
+def _coerce_types(cards: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Coerce bulk data to match API response format.
+
+    1. Convert string numeric values to proper types (Polars NDJSON issue)
+    2. Strip None-valued keys (API omits them, bulk includes them)
+    """
+    result = []
+    for card in cards:
+        # Strip None values to match API sparse response format
+        card = {k: v for k, v in card.items() if v is not None}
+
+        # Coerce numeric types
+        for field_name in FLOAT_FIELDS:
+            if field_name in card:
+                val = card[field_name]
+                if isinstance(val, str):
+                    try:
+                        card[field_name] = float(val)
+                    except (ValueError, TypeError):
+                        pass
+        for field_name in INT_FIELDS:
+            if field_name in card:
+                val = card[field_name]
+                if isinstance(val, str):
+                    try:
+                        card[field_name] = int(float(val))  # Handle "123.0" strings
+                    except (ValueError, TypeError):
+                        pass
+        result.append(card)
+    return result
+
+
+# =============================================================================
+# Data Source Protocol and Implementations
+# =============================================================================
+
+
+@runtime_checkable
+class ScryfallDataSource(Protocol):
+    """Protocol for Scryfall data access."""
+
+    def search(self, url: str) -> List[Dict[str, Any]]:
+        """
+        Execute a Scryfall search query.
+
+        Args:
+            url: Full Scryfall API URL with query parameters
+
+        Returns:
+            List of card objects as dicts (same format as API response)
+        """
+        ...
+
+    def get_card_by_id(self, scryfall_id: str) -> Optional[Dict[str, Any]]:
+        """Get a single card by its Scryfall ID."""
+        ...
+
+
+class BulkDataSource:
+    """
+    Data source that reads from Scryfall bulk NDJSON files.
+
+    Uses Polars SQL mode to execute queries against the bulk data,
+    translating Scryfall search syntax to SQL.
+
+    Supports fallback to API calls when:
+    - Bulk data files don't exist
+    - Query returns no results (e.g., new set not in bulk data)
+    - Specific card not found in bulk data
+    """
+
+    def __init__(
+        self,
+        cache_path: Optional[Path] = None,
+        api_fallback: bool = True,
+        api_provider: Optional[Any] = None,
+    ):
+        """
+        Initialize the bulk data source.
+
+        Args:
+            cache_path: Path to bulk data cache directory
+            api_fallback: If True, fall back to API when bulk data missing/empty
+            api_provider: ScryfallProvider instance for API fallback (lazy-loaded if None)
+        """
+        self.cache_path = cache_path or constants.CACHE_PATH
+        self.api_fallback = api_fallback
+        self._api_provider = api_provider
+        self._cards_df: Optional[pl.LazyFrame] = None
+        self._rulings_df: Optional[pl.LazyFrame] = None
+        self._sql_context: Optional[pl.SQLContext] = None
+        self._loaded = False
+        self._bulk_available = False
+        # Caches for frequently accessed lookups
+        self._oracle_id_cache: Optional[Dict[str, List[Dict[str, Any]]]] = None
+        self._oracle_id_cache_built = False
+
+    @property
+    def api_provider(self):
+        """Lazy-load the API provider for fallback."""
+        if self._api_provider is None:
+            # Import here to avoid circular imports
+            from .monolith import ScryfallProvider # noqa: F401
+            self._api_provider = ScryfallProvider()
+        return self._api_provider
+
+    def _ensure_loaded(self) -> None:
+        """Lazy-load bulk data on first access."""
+        if self._loaded:
+            return
+
+        cards_path = self.cache_path / "all_cards.ndjson"
+        rulings_path = self.cache_path / "rulings.ndjson"
+
+        if not cards_path.exists():
+            if self.api_fallback:
+                LOGGER.warning(
+                    f"Bulk cards file not found: {cards_path}. "
+                    "Will use API fallback for all queries."
+                )
+                self._loaded = True
+                self._bulk_available = False
+                return
+            else:
+                raise FileNotFoundError(
+                    f"Bulk cards file not found: {cards_path}. "
+                    "Run with --polars first to download bulk data, or remove --bulk-files flag."
+                )
+
+        LOGGER.info(f"Loading bulk data from {self.cache_path}")
+
+        self._cards_df = pl.scan_ndjson(
+            cards_path,
+            infer_schema_length=10000,
+        )
+
+        if rulings_path.exists():
+            self._rulings_df = pl.scan_ndjson(
+                rulings_path,
+                infer_schema_length=1000,
+            )
+
+        # Create SQL context and register tables
+        self._sql_context = pl.SQLContext()
+        self._sql_context.register("cards", self._cards_df)
+        if self._rulings_df is not None:
+            self._sql_context.register("rulings", self._rulings_df)
+
+        self._loaded = True
+        self._bulk_available = True
+        LOGGER.info("Bulk data loaded into SQL context")
+
+    def _build_oracle_id_cache(self) -> None:
+        """
+        Build an in-memory cache of all cards grouped by oracle_id.
+
+        This allows O(1) lookups for printings queries instead of
+        re-scanning the NDJSON file for each card.
+        """
+        if self._oracle_id_cache_built or self._sql_context is None:
+            return
+
+        LOGGER.info("Building oracle_id lookup cache (one-time operation)...")
+
+        # Get all cards and group by oracle_id
+        sql = "SELECT * FROM cards"
+        result = self._sql_context.execute(sql).collect()
+
+        # Build the lookup dictionary
+        self._oracle_id_cache = {}
+        for card in _coerce_types(result.to_dicts()):
+            oracle_id = card.get("oracle_id")
+            if oracle_id:
+                if oracle_id not in self._oracle_id_cache:
+                    self._oracle_id_cache[oracle_id] = []
+                self._oracle_id_cache[oracle_id].append(card)
+
+        self._oracle_id_cache_built = True
+        LOGGER.info(f"Oracle ID cache built: {len(self._oracle_id_cache)} unique oracle IDs")
+
+    def _get_by_oracle_id(
+        self, oracle_id: str, lang_any: bool = False
+    ) -> List[Dict[str, Any]]:
+        """
+        Get all printings for a given oracle_id using the cache.
+
+        Args:
+            oracle_id: The oracle ID to look up
+            lang_any: If True, include all languages; if False, only English
+
+        Returns:
+            List of card dicts matching the oracle_id
+        """
+        self._build_oracle_id_cache()
+
+        if self._oracle_id_cache is None:
+            return []
+
+        cards = self._oracle_id_cache.get(oracle_id, [])
+
+        if not lang_any:
+            cards = [c for c in cards if c.get("lang") == "en"]
+
+        return cards
+
+    def search(self, url: str) -> List[Dict[str, Any]]:
+        """
+        Execute a Scryfall-style search query against bulk data using SQL.
+
+        Parses the URL to extract query parameters and translates them
+        to a SQL query executed via Polars SQLContext.
+
+        For oracle_id queries, uses an in-memory cache for O(1) lookups.
+
+        Falls back to API if:
+        - Bulk data not available
+        - Query returns no results and fallback is enabled
+        """
+        self._ensure_loaded()
+
+        # If bulk data not available, use API directly
+        if not self._bulk_available:
+            if self.api_fallback:
+                LOGGER.debug(f"Using API fallback (no bulk data): {url}")
+                return self.api_provider._download_all_pages_api(url)
+            return []
+
+        if self._sql_context is None:
+            return []
+
+        # Parse the query
+        parsed = parse_scryfall_query(url)
+        LOGGER.debug(f"Parsed query: {parsed}")
+
+        # Fast path: oracle_id queries use the cache
+        if parsed.oracle_id:
+            results = self._get_by_oracle_id(parsed.oracle_id, parsed.lang_any)
+            if not results and self.api_fallback:
+                LOGGER.info(f"Oracle ID not in cache, falling back to API: {url}")
+                return self.api_provider._download_all_pages_api(url)
+            return results
+
+        # Build SQL query for other query types
+        sql = build_sql_query(parsed)
+        LOGGER.debug(f"Generated SQL: {sql}")
+
+        # Execute query
+        try:
+            result_lf = self._sql_context.execute(sql)
+
+            # Apply unique parameter (post-SQL since DISTINCT on specific columns is complex)
+            if parsed.unique == "cards":
+                result_lf = result_lf.unique(subset=["oracle_id"], keep="first")
+            elif parsed.unique == "art":
+                result_lf = result_lf.unique(subset=["illustration_id"], keep="first")
+            # unique=prints is default - no deduplication
+
+            # Collect and convert to dicts
+            collected = result_lf.collect()
+            LOGGER.info(f"SQL query returned {len(collected)} cards")
+
+            # If no results and fallback enabled, try API
+            if collected.is_empty() and self.api_fallback:
+                LOGGER.info(f"No bulk results, falling back to API: {url}")
+                return self.api_provider._download_all_pages_api(url)
+
+            # Coerce types to match API response format
+            return _coerce_types(collected.to_dicts())
+
+        except Exception as e:
+            LOGGER.error(f"SQL query failed: {e}\nQuery: {sql}")
+            if self.api_fallback:
+                LOGGER.info(f"SQL failed, falling back to API: {url}")
+                return self.api_provider._download_all_pages_api(url)
+            return []
+
+    def search_sql(self, sql: str) -> List[Dict[str, Any]]:
+        """
+        Execute a raw SQL query directly.
+
+        Useful for complex queries that don't map to Scryfall syntax.
+        """
+        self._ensure_loaded()
+
+        if self._sql_context is None:
+            return []
+
+        try:
+            result_lf = self._sql_context.execute(sql)
+            collected = result_lf.collect()
+            return _coerce_types(collected.to_dicts())
+        except Exception as e:
+            LOGGER.error(f"SQL query failed: {e}\nQuery: {sql}")
+            return []
+
+    def get_card_by_id(self, scryfall_id: str) -> Optional[Dict[str, Any]]:
+        """Get a single card by its Scryfall ID using SQL."""
+        self._ensure_loaded()
+
+        # If bulk data not available, use API directly
+        if not self._bulk_available:
+            if self.api_fallback:
+                LOGGER.debug(f"Using API fallback for card: {scryfall_id}")
+                return self.api_provider.download(
+                    f"https://api.scryfall.com/cards/{scryfall_id}"
+                )
+            return None
+
+        if self._sql_context is None:
+            return None
+
+        sql = f"SELECT * FROM cards WHERE id = '{scryfall_id}' LIMIT 1"
+        try:
+            result = self._sql_context.execute(sql).collect()
+            if result.is_empty():
+                # Card not in bulk data - try API fallback
+                if self.api_fallback:
+                    LOGGER.info(f"Card {scryfall_id} not in bulk data, falling back to API")
+                    return self.api_provider.download(
+                        f"https://api.scryfall.com/cards/{scryfall_id}"
+                    )
+                return None
+            return result.to_dicts()[0]
+        except Exception as e:
+            LOGGER.error(f"SQL query failed: {e}")
+            if self.api_fallback:
+                return self.api_provider.download(
+                    f"https://api.scryfall.com/cards/{scryfall_id}"
+                )
+            return None
+
+    def get_cards_by_set(self, set_code: str) -> List[Dict[str, Any]]:
+        """
+        Convenience method: Get all cards for a set.
+
+        Equivalent to CARDS_URL_ALL_DETAIL_BY_SET_CODE query.
+        """
+        url = f"https://api.scryfall.com/cards/search?include_extras=true&include_variations=true&order=set&q=e%3A{set_code}&unique=prints"
+        return self.search(url)
+
+    def get_booster_cards(self, set_code: str) -> List[Dict[str, Any]]:
+        """
+        Get cards that appear in boosters for a set.
+
+        Equivalent to CARDS_IN_BASE_SET_URL query.
+        """
+        url = f"https://api.scryfall.com/cards/search?order=set&q=set:{set_code}%20is:booster%20unique:prints"
+        return self.search(url)
+
+    def get_cards_without_limits(self) -> List[Dict[str, Any]]:
+        """
+        Get cards that can have unlimited copies in a deck.
+
+        Equivalent to CARDS_WITHOUT_LIMITS_URL query.
+        """
+        # This is a complex OR query - use direct SQL for clarity
+        sql = """
+        SELECT * FROM cards
+        WHERE lang = 'en' AND (
+            (LOWER(COALESCE(oracle_text, '')) LIKE '%deck%'
+             AND LOWER(COALESCE(oracle_text, '')) LIKE '%any%'
+             AND LOWER(COALESCE(oracle_text, '')) LIKE '%number%'
+             AND LOWER(COALESCE(oracle_text, '')) LIKE '%cards%'
+             AND LOWER(COALESCE(oracle_text, '')) LIKE '%named%')
+            OR
+            (LOWER(COALESCE(oracle_text, '')) LIKE '%deck%'
+             AND LOWER(COALESCE(oracle_text, '')) LIKE '%have%'
+             AND LOWER(COALESCE(oracle_text, '')) LIKE '%up%'
+             AND LOWER(COALESCE(oracle_text, '')) LIKE '%to%'
+             AND LOWER(COALESCE(oracle_text, '')) LIKE '%cards%'
+             AND LOWER(COALESCE(oracle_text, '')) LIKE '%named%')
+        )
+        """
+        return self.search_sql(sql)
+
+    def get_alchemy_spellbook_cards(self) -> List[Dict[str, Any]]:
+        """
+        Get alchemy cards with spellbooks.
+
+        Equivalent to CARDS_WITH_ALCHEMY_SPELLBOOK_URL query.
+        """
+        sql = """
+        SELECT * FROM cards
+        WHERE lang = 'en'
+          AND (set_type = 'alchemy' OR name LIKE 'A-%')
+          AND (
+            LOWER(COALESCE(oracle_text, '')) LIKE '%conjure%'
+            OR LOWER(COALESCE(oracle_text, '')) LIKE '%draft%'
+            OR LOWER(COALESCE(oracle_text, '')) LIKE '%spellbook%'
+          )
+        """
+        return self.search_sql(sql)
+
+    def get_rulings(self, oracle_id: str) -> List[Dict[str, Any]]:
+        """Get rulings for a card by oracle ID."""
+        self._ensure_loaded()
+
+        if self._sql_context is None or self._rulings_df is None:
+            return []
+
+        sql = f"""
+        SELECT * FROM rulings
+        WHERE oracle_id = '{oracle_id}'
+        ORDER BY published_at
+        """
+        return self.search_sql(sql)
+
+    def get_foreign_cards(self, set_code: str, collector_number: str) -> List[Dict[str, Any]]:
+        """
+        Get non-English printings of a card.
+
+        Used for foreignData field in MTGJSON.
+        """
+        self._ensure_loaded()
+
+        if self._sql_context is None:
+            return []
+
+        # Escape collector_number for SQL
+        escaped_cn = collector_number.replace("'", "''")
+        sql = f"""
+        SELECT * FROM cards
+        WHERE UPPER(set) = '{set_code.upper()}'
+          AND collector_number = '{escaped_cn}'
+          AND lang != 'en'
+        """
+        return self.search_sql(sql)
+
+
+# =============================================================================
+# Module-level singleton management
+# =============================================================================
+
+_bulk_data_source: Optional[BulkDataSource] = None
+
+
+def get_bulk_data_source() -> BulkDataSource:
+    """Get or create the singleton bulk data source."""
+    global _bulk_data_source
+    if _bulk_data_source is None:
+        _bulk_data_source = BulkDataSource()
+    return _bulk_data_source
+
+
+def reset_bulk_data_source() -> None:
+    """Reset the singleton (useful for testing)."""
+    global _bulk_data_source
+    _bulk_data_source = None


### PR DESCRIPTION
Introduces a bulk data source layer for Scryfall card data, enabling queries against local NDJSON files using Polars SQL when the --bulk-files flag is set. Provides a unified interface that transparently falls back to the API if bulk data is unavailable or incomplete, improving performance and supporting offline workflows. Refactors provider logic to delegate queries to this abstraction and adds comprehensive schema models for card data.
