### PR TITLE
Refactor list serialization to use JSON format instead of CSV

### DIFF
--- a/mtgjson5/v2/build/serializers.py
+++ b/mtgjson5/v2/build/serializers.py
@@ -43,16 +43,16 @@ def serialize_complex_types(df: pl.DataFrame) -> pl.DataFrame:
     if list_cols:
         for col_name in list_cols:
             result = result.with_columns(
-                pl.col(col_name).map_batches(_list_to_csv_batch, return_dtype=pl.String).alias(col_name)
+                pl.col(col_name).map_batches(_list_to_json_batch, return_dtype=pl.String).alias(col_name)
             )
 
     return result
 
 
-def _list_to_csv_batch(series: pl.Series) -> pl.Series:
-    """Batch convert list Series to comma-separated strings."""
+def _list_to_json_batch(series: pl.Series) -> pl.Series:
+    """Batch convert list Series to JSON array strings."""
     return pl.Series(
-        [", ".join(str(item) for item in x) if x is not None else None for x in series.to_list()],
+        [orjson.dumps(list(x)).decode() if x is not None else None for x in series.to_list()],
         dtype=pl.String,
     )
 


### PR DESCRIPTION
list columns now serialize as JSON arrays instead of comma-joined string
<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
