### PR TITLE
add alternative foil/url tracking across tcgplayer and cardkingdom

### DIFF
--- a/mtgjson5/build/assemble.py
+++ b/mtgjson5/build/assemble.py
@@ -869,6 +869,7 @@ class TcgplayerSkusAssembler(Assembler):
         self._tcg_skus_lf: pl.LazyFrame | None = None
         self._tcg_to_uuid_lf: pl.LazyFrame | None = None
         self._tcg_etched_to_uuid_lf: pl.LazyFrame | None = None
+        self._tcg_alt_foil_to_uuid_lf: pl.LazyFrame | None = None
 
     def _load_tcg_data(self) -> None:
         """Load TCGPlayer SKU data, awaiting background fetch if needed."""
@@ -897,6 +898,12 @@ class TcgplayerSkusAssembler(Assembler):
         if tcg_etched_path.exists():
             self._tcg_etched_to_uuid_lf = pl.scan_parquet(tcg_etched_path)
 
+        tcg_alt_foil_path = lazy_cache / "tcg_alt_foil_to_uuid.parquet"
+        if not tcg_alt_foil_path.exists():
+            tcg_alt_foil_path = constants.CACHE_PATH / "tcg_alt_foil_to_uuid.parquet"
+        if tcg_alt_foil_path.exists():
+            self._tcg_alt_foil_to_uuid_lf = pl.scan_parquet(tcg_alt_foil_path)
+
     def build(self) -> dict[str, list[dict[str, Any]]]:
         """Build TcgplayerSkus data dict.
 
@@ -922,7 +929,11 @@ class TcgplayerSkusAssembler(Assembler):
             )
             return {}
 
-        if self._tcg_to_uuid_lf is None and self._tcg_etched_to_uuid_lf is None:
+        if (
+            self._tcg_to_uuid_lf is None
+            and self._tcg_etched_to_uuid_lf is None
+            and self._tcg_alt_foil_to_uuid_lf is None
+        ):
             LOGGER.warning("TCG to UUID mappings not found, TcgplayerSkus.json will be empty")
             return {}
 
@@ -987,6 +998,23 @@ class TcgplayerSkusAssembler(Assembler):
 
                 self._add_skus_to_result(etched_joined, result, is_etched=True)
 
+        # Alt-foil products (surge, ripple, textured, etc.)
+        if self._tcg_alt_foil_to_uuid_lf is not None:
+            tcg_alt_foil_df = self._tcg_alt_foil_to_uuid_lf.collect()
+            if "tcgplayerProductId" in tcg_alt_foil_df.columns and "uuid" in tcg_alt_foil_df.columns:
+                tcg_alt_foil_df = tcg_alt_foil_df.with_columns(
+                    pl.col("tcgplayerProductId").cast(pl.Int64).alias("productId_join")
+                )
+
+                alt_joined = flattened.join(
+                    tcg_alt_foil_df.select(["productId_join", "uuid", "foilType"]),
+                    left_on="productId",
+                    right_on="productId_join",
+                    how="inner",
+                )
+
+                self._add_skus_to_result(alt_joined, result, finish_col="foilType")
+
         # Join sealed product UUIDs
         if self.ctx.sealed_df is not None and not self.ctx.sealed_df.is_empty():
             sealed_df = self.ctx.sealed_df
@@ -1015,14 +1043,16 @@ class TcgplayerSkusAssembler(Assembler):
         self,
         joined_df: pl.DataFrame,
         result: dict[str, list[dict[str, Any]]],
-        is_etched: bool,
+        is_etched: bool = False,
+        finish_col: str | None = None,
     ) -> None:
         """Add SKUs from joined DataFrame to result dict.
 
         Args:
             joined_df: DataFrame with SKU data joined to UUIDs
             result: Result dict to populate
