### PR TITLE
Fix otherFaceIds missing/incorrect on meld cards.

### DIFF
--- a/mtgjson5/resources/meld_overrides.json
+++ b/mtgjson5/resources/meld_overrides.json
@@ -1,0 +1,38 @@
+{
+  "2a5b16d1-88c5-59d5-b1fb-f077ba0d1e60": {
+    "otherFaceIds": ["e831d957-15cf-5d61-bcd7-87d9c5c77429"]
+  },
+  "37352d29-3bab-5fef-8b0d-8cc80e5d3b2e": {
+    "otherFaceIds": ["e831d957-15cf-5d61-bcd7-87d9c5c77429"]
+  },
+  "e831d957-15cf-5d61-bcd7-87d9c5c77429": {
+    "otherFaceIds": ["2a5b16d1-88c5-59d5-b1fb-f077ba0d1e60", "37352d29-3bab-5fef-8b0d-8cc80e5d3b2e"]
+  },
+  "523b97de-7744-5ca1-adef-818ff02528d1": {
+    "otherFaceIds": ["3b656422-c867-58ea-8c4d-960317d5712f"]
+  },
+  "14d87a06-22b6-575d-8963-9d9868ba3521": {
+    "otherFaceIds": ["3b656422-c867-58ea-8c4d-960317d5712f"]
+  },
+  "3b656422-c867-58ea-8c4d-960317d5712f": {
+    "otherFaceIds": ["523b97de-7744-5ca1-adef-818ff02528d1", "14d87a06-22b6-575d-8963-9d9868ba3521"]
+  },
+  "10e5f45a-743f-514b-9846-297fb997f534": {
+    "otherFaceIds": ["d870de05-4e42-532a-95d9-4e9d5980dfc2"]
+  },
+  "5af57b16-2554-552f-98f5-ad8ed0a51beb": {
+    "otherFaceIds": ["d870de05-4e42-532a-95d9-4e9d5980dfc2"]
+  },
+  "d870de05-4e42-532a-95d9-4e9d5980dfc2": {
+    "otherFaceIds": ["10e5f45a-743f-514b-9846-297fb997f534", "5af57b16-2554-552f-98f5-ad8ed0a51beb"]
+  },
+  "aed50dfb-16cd-54d4-9b02-3daeab2e606a": {
+    "otherFaceIds": ["bd42102d-9ec8-5ddc-81cd-f2ee99c9d5e8"]
+  },
+  "f73959fe-4ed2-5a27-b218-d0979d6b1b75": {
+    "otherFaceIds": ["bd42102d-9ec8-5ddc-81cd-f2ee99c9d5e8"]
+  },
+  "bd42102d-9ec8-5ddc-81cd-f2ee99c9d5e8": {
+    "otherFaceIds": ["aed50dfb-16cd-54d4-9b02-3daeab2e606a", "f73959fe-4ed2-5a27-b218-d0979d6b1b75"]
+  }
+}

--- a/mtgjson5/v2/pipeline/core.py
+++ b/mtgjson5/v2/pipeline/core.py
@@ -3189,10 +3189,10 @@ def join_name_data(
         )
 
         # Coalesce: prefer name lookup, fall back to faceName lookup
-        # Only keep cardParts for original meld sets (BRO, EMN) - not reprints
-        meld_original_sets = ["BRO", "EMN", "FIN"]
+        # Keep cardParts for ALL meld layout cards (including reprints)
+        # Fixes: #1425, #1427 - reprints were excluded by set filter
         lf = lf.with_columns(
-            pl.when(pl.col("setCode").is_in(meld_original_sets))
+            pl.when(pl.col("layout") == "meld")
             .then(
                 pl.coalesce(
                     pl.col("cardParts"),

--- a/mtgjson5/v2/pipeline/lookups.py
+++ b/mtgjson5/v2/pipeline/lookups.py
@@ -21,7 +21,6 @@ def add_meld_other_face_ids(lf: pl.LazyFrame) -> pl.LazyFrame:
     cardParts format: [front1_name, front2_name, meld_result_name]
     The 3rd element (index 2) is always the meld result.
 
-    Variant handling (fixes #1426):
     Sets like FIN have multiple variants of the same meld triplet with different
     collector numbers (e.g., 99a/100a/99b, 282a/283a/282b). We use a two-pass
     approach:
@@ -61,7 +60,6 @@ def add_meld_other_face_ids(lf: pl.LazyFrame) -> pl.LazyFrame:
     front_cards = meld_cards.filter(~pl.col("_is_result"))
     result_cards = meld_cards.filter(pl.col("_is_result"))
 
-    # === PASS 1: Number-proximity matching (for variant sets like FIN) ===
     # For FRONT faces: find result card with matching name AND adjacent number base
     front_other_ids_strict = (
         front_cards
@@ -118,7 +116,6 @@ def add_meld_other_face_ids(lf: pl.LazyFrame) -> pl.LazyFrame:
         .select(["setCode", "faceName", "_num_base", "_meld_other_uuids"])
     )
 
-    # === PASS 2: Name-only matching (fallback for non-variant sets) ===
     # For FRONT faces: find ANY result card with matching name in the set
     front_other_ids_loose = (
         front_cards


### PR DESCRIPTION
Fixes #1425, #1426, #1427 

Changes:
- Replace setCode filter with layout filter in core.py so all meld cards receive cardParts data
- Add two-pass matching in lookups.py: strict number-proximity matching for variant sets, with loose name-only fallback for non-variant sets
- Add meld_overrides.json for FIN variant mappings where Vanille cards have non-adjacent collector numbers to their Fang/Ragnarok pairs

<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
