### PR TITLE
fix: remove duplicate compress_files_parallel call in --parallel mode

### DIFF
--- a/mtgjson5/compress_generator.py
+++ b/mtgjson5/compress_generator.py
@@ -569,10 +569,6 @@ def compress_mtgjson_contents_parallel(
 
     stats = compress_files_parallel(all_files, workers, streaming=streaming)
 
-    if all_files:
-        LOGGER.info(f"Compressing {len(all_files)} files")
-        stats = compress_files_parallel(all_files, workers)
-
     # Directory archives
     if set_files:
         LOGGER.info(f"Creating archive: {ALL_SETS_DIRECTORY}")


### PR DESCRIPTION
<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