-            is_etched: Whether these are etched products (adds finish field)
+            is_etched: Whether these are etched products (adds finish="ETCHED")
+            finish_col: Column name containing per-row finish type (e.g. "foilType")
         """
         for row in joined_df.iter_rows(named=True):
             uuid = row.get("uuid")
@@ -1037,7 +1067,9 @@ class TcgplayerSkusAssembler(Assembler):
                 "skuId": row.get("skuId"),
             }
 
-            if is_etched:
+            if finish_col and row.get(finish_col):
+                sku_entry["finish"] = row[finish_col].upper()
+            elif is_etched:
                 sku_entry["finish"] = "ETCHED"
 
             if uuid not in result:

--- a/mtgjson5/consts/fields.py
+++ b/mtgjson5/consts/fields.py
@@ -179,9 +179,11 @@ IDENTIFIERS_FIELD_SOURCES: Final[dict[str, str | tuple[str, ...]]] = {
     "mtgoFoilId": "mtgoFoilId",
     "multiverseId": "multiverseIds[faceId]",
     "tcgplayerProductId": "tcgplayerId",
+    "tcgplayerAlternativeFoilIds": "tcgplayerAlternativeFoilIds",
     "tcgplayerEtchedProductId": "tcgplayerEtchedId",
     "cardKingdomId": "cardKingdomId",
     "cardKingdomFoilId": "cardKingdomFoilId",
+    "cardKingdomAlternativeFoilIds": "cardKingdomAlternativeFoilIds",
     "cardKingdomEtchedId": "cardKingdomEtchedId",
 }
 

--- a/mtgjson5/data/cache.py
+++ b/mtgjson5/data/cache.py
@@ -143,6 +143,7 @@ class GlobalCache:
         self.tcg_sku_map_lf: pl.LazyFrame | None = None
         self.tcg_to_uuid_lf: pl.LazyFrame | None = None
         self.tcg_etched_to_uuid_lf: pl.LazyFrame | None = None
+        self.tcg_alt_foil_to_uuid_lf: pl.LazyFrame | None = None
         self.mtgo_to_uuid_lf: pl.LazyFrame | None = None
         self.scryfall_to_uuid_lf: pl.LazyFrame | None = None
         self.cardmarket_to_uuid_lf: pl.LazyFrame | None = None
@@ -241,6 +242,7 @@ class GlobalCache:
             "tcg_sku_map_lf",
             "tcg_to_uuid_lf",
             "tcg_etched_to_uuid_lf",
+            "tcg_alt_foil_to_uuid_lf",
             "mtgo_to_uuid_lf",
             "scryfall_to_uuid_lf",
             "cardmarket_to_uuid_lf",
@@ -395,6 +397,7 @@ class GlobalCache:
             "tcg_sku_map_lf": "tcg_sku_map.parquet",
             "tcg_to_uuid_lf": "tcg_to_uuid.parquet",
             "tcg_etched_to_uuid_lf": "tcg_etched_to_uuid.parquet",
+            "tcg_alt_foil_to_uuid_lf": "tcg_alt_foil_to_uuid.parquet",
             "mtgo_to_uuid_lf": "mtgo_to_uuid.parquet",
             "scryfall_to_uuid_lf": "scryfall_to_uuid.parquet",
             "cardmarket_to_uuid_lf": "cardmarket_to_uuid.parquet",
@@ -615,6 +618,11 @@ class GlobalCache:
         if tcg_etched_path.exists():
             self.tcg_etched_to_uuid_lf = pl.scan_parquet(tcg_etched_path)
             LOGGER.info("Loaded tcg_etched_to_uuid mapping from cache")
+
+        tcg_alt_foil_path = self.cache_path / "tcg_alt_foil_to_uuid.parquet"
+        if tcg_alt_foil_path.exists():
+            self.tcg_alt_foil_to_uuid_lf = pl.scan_parquet(tcg_alt_foil_path)
+            LOGGER.info("Loaded tcg_alt_foil_to_uuid mapping from cache")
 
         mtgo_path = self.cache_path / "mtgo_to_uuid.parquet"
         if mtgo_path.exists():

--- a/mtgjson5/data/context.py
+++ b/mtgjson5/data/context.py
@@ -49,6 +49,7 @@ class PipelineContext:
     scryfall_id_filter: set[str] | None = None
 
     identifiers_lf: pl.LazyFrame | None = None
+    tcg_alt_foil_lf: pl.LazyFrame | None = None
     oracle_data_lf: pl.LazyFrame | None = None
     set_number_lf: pl.LazyFrame | None = None
     name_lf: pl.LazyFrame | None = None
@@ -527,6 +528,7 @@ class PipelineContext:
         self._load_face_flavor_names()
         self._build_mcm_set_map()
         self._build_mcm_lookup()
+        self._build_tcg_alt_foil_lookup()
 
         return self
 
@@ -562,17 +564,21 @@ class PipelineContext:
             else:
                 ck = ck_raw
             if ck.height > 0:
-                ck = ck.rename({"id": "scryfallId"}).select(
-                    [
-                        "scryfallId",
-                        "cardKingdomId",
-                        "cardKingdomFoilId",
-                        "cardKingdomEtchedId",
-                        "cardKingdomUrl",
-                        "cardKingdomFoilUrl",
-                        "cardKingdomEtchedUrl",
-                    ]
-                )
+                ck = ck.rename({"id": "scryfallId"})
+                ck_cols = [
+                    "scryfallId",
+                    "cardKingdomId",
+                    "cardKingdomFoilId",
+                    "cardKingdomEtchedId",
+                    "cardKingdomUrl",
+                    "cardKingdomFoilUrl",
+                    "cardKingdomEtchedUrl",
+                    "cardKingdomAlternativeFoilIds",
+                    "cardKingdomAlternativeFoilUrls",
+                ]
+                # Only select columns that exist (alt-foil cols may be absent in older data)
+                ck_cols = [c for c in ck_cols if c in ck.columns]
+                ck = ck.select(ck_cols)
                 # Full join: keep all uuid_cache cards AND all CK-only cards
                 result = result.join(ck, on="scryfallId", how="full", coalesce=True)
                 LOGGER.info(f"identifiers: +card_kingdom ({ck.height:,} rows)")
@@ -1209,3 +1215,153 @@ class PipelineContext:
                 self.mcm_set_map[new_name.lower()] = raw_map.pop(old_key)
 
         self.mcm_set_map.update(raw_map)
+
+    def _build_tcg_alt_foil_lookup(self) -> None:
+        """
+        Build TCGPlayer alternative foil product ID mapping.
+
+        Matches alt-foil products (e.g. "Card Name (Surge Foil)")
+        to base products by stripping the foil suffix and matching
+        within the same TCGPlayer group (set).
+
+        Result: tcg_alt_foil_lf with columns:
+            - tcgplayerProductId (base product, string)
+            - tcgplayerAlternativeFoilIds (JSON string: {"surge": "12345", ...})
+        """
+        # Await background TCG fetch if still running
+        if self._cache is not None:
+            self._cache._await_tcg_skus()
+
+        tcg_skus = self.tcg_skus_lf
+        if tcg_skus is None:
+            LOGGER.info("tcg_alt_foil: No TCG SKU data available, skipping")
+            return
+
+        try:
+            schema = tcg_skus.collect_schema()
+        except Exception:
+            LOGGER.info("tcg_alt_foil: Cannot read TCG schema, skipping")
+            return
+
+        required = {"productId", "name", "groupId"}
+        if not required.issubset(set(schema.names())):
+            LOGGER.info(f"tcg_alt_foil: Missing columns {required - set(schema.names())}, skipping")
+            return
+
+        products = tcg_skus.select(["productId", "name", "groupId"]).collect()
+
+        if products.is_empty():
+            LOGGER.info("tcg_alt_foil: TCG products empty, skipping")
+            return
+
+        # Heuristic: detect trailing parenthetical containing "Foil" or "Etched"
+        # e.g. "Card Name (Surge Foil)" or "Card Name (Etched)"
+        foil_suffix_expr = pl.col("name").str.extract(r"\(([^)]*(?:Foil|Etched)[^)]*)\)\s*$", 1)
+
+        products = products.with_columns(
+            [
+                foil_suffix_expr.alias("_foil_suffix"),
+                # Strip trailing parenthetical to get the base product name
+                pl.col("name").str.replace(r"\s*\([^)]*(?:Foil|Etched)[^)]*\)\s*$", "").alias("_baseName"),
+            ]
+        )
+
+        # Split into alt-foil products (have suffix) and base products (no suffix)
+        alt_products = products.filter(pl.col("_foil_suffix").is_not_null())
+
+        if alt_products.is_empty():
+            LOGGER.info("tcg_alt_foil: No alternative foil products found")
+            return
+
+        # Normalize foil type: "Surge Foil" → "surge", "Foil Etched" → "etched", "Etched" → "etched"
+        alt_products = alt_products.with_columns(
+            pl.col("_foil_suffix")
+            .str.replace(r"(?i)\bFoil\b", "")  # remove "Foil"
+            .str.strip_chars()  # trim whitespace
+            .str.to_lowercase()
+            .alias("_foilType")
+        )
+
+        base_products = products.filter(pl.col("_foil_suffix").is_null()).select(
+            [
+                pl.col("productId").alias("_baseProductId"),
+                pl.col("name").alias("_baseProductName"),
+                pl.col("groupId").alias("_baseGroupId"),
+            ]
+        )
+
+        # Join alt-foil products to base products by (groupId, baseName == base name)
+        matched = alt_products.join(
+            base_products,
+            left_on=["groupId", "_baseName"],
+            right_on=["_baseGroupId", "_baseProductName"],
+            how="inner",
+        )
+
+        if matched.is_empty():
+            LOGGER.info("tcg_alt_foil: No alt-foil products matched to base products")
+            return
+
+        # Build JSON dicts per base product: {"surge": "alt_id", ...}
+        # Vectorized: build key-value pair strings, then aggregate
+        deduped = matched.unique(subset=["_baseProductId", "_foilType"], keep="last")
+
+        # Build IDs JSON dict
+        ids_df = (
+            deduped.with_columns(
+                pl.concat_str(
+                    [
+                        pl.lit('"'),
+                        pl.col("_foilType"),
+                        pl.lit('":"'),
+                        pl.col("productId").cast(pl.String),
+                        pl.lit('"'),
+                    ]
+                ).alias("_kv_pair")
+            )
+            .group_by("_baseProductId")
+            .agg(pl.col("_kv_pair").str.join(",").alias("_json_inner"))
+            .with_columns(
+                pl.concat_str([pl.lit("{"), pl.col("_json_inner"), pl.lit("}")])
+                .alias("tcgplayerAlternativeFoilIds")
+            )
+            .select(["_baseProductId", "tcgplayerAlternativeFoilIds"])
+        )
+
+        # Build purchase URLs JSON dict (TCG affiliate format)
+        tcg_url_prefix = (
+            "https://partner.tcgplayer.com/c/4948039/1780961/21018"
+            "?subId1=api&u=https%3A%2F%2Fwww.tcgplayer.com%2Fproduct%2F"
+        )
+        tcg_url_suffix = "%3Fpage%3D1"
+        urls_df = (
+            deduped.with_columns(
+                pl.concat_str(
+                    [
+                        pl.lit('"'),
+                        pl.col("_foilType"),
+                        pl.lit('":"'),
+                        pl.lit(tcg_url_prefix),
+                        pl.col("productId").cast(pl.String),
+                        pl.lit(tcg_url_suffix),
+                        pl.lit('"'),
+                    ]
+                ).alias("_kv_pair")
+            )
+            .group_by("_baseProductId")
+            .agg(pl.col("_kv_pair").str.join(",").alias("_json_inner"))
+            .with_columns(
+                pl.concat_str([pl.lit("{"), pl.col("_json_inner"), pl.lit("}")])
+                .alias("tcgplayerAlternativeFoilUrls")
+            )
+            .select(["_baseProductId", "tcgplayerAlternativeFoilUrls"])
+        )
+
+        result = (
+            ids_df.join(urls_df, on="_baseProductId", how="left")
+            .with_columns(pl.col("_baseProductId").cast(pl.String).alias("tcgplayerProductId"))
+            .select(["tcgplayerProductId", "tcgplayerAlternativeFoilIds", "tcgplayerAlternativeFoilUrls"])
+        )
+
+        self.tcg_alt_foil_lf = result.lazy()
+        LOGGER.info(f"tcg_alt_foil: Built mapping for {result.height:,} base products")

--- a/mtgjson5/data/context.py
+++ b/mtgjson5/data/context.py
@@ -1322,8 +1322,7 @@ class PipelineContext:
             .group_by("_baseProductId")
             .agg(pl.col("_kv_pair").str.join(",").alias("_json_inner"))
             .with_columns(
-                pl.concat_str([pl.lit("{"), pl.col("_json_inner"), pl.lit("}")])
-                .alias("tcgplayerAlternativeFoilIds")
+                pl.concat_str([pl.lit("{"), pl.col("_json_inner"), pl.lit("}")]).alias("tcgplayerAlternativeFoilIds")
             )
             .select(["_baseProductId", "tcgplayerAlternativeFoilIds"])
         )
@@ -1351,8 +1350,7 @@ class PipelineContext:
             .group_by("_baseProductId")
             .agg(pl.col("_kv_pair").str.join(",").alias("_json_inner"))
             .with_columns(
-                pl.concat_str([pl.lit("{"), pl.col("_json_inner"), pl.lit("}")])
-                .alias("tcgplayerAlternativeFoilUrls")
+                pl.concat_str([pl.lit("{"), pl.col("_json_inner"), pl.lit("}")]).alias("tcgplayerAlternativeFoilUrls")
             )
             .select(["_baseProductId", "tcgplayerAlternativeFoilUrls"])
         )

--- a/mtgjson5/models/base.py
+++ b/mtgjson5/models/base.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import pathlib
 from typing import TYPE_CHECKING, Any, ClassVar, Self, get_args, get_origin
 
+import orjson
 from pydantic import BaseModel
 
 from mtgjson5.consts import (
@@ -176,7 +177,18 @@ class PolarsMixin:
                 if key in ("legalities", "purchaseUrls") and not value:
                     result[key] = {}
                 elif value or field_name in cls._allow_if_falsey or not exclude_none:
-                    result[key] = dict(sorted(value.items())) if sort_keys else value
+                    # Parse JSON-encoded dict strings (e.g. alternative foil IDs
+                    # stored as '{"etched":"12345"}' in Polars structs)
+                    resolved = {}
+                    for dk, dv in value.items():
+                        if isinstance(dv, str) and dv.startswith("{") and dv.endswith("}"):
+                            try:
+                                resolved[dk] = orjson.loads(dv)
+                            except Exception:
+                                resolved[dk] = dv
+                        else:
+                            resolved[dk] = dv
+                    result[key] = dict(sorted(resolved.items())) if sort_keys else resolved
             elif isinstance(value, list):
                 if not value and exclude_none and key in OMIT_EMPTY_LIST_FIELDS and not keep_empty_lists:
                     continue
@@ -275,11 +287,12 @@ class PolarsMixin:
                 if isinstance(annotation, type) and issubclass(annotation, BaseModel):
                     result[field_name] = cls._from_row_recursive(value, annotation)
                 elif TypedDictUtils.is_typeddict(annotation):
-                    result[field_name] = TypedDictUtils.apply_aliases(
+                    processed = TypedDictUtils.apply_aliases(
                         annotation,  # type: ignore[arg-type]
                         value,
                         TYPEDDICT_FIELD_ALIASES,
                     )
+                    result[field_name] = processed
                 else:
                     result[field_name] = value
             elif isinstance(value, list) and value and isinstance(value[0], dict):

--- a/mtgjson5/models/base.py
+++ b/mtgjson5/models/base.py
@@ -34,11 +34,6 @@ except ImportError:
     POLARS_AVAILABLE = False
     pl = None  # type: ignore
 
-try:
-    import orjson
-except ImportError:
-    orjson = None  # type: ignore
-
 
 class PolarsMixin:
     """Mixin providing Polars DataFrame serialization for Pydantic models."""

--- a/mtgjson5/models/submodels.py
+++ b/mtgjson5/models/submodels.py
@@ -106,9 +106,16 @@ class Identifiers(TypedDict, total=False):
             "introduced": "v5.2.2",
             "optional": True,
         },
+        "cardKingdomAlternativeFoilIds": {
+            "description": "A mapping of alternative foil types to their [Card Kingdom](https://www.cardkingdom.com/?partner=mtgjson&utm_source=mtgjson&utm_medium=affiliate&utm_campaign=mtgjson) identifiers. Keys are foil type names (e.g. `etched`, `surge`, `rainbow`).",
+            "introduced": "v5.3.0",
+            "optional": True,
+            "type_override": "Record<string, string>",
+        },
         "cardKingdomEtchedId": {
             "description": "The [Card Kingdom](https://www.cardkingdom.com/?partner=mtgjson&utm_source=mtgjson&utm_medium=affiliate&utm_campaign=mtgjson) etched card identifier.",
             "introduced": "v5.2.0",
+            "deprecated": "v5.4.0",
             "optional": True,
         },
         "cardKingdomFoilId": {
@@ -221,9 +228,16 @@ class Identifiers(TypedDict, total=False):
             "introduced": "v4.2.1",
             "optional": True,
         },
+        "tcgplayerAlternativeFoilIds": {
+            "description": "A mapping of alternative foil types to their [TCGplayer](https://www.tcgplayer.com?partner=mtgjson&utm_campaign=affiliate&utm_medium=mtgjson&utm_source=mtgjson) product identifiers. Keys are foil type names (e.g. `etched`, `surge`, `rainbow`).",
+            "introduced": "v5.3.0",
+            "optional": True,
+            "type_override": "Record<string, string>",
+        },
         "tcgplayerEtchedProductId": {
             "description": "The [TCGplayer](https://www.tcgplayer.com?partner=mtgjson&utm_campaign=affiliate&utm_medium=mtgjson&utm_source=mtgjson) etched card identifier.",
             "introduced": "v5.2.0",
+            "deprecated": "v5.4.0",
             "optional": True,
         },
         "tntId": {
@@ -242,7 +256,8 @@ class Identifiers(TypedDict, total=False):
     scgId: str
     tntId: str
     # Card identifiers
-    cardKingdomEtchedId: str
+    cardKingdomAlternativeFoilIds: str | dict[str, str]  # {"etched": "abc", "surge": "def"}
+    cardKingdomEtchedId: str  # Deprecated v5.4.0 — use cardKingdomAlternativeFoilIds
     cardKingdomFoilId: str
     cardKingdomId: str
     cardsphereId: str
@@ -261,7 +276,8 @@ class Identifiers(TypedDict, total=False):
     scryfallCardBackId: str
     scryfallIllustrationId: str
     scryfallOracleId: str
-    tcgplayerEtchedProductId: str
+    tcgplayerAlternativeFoilIds: str | dict[str, str]  # {"etched": "12345", "surge": "67890"}
+    tcgplayerEtchedProductId: str  # Deprecated v5.4.0 — use tcgplayerAlternativeFoilIds
     tcgplayerProductId: str
 
 
@@ -475,9 +491,16 @@ class PurchaseUrls(TypedDict, total=False):
             "introduced": "v5.0.0",
             "optional": True,
         },
+        "cardKingdomAlternativeFoilUrls": {
+            "description": "A mapping of alternative foil types to their purchase URLs on [Card Kingdom](https://www.cardkingdom.com?partner=mtgjson&utm_source=mtgjson&utm_medium=affiliate&utm_campaign=mtgjson). Keys are foil type names (e.g. `etched`, `surge`, `rainbow`).",
+            "introduced": "v5.3.0",
+            "optional": True,
+            "type_override": "Record<string, string>",
+        },
         "cardKingdomEtched": {
             "description": "The URL to purchase an etched product on [Card Kingdom](https://www.cardkingdom.com?partner=mtgjson&utm_source=mtgjson&utm_medium=affiliate&utm_campaign=mtgjson).",
             "introduced": "v5.2.0",
+            "deprecated": "v5.4.0",
             "optional": True,
         },
         "cardKingdomFoil": {
@@ -495,19 +518,28 @@ class PurchaseUrls(TypedDict, total=False):
             "introduced": "v4.4.0",
             "optional": True,
         },
+        "tcgplayerAlternativeFoilUrls": {
+            "description": "A mapping of alternative foil types to their purchase URLs on [TCGplayer](https://www.tcgplayer.com?partner=mtgjson&utm_campaign=affiliate&utm_medium=mtgjson&utm_source=mtgjson). Keys are foil type names (e.g. `etched`, `surge`, `rainbow`).",
+            "introduced": "v5.3.0",
+            "optional": True,
+            "type_override": "Record<string, string>",
+        },
         "tcgplayerEtched": {
             "description": "The URL to purchase an etched product on [TCGplayer](https://www.tcgplayer.com?partner=mtgjson&utm_campaign=affiliate&utm_medium=mtgjson&utm_source=mtgjson).",
             "introduced": "v5.2.0",
+            "deprecated": "v5.4.0",
             "optional": True,
         },
     }
 
     cardKingdom: str
-    cardKingdomEtched: str
+    cardKingdomAlternativeFoilUrls: str | dict[str, str]  # redirect URLs per foil type
+    cardKingdomEtched: str  # Deprecated v5.4.0 — use cardKingdomAlternativeFoilUrls
     cardKingdomFoil: str
     cardmarket: str
     tcgplayer: str
-    tcgplayerEtched: str
+    tcgplayerAlternativeFoilUrls: str | dict[str, str]  # redirect URLs per foil type
+    tcgplayerEtched: str  # Deprecated v5.4.0 — use tcgplayerAlternativeFoilUrls
 
 
 class RelatedCards(TypedDict, total=False):

--- a/mtgjson5/pipeline/core.py
+++ b/mtgjson5/pipeline/core.py
@@ -56,6 +56,7 @@ from mtgjson5.pipeline.stages.identifiers import (
     join_name_data,
     join_oracle_data,
     join_set_number_data,
+    join_tcg_alt_foil_lookup,
 )
 from mtgjson5.pipeline.stages.legalities import (
     add_availability_struct,
@@ -240,6 +241,7 @@ def build_cards(ctx: PipelineContext) -> PipelineContext:
 
     lf = (
         lf.pipe(partial(join_identifiers, ctx=ctx))
+        .pipe(partial(join_tcg_alt_foil_lookup, ctx=ctx))
         .pipe(partial(join_oracle_data, ctx=ctx))
         .pipe(partial(join_set_number_data, ctx=ctx))
         .pipe(fix_foreigndata_for_faces, ctx=ctx)

--- a/mtgjson5/pipeline/stages/derived.py
+++ b/mtgjson5/pipeline/stages/derived.py
@@ -155,14 +155,15 @@ def add_purchase_urls_struct(
                     .then(pl.lit(redirect_base) + pl.col("_ck_hash"))
                     .otherwise(None)
                     .alias("cardKingdom"),
-                    pl.when(ckf_url.is_not_null())
-                    .then(pl.lit(redirect_base) + pl.col("_ckf_hash"))
-                    .otherwise(None)
-                    .alias("cardKingdomFoil"),
+                    pl.col("cardKingdomAlternativeFoilUrls"),
                     pl.when(cke_url.is_not_null())
                     .then(pl.lit(redirect_base) + pl.col("_cke_hash"))
                     .otherwise(None)
                     .alias("cardKingdomEtched"),
+                    pl.when(ckf_url.is_not_null())
+                    .then(pl.lit(redirect_base) + pl.col("_ckf_hash"))
+                    .otherwise(None)
+                    .alias("cardKingdomFoil"),
                     pl.when(mcm_id.is_not_null())
                     .then(pl.lit(redirect_base) + pl.col("_cm_hash"))
                     .otherwise(None)
@@ -171,6 +172,7 @@ def add_purchase_urls_struct(
                     .then(pl.lit(redirect_base) + pl.col("_tcg_hash"))
                     .otherwise(None)
                     .alias("tcgplayer"),
+                    pl.col("tcgplayerAlternativeFoilUrls"),
                     pl.when(tcge_id.is_not_null())
                     .then(pl.lit(redirect_base) + pl.col("_tcge_hash"))
                     .otherwise(None)

--- a/mtgjson5/pipeline/stages/identifiers.py
+++ b/mtgjson5/pipeline/stages/identifiers.py
@@ -302,12 +302,16 @@ def join_tcg_alt_foil_lookup(
         )
 
     # tcgplayerId is i64 in pipeline, tcgplayerProductId is str in lookup
-    lf = lf.with_columns(pl.col("tcgplayerId").cast(pl.String).alias("_tcg_id_str")).join(
-        ctx.tcg_alt_foil_lf,
-        left_on="_tcg_id_str",
-        right_on="tcgplayerProductId",
-        how="left",
-    ).drop("_tcg_id_str")
+    lf = (
+        lf.with_columns(pl.col("tcgplayerId").cast(pl.String).alias("_tcg_id_str"))
+        .join(
+            ctx.tcg_alt_foil_lf,
+            left_on="_tcg_id_str",
+            right_on="tcgplayerProductId",
+            how="left",
+        )
+        .drop("_tcg_id_str")
+    )
 
     return lf
 

--- a/mtgjson5/pipeline/stages/output.py
+++ b/mtgjson5/pipeline/stages/output.py
@@ -449,8 +449,7 @@ def _build_alt_foil_id_mapping(
     import orjson
 
     alt_df = combined_df.select(["uuid", json_dict_field]).filter(
-        pl.col(json_dict_field).is_not_null()
-        & (pl.col(json_dict_field) != "")
+        pl.col(json_dict_field).is_not_null() & (pl.col(json_dict_field) != "")
     )
     if alt_df.is_empty():
         return
@@ -464,9 +463,7 @@ def _build_alt_foil_id_mapping(
             if isinstance(parsed, dict):
                 for foil_type, product_id in parsed.items():
                     if product_id:
-                        rows.append(
-                            {"tcgplayerProductId": str(product_id), "foilType": foil_type, "uuid": uuid_val}
-                        )
+                        rows.append({"tcgplayerProductId": str(product_id), "foilType": foil_type, "uuid": uuid_val})
         except Exception:
             continue
 

--- a/mtgjson5/providers/cardkingdom/transformer.py
+++ b/mtgjson5/providers/cardkingdom/transformer.py
@@ -71,10 +71,7 @@ def _build_alt_foil_json(
         )
         .group_by("scryfall_id")
         .agg(pl.col("_kv_pair").str.join(",").alias("_json_inner"))
-        .with_columns(
-            pl.concat_str([pl.lit("{"), pl.col("_json_inner"), pl.lit("}")])
-            .alias(out_col)
-        )
+        .with_columns(pl.concat_str([pl.lit("{"), pl.col("_json_inner"), pl.lit("}")]).alias(out_col))
         .select(["scryfall_id", out_col])
     )
     return exploded

--- a/mtgjson5/providers/cardkingdom/transformer.py
+++ b/mtgjson5/providers/cardkingdom/transformer.py
@@ -19,6 +19,67 @@ def parse_price(price_str: str | None) -> float | None:
         return None
 
 
+# Polars expression to dynamically extract alternative foil type from CK variation.
+# Handles two patterns:
+#   "Foil Etched" → "etched"  (Foil {Type})
+#   "Surge Foil"  → "surge"   ({Type} Foil)
+# Returns null for plain foil/non-foil.
+_ALT_FOIL_TYPE_EXPR = (
+    pl.coalesce(
+        pl.col("variation").str.extract(r"Foil\s+(\w+)", 1),  # "Foil Etched" → "Etched"
+        pl.col("variation").str.extract(r"(\w+)\s+Foil", 1),  # "Surge Foil" → "Surge"
+    )
+    .str.to_lowercase()
+    .alias("altFoilType")
+)
+
+
+def _build_alt_foil_json(
+    df: pl.DataFrame,
+    value_col: str,
+    out_col: str,
+    value_prefix: str = "",
+    value_suffix: str = "",
+) -> pl.DataFrame:
+    """
+    Build JSON dict strings from altFoilType + value column, grouped by scryfall_id.
+
+    E.g., {"etched": "12345", "surge": "67890"}
+
+    Args:
+        value_prefix: Prepended to each value (e.g. URL base for purchase URLs)
+        value_suffix: Appended to each value (e.g. referral code)
+
+    Pure vectorized Polars — no map_elements.
+    """
+    exploded = (
+        df.filter(pl.col("scryfall_id").is_not_null() & pl.col("altFoilType").is_not_null())
+        .sort("id")
+        .unique(subset=["scryfall_id", "altFoilType"], keep="last")
+        .with_columns(
+            pl.concat_str(
+                [
+                    pl.lit('"'),
+                    pl.col("altFoilType"),
+                    pl.lit('":"'),
+                    pl.lit(value_prefix),
+                    pl.col(value_col).cast(pl.String),
+                    pl.lit(value_suffix),
+                    pl.lit('"'),
+                ]
+            ).alias("_kv_pair")
+        )
+        .group_by("scryfall_id")
+        .agg(pl.col("_kv_pair").str.join(",").alias("_json_inner"))
+        .with_columns(
+            pl.concat_str([pl.lit("{"), pl.col("_json_inner"), pl.lit("}")])
+            .alias(out_col)
+        )
+        .select(["scryfall_id", out_col])
+    )
+    return exploded
+
+
 class CardKingdomTransformer:
     """
     Transforms raw CK API records into normalized DataFrames.
