### PR TITLE
Remove reverseRelated top level from token data

### DIFF
--- a/mtgjson5/consts/fields.py
+++ b/mtgjson5/consts/fields.py
@@ -25,7 +25,6 @@ SORTED_LIST_FIELDS: Final[frozenset[str]] = frozenset(
         "printings",
         "promoTypes",
         "rebalancedPrintings",
-        "reverseRelated",
         "sourceProducts",
         "subsets",
         "variations",

--- a/mtgjson5/models/cards.py
+++ b/mtgjson5/models/cards.py
@@ -867,17 +867,6 @@ class CardToken(CardPrintingBase):
         description="The layout direction of the card. Used on [Art cards](https://mtg.wiki/page/Art_card).",
         json_schema_extra={"introduced": "v5.2.1", "optional": True},
     )
-    reverse_related: list[str] | None = Field(
-        default=None,
-        alias="reverseRelated",
-        description="The names of the cards that produce this card.",
-        json_schema_extra={
-            "introduced": "v4.0.0",
-            "optional": True,
-            "deprecated": True,
-            "deprecated_msg": "This property is deprecated. Use the [relatedCards](#relatedcards) property instead.",
-        },
-    )
     related_cards: RelatedCards | None = Field(
         default=None,
         alias="relatedCards",

--- a/mtgjson5/models/schemas.py
+++ b/mtgjson5/models/schemas.py
@@ -136,7 +136,6 @@ CARDS_TABLE_EXCLUDE: frozenset[str] = frozenset(
         "convertedManaCost",
         "orientation",
         "originalType",
-        "reverseRelated",
     }
 )
 

--- a/mtgjson5/pipeline/stages/signatures.py
+++ b/mtgjson5/pipeline/stages/signatures.py
@@ -146,4 +146,4 @@ def add_related_cards_from_context(
             )
         )
         .alias("relatedCards")
-    ).drop(["_spellbook_list", "_token_uuids"], strict=False)
+    ).drop(["_spellbook_list", "_token_uuids", "reverseRelated"], strict=False)


### PR DESCRIPTION
- Still exists as relatedCards.reverseRelated

<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
