### PR TITLE
fix(decks): use deck's
    set_code for sealedProductUuids lookup

### DIFF
--- a/mtgjson5/providers/github/github_decks.py
+++ b/mtgjson5/providers/github/github_decks.py
@@ -81,7 +81,7 @@ class GitHubDecksProvider(AbstractProvider):
         if not self.decks_by_set:
             decks_uuid_content = self.download(self.decks_uuid_api_url)
             for deck in self.download(self.decks_api_url):
-                sealed_uuids = decks_uuid_content.get(set_code.lower(), {}).get(
+                sealed_uuids = decks_uuid_content.get(deck["set_code"].lower(), {}).get(
                     deck["name"]
                 )
 


### PR DESCRIPTION
## Summary
   - Fixed bug where  lookup used the function parameter  instead of each deck's actual 
   - This caused only the first requested set's decks to get their sealedProductUuids populated