@@ -74,37 +135,39 @@ class CardKingdomTransformer:
     @staticmethod
     def add_derived_columns(df: pl.DataFrame) -> pl.DataFrame:
         """
-        Add derived columns for foil/etched detection.
+        Add derived columns for foil/etched/alt-foil detection.
 
-        - is_foil_bool: True if is_foil == 'true' (don't use SKU - set codes like FDN start with F)
-        - is_etched: True if variation contains 'Foil Etched'
+        - is_foil_bool: True if is_foil == 'true'
+        - is_etched: True if variation contains 'Foil Etched' (backward compat)
+        - altFoilType: Dynamically detected foil type (e.g. "etched", "surge", "rainbow")
         """
         return df.with_columns(
             [
                 (pl.col("is_foil").str.to_lowercase() == "true").alias("is_foil_bool"),
                 pl.col("variation").fill_null("").str.contains("Foil Etched").alias("is_etched"),
+                _ALT_FOIL_TYPE_EXPR,
             ]
         )
 
     @staticmethod
     def pivot_by_scryfall_id(df: pl.DataFrame) -> pl.DataFrame:
         """
-        Pivot to one row per scryfall_id with foil/non-foil/etched columns.
+        Pivot to one row per scryfall_id with foil/non-foil/etched/alt-foil columns.
 
         Output columns:
         - id (scryfall_id renamed for joins)
-        - cardKingdomId (non-foil CK product ID)
-        - cardKingdomUrl (non-foil URL path)
-        - cardKingdomFoilId (foil CK product ID)
-        - cardKingdomFoilUrl (foil URL path)
-        - cardKingdomEtchedId (etched CK product ID)
-        - cardKingdomEtchedUrl (etched URL path)
+        - cardKingdomId, cardKingdomUrl (non-foil)
+        - cardKingdomFoilId, cardKingdomFoilUrl (standard foil)
+        - cardKingdomEtchedId, cardKingdomEtchedUrl (deprecated, backfilled)
+        - cardKingdomAlternativeFoilIds (JSON dict)
+        - cardKingdomAlternativeFoilUrls (JSON dict)
 
         Cards without scryfall_id are excluded.
         """
         df_with_flags = CardKingdomTransformer.add_derived_columns(df)
 
