### PR TITLE
Add produced_mana field

### DIFF
--- a/mtgjson5/classes/mtgjson_card.py
+++ b/mtgjson5/classes/mtgjson_card.py
@@ -34,6 +34,7 @@ class MtgjsonCardObject(JsonObject):
     color_identity: List[str]
     color_indicator: Optional[List[str]]
     colors: List[str]
+    produced_mana: Optional[List[str]]
     converted_mana_cost: float
     count: int
     defense: Optional[str]
@@ -163,6 +164,7 @@ class MtgjsonCardObject(JsonObject):
         "color_identity",
         "color_indicator",
         "colors",
+        "produced_mana",
         "converted_mana_cost",
         "count",
         "defense",

--- a/mtgjson5/set_builder.py
+++ b/mtgjson5/set_builder.py
@@ -1019,6 +1019,10 @@ def build_mtgjson_card(
     mtgjson_card.attraction_lights = scryfall_object.get("attraction_lights")
     mtgjson_card.border_color = scryfall_object.get("border_color", "")
     mtgjson_card.color_identity = scryfall_object.get("color_identity", "")
+    if "produced_mana" in face_data:
+        mtgjson_card.produced_mana = face_data.get("produced_mana")
+    else:
+        mtgjson_card.produced_mana = scryfall_object.get("produced_mana")
     if not hasattr(mtgjson_card, "mana_value"):
         mtgjson_card.mana_value = scryfall_object.get("cmc", "")
         # Deprecated - Remove in 6.0.0


### PR DESCRIPTION
Hey, I added the `produced_mana` field to MTGJson cards, which is filled from Scryfall data. It uses face data first when a card has multiple faces.
Should I add any tests for this? Can I test this locally?
I am not sure if there is a way for me run the project locally.