### PR TITLE
fix(promoTypes): prevent duplicate planeswalkerstamped for multi-face cards

### DIFF
--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -1001,7 +1001,7 @@ def build_mtgjson_card(
 
     # Handle Promo Types for MTGJSON
     mtgjson_card.promo_types = scryfall_object.get("promo_types", [])
-    if mtgjson_card.number.endswith("p"):
+    if mtgjson_card.number.endswith("p") and "planeswalkerstamped" not in mtgjson_card.promo_types:
         mtgjson_card.promo_types.append("planeswalkerstamped")
 
     # Remove terms that are covered elsewhere


### PR DESCRIPTION
Adds check for 'planeswalkerstamped' to prevent duplicate adds for multi-faced, stamped cards