-        return (
+        # Standard pivot for non-foil, foil, etched (backward compat)
+        pivoted = (
             df_with_flags.filter(pl.col("scryfall_id").is_not_null())
             .sort("id")
             .group_by("scryfall_id")
@@ -129,8 +192,22 @@ class CardKingdomTransformer:
                     pl.col("url").filter(pl.col("is_etched")).last().alias("cardKingdomEtchedUrl"),
                 ]
             )
-            .rename({"scryfall_id": "id"})
         )
+
+        # Build alternative foil JSON dicts (vectorized, no map_elements)
+        alt_ids_df = _build_alt_foil_json(df_with_flags, "id", "cardKingdomAlternativeFoilIds")
+        alt_urls_df = _build_alt_foil_json(
+            df_with_flags,
+            "url",
+            "cardKingdomAlternativeFoilUrls",
+            value_prefix="https://www.cardkingdom.com/",
+            value_suffix="?partner=mtgjson&utm_source=mtgjson&utm_medium=affiliate&utm_campaign=mtgjson",
+        )
+
+        pivoted = pivoted.join(alt_ids_df, on="scryfall_id", how="left")
+        pivoted = pivoted.join(alt_urls_df, on="scryfall_id", how="left")
+
+        return pivoted.rename({"scryfall_id": "id"})
 
     @staticmethod
     def to_pricing_df(df: pl.DataFrame) -> pl.DataFrame:


### PR DESCRIPTION
Introduces support for tracking alternative foil product IDs (etched, rainbow, surge, confetti, etc.) as dynamic Dict[str, int|str] fields on Identifiers and PurchaseUrls, replacing the single-foil etched fields deprecated in v5.4.0.

Models & Schema

Add tcgplayerAlternativeFoilIds, tcgplayerAlternativeFoilUrls, cardKingdomAlternativeFoilIds, cardKingdomAlternativeFoilUrls to Identifiers and PurchaseUrls submodels
Register new fields in IDENTIFIERS_FIELD_SOURCES
Handle JSON-encoded dict strings during serialization in _to_dict_recursive

Card Kingdom Provider

Extract foil types dynamically from variation fields via regex
Join alternative foil JSON dicts into pivot output

TCGPlayer Alternative Foil Lookup

New _build_tcg_alt_foil_lookup() in pipeline context: heuristic name-matching of alt-foil products (e.g. "Card Name (Surge Foil)") to base products by (groupId, baseName), producing JSON dicts for IDs and URLs
CK column passthrough with existence guards

Pipeline Stages

Wire join_tcg_alt_foil_lookup into the build pipeline
Add alt-foil fields to identifiers struct with Scryfall etched fallback
Add alt-foil URL fields to purchaseUrls struct
New _build_alt_foil_id_mapping(): parse JSON dicts into flat (productId, foilType, uuid) parquet for downstream consumers

Cache & Assembly

Add tcg_alt_foil_to_uuid_lf to cache init/attrs/dump/load
SKU assembler loads alt-foil mapping and joins by productId with dynamic foilType finish column<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
