### PR TITLE
Redo tcgplayer alternative foil

### DIFF
--- a/mtgjson5/build/referral_builder.py
+++ b/mtgjson5/build/referral_builder.py
@@ -287,8 +287,8 @@ def _build_tcg_entries_from_parquet(parquet_dir: Path | None) -> pl.DataFrame | 
             entries.append(tcge_df)
 
     # TCGPlayer alternative foil entries
-    if "tcgplayerAlternativeFoilId" in id_fields:
-        tcga_id = pl.col("identifiers").struct.field("tcgplayerAlternativeFoilId")
+    if "tcgplayerAlternativeFoilProductId" in id_fields:
+        tcga_id = pl.col("identifiers").struct.field("tcgplayerAlternativeFoilProductId")
         tcga_df = (
             cards_lf.select(["uuid", "identifiers"])
             .filter(tcga_id.is_not_null())

--- a/mtgjson5/build/referral_builder.py
+++ b/mtgjson5/build/referral_builder.py
@@ -286,6 +286,37 @@ def _build_tcg_entries_from_parquet(parquet_dir: Path | None) -> pl.DataFrame | 
         if len(tcge_df) > 0:
             entries.append(tcge_df)
 
+    # TCGPlayer alternative foil entries
+    if "tcgplayerAlternativeFoilId" in id_fields:
+        tcga_id = pl.col("identifiers").struct.field("tcgplayerAlternativeFoilId")
+        tcga_df = (
+            cards_lf.select(["uuid", "identifiers"])
+            .filter(tcga_id.is_not_null())
+            .with_columns(
+                [
+                    plh.concat_str([tcga_id.cast(pl.String), pl.col("uuid")])
+                    .chash.sha2_256()
+                    .str.slice(0, 16)
+                    .alias("hash"),
+                    tcga_id.cast(pl.String).alias("_tcg_id"),
+                ]
+            )
+            .with_columns(
+                plh.concat_str(
+                    [
+                        pl.lit(TCG_REFERRAL_PREFIX),
+                        pl.col("_tcg_id"),
+                        pl.lit(TCG_REFERRAL_SUFFIX),
+                    ]
+                ).alias("referral_url")
+            )
+            .select(["hash", "referral_url"])
+            .unique(subset=["hash"])
+            .collect()
+        )
+        if len(tcga_df) > 0:
+            entries.append(tcga_df)
+
     if not entries:
         return None
 

--- a/mtgjson5/consts/fields.py
+++ b/mtgjson5/consts/fields.py
@@ -180,7 +180,7 @@ IDENTIFIERS_FIELD_SOURCES: Final[dict[str, str | tuple[str, ...]]] = {
     "multiverseId": "multiverseIds[faceId]",
     "tcgplayerProductId": "tcgplayerId",
     "tcgplayerEtchedProductId": "tcgplayerEtchedId",
-    "tcgplayerAlternativeFoilId": "tcgplayerAlternativeFoilId",
+    "tcgplayerAlternativeFoilProductId": "tcgplayerAlternativeFoilProductId",
     "cardKingdomId": "cardKingdomId",
     "cardKingdomFoilId": "cardKingdomFoilId",
     "cardKingdomEtchedId": "cardKingdomEtchedId",
@@ -224,6 +224,6 @@ SCRYFALL_COLUMNS_TO_DROP = [
     "mtgoFoilId",  # -> identifiers.mtgoFoilId
     "tcgplayerId",  # -> identifiers.tcgplayerProductId
     "tcgplayerEtchedId",  # -> identifiers.tcgplayerEtchedProductId
-    "tcgplayerAlternativeFoilId",  # -> identifiers.tcgplayerAlternativeFoilId
+    "tcgplayerAlternativeFoilProductId",  # -> identifiers.tcgplayerAlternativeFoilProductId
     "_meld_face_name",  # temp column for meld card faceName assignment
 ]

--- a/mtgjson5/consts/fields.py
+++ b/mtgjson5/consts/fields.py
@@ -180,6 +180,7 @@ IDENTIFIERS_FIELD_SOURCES: Final[dict[str, str | tuple[str, ...]]] = {
     "multiverseId": "multiverseIds[faceId]",
     "tcgplayerProductId": "tcgplayerId",
     "tcgplayerEtchedProductId": "tcgplayerEtchedId",
+    "tcgplayerAlternativeFoilId": "tcgplayerAlternativeFoilId",
     "cardKingdomId": "cardKingdomId",
     "cardKingdomFoilId": "cardKingdomFoilId",
     "cardKingdomEtchedId": "cardKingdomEtchedId",
@@ -223,5 +224,6 @@ SCRYFALL_COLUMNS_TO_DROP = [
     "mtgoFoilId",  # -> identifiers.mtgoFoilId
     "tcgplayerId",  # -> identifiers.tcgplayerProductId
     "tcgplayerEtchedId",  # -> identifiers.tcgplayerEtchedProductId
+    "tcgplayerAlternativeFoilId",  # -> identifiers.tcgplayerAlternativeFoilId
     "_meld_face_name",  # temp column for meld card faceName assignment
 ]

--- a/mtgjson5/data/cache.py
+++ b/mtgjson5/data/cache.py
@@ -143,6 +143,7 @@ class GlobalCache:
         self.tcg_sku_map_lf: pl.LazyFrame | None = None
         self.tcg_to_uuid_lf: pl.LazyFrame | None = None
         self.tcg_etched_to_uuid_lf: pl.LazyFrame | None = None
+        self.tcg_alt_foil_to_uuid_lf: pl.LazyFrame | None = None
         self.mtgo_to_uuid_lf: pl.LazyFrame | None = None
         self.scryfall_to_uuid_lf: pl.LazyFrame | None = None
         self.cardmarket_to_uuid_lf: pl.LazyFrame | None = None
@@ -241,6 +242,7 @@ class GlobalCache:
             "tcg_sku_map_lf",
             "tcg_to_uuid_lf",
             "tcg_etched_to_uuid_lf",
+            "tcg_alt_foil_to_uuid_lf",
             "mtgo_to_uuid_lf",
             "scryfall_to_uuid_lf",
             "cardmarket_to_uuid_lf",
@@ -615,6 +617,11 @@ class GlobalCache:
         if tcg_etched_path.exists():
             self.tcg_etched_to_uuid_lf = pl.scan_parquet(tcg_etched_path)
             LOGGER.info("Loaded tcg_etched_to_uuid mapping from cache")
+
+        tcg_alt_foil_path = self.cache_path / "tcg_alt_foil_to_uuid.parquet"
+        if tcg_alt_foil_path.exists():
+            self.tcg_alt_foil_to_uuid_lf = pl.scan_parquet(tcg_alt_foil_path)
+            LOGGER.info("Loaded tcg_alt_foil_to_uuid mapping from cache")
 
         mtgo_path = self.cache_path / "mtgo_to_uuid.parquet"
         if mtgo_path.exists():

--- a/mtgjson5/data/context.py
+++ b/mtgjson5/data/context.py
@@ -49,6 +49,7 @@ class PipelineContext:
     scryfall_id_filter: set[str] | None = None
 
     identifiers_lf: pl.LazyFrame | None = None
+    tcg_alt_foil_lf: pl.LazyFrame | None = None
     oracle_data_lf: pl.LazyFrame | None = None
     set_number_lf: pl.LazyFrame | None = None
     name_lf: pl.LazyFrame | None = None
@@ -244,6 +245,15 @@ class PipelineContext:
                 "_tcg_etched_to_uuid_lf"
             ]
         return self._cache.tcg_etched_to_uuid_lf if self._cache else None
+
+    @property
+    def tcg_alt_foil_to_uuid_lf(self) -> pl.LazyFrame | None:
+        """TCG alt foil to UUID mapping from cache."""
+        if "_tcg_alt_foil_to_uuid_lf" in self._test_data:
+            return self._test_data[  # type: ignore[no-any-return]
+                "_tcg_alt_foil_to_uuid_lf"
+            ]
+        return self._cache.tcg_alt_foil_to_uuid_lf if self._cache else None
 
     @property
     def mtgo_to_uuid_lf(self) -> pl.LazyFrame | None:
@@ -527,6 +537,7 @@ class PipelineContext:
         self._load_face_flavor_names()
         self._build_mcm_set_map()
         self._build_mcm_lookup()
+        self._build_tcg_alt_foil_lookup()
 
         return self
 
@@ -1209,3 +1220,131 @@ class PipelineContext:
                 self.mcm_set_map[new_name.lower()] = raw_map.pop(old_key)
 
         self.mcm_set_map.update(raw_map)
+
+    def _build_tcg_alt_foil_lookup(self) -> None:
+        """
+        Build lookup mapping base TCGPlayer productId -> alternative foil productId.
+
+        Detects alternative foil products (e.g. Rainbow Foil, Surge Foil) by
+        matching parenthesized suffixes in TCGPlayer product names, then deduplicates
+        against existing tcgplayerId and tcgplayerEtchedId values.
+        """
+        if self._cache is not None:
+            self._cache._await_tcg_skus()
+
+        tcg_skus = self.tcg_skus_lf
+        if tcg_skus is None:
+            LOGGER.info("tcg_alt_foil: No TCG SKUs data, skipping")
+            return
+
+        uuid_cache = self.uuid_cache_lf
+        if uuid_cache is None:
+            LOGGER.info("tcg_alt_foil: No uuid_cache_lf, skipping")
+            return
+
+        # Load products: productId, name, groupId
+        products = tcg_skus.select(["productId", "name", "groupId"]).unique(subset=["productId"])
+
+        # Detect alt-foil suffix via regex: e.g. "(Rainbow Foil)" at end of name
+        suffix_pattern = r"\(([^)]*(?:Foil|Etched)[^)]*)\)\s*$"
+        products = products.with_columns(
+            pl.col("name").str.extract(suffix_pattern, 1).alias("_foilSuffix"),
+        )
+
+        # Split: alt-foil products have a suffix, base products do not
+        alt_foil = products.filter(pl.col("_foilSuffix").is_not_null())
+        base = products.filter(pl.col("_foilSuffix").is_null())
+
+        if isinstance(alt_foil, pl.LazyFrame):
+            alt_count = alt_foil.select(pl.len()).collect().item()
+        else:
+            alt_count = len(alt_foil)
+        if alt_count == 0:
+            LOGGER.info("tcg_alt_foil: No alt-foil products found")
+            return
+
+        # Strip suffix from alt-foil names to get base name for matching
+        alt_foil = alt_foil.with_columns(
+            pl.col("name").str.replace(suffix_pattern, "").str.strip_chars().alias("_baseName"),
+            pl.col("_foilSuffix")
+            .str.replace(r"(?i)\bFoil\b", "")
+            .str.to_lowercase()
+            .str.strip_chars()
+            .alias("_foilType"),
+        )
+
+        base = base.with_columns(
+            pl.col("name").str.strip_chars().alias("_baseName"),
+        )
+
+        # Inner join alt-foil -> base by (groupId, baseName)
+        joined = alt_foil.join(
+            base.select(["productId", "groupId", "_baseName"]).rename({"productId": "_baseProductId"}),
+            on=["groupId", "_baseName"],
+            how="inner",
+        )
+
+        # Dedup filter: remove alt-foil productIds that already appear as any
+        # card's tcgplayerProductId or tcgplayerEtchedProductId. We gather known
+        # IDs from both uuid_cache (prior build) and Scryfall cards (current data).
+        known_ids: set[str] = set()
+
+        # From uuid_cache (prior build's IDs)
+        uuid_cache_df = uuid_cache.collect() if isinstance(uuid_cache, pl.LazyFrame) else uuid_cache
+        for col in ("tcgplayerId", "tcgplayerEtchedId"):
+            if col in uuid_cache_df.columns:
+                known_ids.update(
+                    uuid_cache_df.select(col)
+                    .drop_nulls()
+                    .get_column(col)
+                    .cast(pl.String)
+                    .to_list()
+                )
+
+        # From Scryfall cards (current source data — covers IDs not in uuid_cache)
+        cards_raw = self.cards_lf
+        if cards_raw is not None:
+            cards_ids = cards_raw.select(
+                [c for c in ["tcgplayerId", "tcgplayerEtchedId"] if c in cards_raw.collect_schema().names()]
+            ).collect()
+            for col in cards_ids.columns:
+                known_ids.update(
+                    cards_ids.select(col)
+                    .drop_nulls()
+                    .get_column(col)
+                    .cast(pl.String)
+                    .to_list()
+                )
+
+        LOGGER.info(f"tcg_alt_foil: {len(known_ids):,} known tcgplayer IDs for dedup")
+
+        if known_ids:
+            known_ids_series = pl.Series("_known", list(known_ids), dtype=pl.String)
+            joined = joined.with_columns(
+                pl.col("productId").cast(pl.String).alias("_altIdStr"),
+            ).filter(~pl.col("_altIdStr").is_in(known_ids_series)).drop("_altIdStr")
+
+        # Pick single value per base product: prefer non-etched types, then first
+        joined = joined.sort(
+            [
+                pl.col("_foilType").str.contains("(?i)etched").cast(pl.Int8),
+                "productId",
+            ]
+        )
+
+        if isinstance(joined, pl.LazyFrame):
+            joined = joined.collect()
+
+        result = joined.unique(subset=["_baseProductId"], keep="first").select(
+            [
+                pl.col("_baseProductId").cast(pl.String).alias("tcgplayerProductId"),
+                pl.col("productId").cast(pl.String).alias("tcgplayerAlternativeFoilId"),
+            ]
+        )
+
+        if result.height == 0:
+            LOGGER.info("tcg_alt_foil: No alt-foil mappings after dedup")
+            return
+
+        self.tcg_alt_foil_lf = result.lazy()
+        LOGGER.info(f"tcg_alt_foil_lf: {result.height:,} rows")

--- a/mtgjson5/data/context.py
+++ b/mtgjson5/data/context.py
@@ -1338,7 +1338,7 @@ class PipelineContext:
         result = joined.unique(subset=["_baseProductId"], keep="first").select(
             [
                 pl.col("_baseProductId").cast(pl.String).alias("tcgplayerProductId"),
-                pl.col("productId").cast(pl.String).alias("tcgplayerAlternativeFoilId"),
+                pl.col("productId").cast(pl.String).alias("tcgplayerAlternativeFoilProductId"),
             ]
         )
 

--- a/mtgjson5/models/submodels.py
+++ b/mtgjson5/models/submodels.py
@@ -226,6 +226,11 @@ class Identifiers(TypedDict, total=False):
             "introduced": "v5.2.0",
             "optional": True,
         },
+        "tcgplayerAlternativeFoilId": {
+            "description": "The [TCGplayer](https://www.tcgplayer.com?partner=mtgjson&utm_campaign=affiliate&utm_medium=mtgjson&utm_source=mtgjson) alternative foil card identifier.",
+            "introduced": "v5.3.0",
+            "optional": True,
+        },
         "tntId": {
             "description": "The [Troll and Toad](https://www.trollandtoad.com/) identifier.",
             "introduced": "v5.2.2",
@@ -261,6 +266,7 @@ class Identifiers(TypedDict, total=False):
     scryfallCardBackId: str
     scryfallIllustrationId: str
     scryfallOracleId: str
+    tcgplayerAlternativeFoilId: str
     tcgplayerEtchedProductId: str
     tcgplayerProductId: str
 

--- a/mtgjson5/models/submodels.py
+++ b/mtgjson5/models/submodels.py
@@ -506,6 +506,11 @@ class PurchaseUrls(TypedDict, total=False):
             "introduced": "v5.2.0",
             "optional": True,
         },
+        "tcgplayerAlternativeFoil": {
+            "description": "The URL to purchase an alternative foil product on [TCGplayer](https://www.tcgplayer.com?partner=mtgjson&utm_campaign=affiliate&utm_medium=mtgjson&utm_source=mtgjson).",
+            "introduced": "v5.3.0",
+            "optional": True,
+        },
     }
 
     cardKingdom: str
@@ -514,6 +519,7 @@ class PurchaseUrls(TypedDict, total=False):
     cardmarket: str
     tcgplayer: str
     tcgplayerEtched: str
+    tcgplayerAlternativeFoil: str
 
 
 class RelatedCards(TypedDict, total=False):

--- a/mtgjson5/models/submodels.py
+++ b/mtgjson5/models/submodels.py
@@ -226,7 +226,7 @@ class Identifiers(TypedDict, total=False):
             "introduced": "v5.2.0",
             "optional": True,
         },
-        "tcgplayerAlternativeFoilId": {
+        "tcgplayerAlternativeFoilProductId": {
             "description": "The [TCGplayer](https://www.tcgplayer.com?partner=mtgjson&utm_campaign=affiliate&utm_medium=mtgjson&utm_source=mtgjson) alternative foil card identifier.",
             "introduced": "v5.3.0",
             "optional": True,
@@ -266,7 +266,7 @@ class Identifiers(TypedDict, total=False):
     scryfallCardBackId: str
     scryfallIllustrationId: str
     scryfallOracleId: str
-    tcgplayerAlternativeFoilId: str
+    tcgplayerAlternativeFoilProductId: str
     tcgplayerEtchedProductId: str
     tcgplayerProductId: str
 

--- a/mtgjson5/pipeline/core.py
+++ b/mtgjson5/pipeline/core.py
@@ -56,6 +56,7 @@ from mtgjson5.pipeline.stages.identifiers import (
     join_name_data,
     join_oracle_data,
     join_set_number_data,
+    join_tcg_alt_foil_lookup,
 )
 from mtgjson5.pipeline.stages.legalities import (
     add_availability_struct,
@@ -245,6 +246,7 @@ def build_cards(ctx: PipelineContext) -> PipelineContext:
         .pipe(fix_foreigndata_for_faces, ctx=ctx)
         .pipe(partial(join_name_data, ctx=ctx))
         .pipe(partial(join_cardmarket_ids, ctx=ctx))
+        .pipe(partial(join_tcg_alt_foil_lookup, ctx=ctx))
         .pipe(fix_availability_from_ids)
     )
 
@@ -264,6 +266,7 @@ def build_cards(ctx: PipelineContext) -> PipelineContext:
                 "mtgoFoilId",
                 "tcgplayerId",
                 "tcgplayerEtchedId",
+                "tcgplayerAlternativeFoilId",
                 "illustrationId",
                 "cardBackId",
             ],

--- a/mtgjson5/pipeline/core.py
+++ b/mtgjson5/pipeline/core.py
@@ -266,7 +266,7 @@ def build_cards(ctx: PipelineContext) -> PipelineContext:
                 "mtgoFoilId",
                 "tcgplayerId",
                 "tcgplayerEtchedId",
-                "tcgplayerAlternativeFoilId",
+                "tcgplayerAlternativeFoilProductId",
                 "illustrationId",
                 "cardBackId",
             ],

--- a/mtgjson5/pipeline/stages/derived.py
+++ b/mtgjson5/pipeline/stages/derived.py
@@ -98,7 +98,7 @@ def add_purchase_urls_struct(
     mcm_id = pl.col("identifiers").struct.field("mcmId")
     tcg_id = pl.col("identifiers").struct.field("tcgplayerProductId")
     tcge_id = pl.col("identifiers").struct.field("tcgplayerEtchedProductId")
-    tcga_id = pl.col("identifiers").struct.field("tcgplayerAlternativeFoilId")
+    tcga_id = pl.col("identifiers").struct.field("tcgplayerAlternativeFoilProductId")
 
     return (
         lf.with_columns(

--- a/mtgjson5/pipeline/stages/derived.py
+++ b/mtgjson5/pipeline/stages/derived.py
@@ -98,6 +98,7 @@ def add_purchase_urls_struct(
     mcm_id = pl.col("identifiers").struct.field("mcmId")
     tcg_id = pl.col("identifiers").struct.field("tcgplayerProductId")
     tcge_id = pl.col("identifiers").struct.field("tcgplayerEtchedProductId")
+    tcga_id = pl.col("identifiers").struct.field("tcgplayerAlternativeFoilId")
 
     return (
         lf.with_columns(
@@ -134,6 +135,12 @@ def add_purchase_urls_struct(
                 .chash.sha2_256()
                 .str.slice(0, 16)
                 .alias("_tcge_hash"),
+                plh.concat_str(  # pylint: disable=no-member
+                    [tcga_id.cast(pl.String), pl.col("uuid")]
+                )
+                .chash.sha2_256()
+                .str.slice(0, 16)
+                .alias("_tcga_hash"),
                 # Cardmarket: hash(mcm_id + uuid + BUFFER + mcm_meta_id)
                 plh.concat_str(  # pylint: disable=no-member
                     [
@@ -175,6 +182,10 @@ def add_purchase_urls_struct(
                     .then(pl.lit(redirect_base) + pl.col("_tcge_hash"))
                     .otherwise(None)
                     .alias("tcgplayerEtched"),
+                    pl.when(tcga_id.is_not_null())
+                    .then(pl.lit(redirect_base) + pl.col("_tcga_hash"))
+                    .otherwise(None)
+                    .alias("tcgplayerAlternativeFoil"),
                 ]
             ).alias("purchaseUrls")
         )
@@ -186,6 +197,7 @@ def add_purchase_urls_struct(
                 "_cm_hash",
                 "_tcg_hash",
                 "_tcge_hash",
+                "_tcga_hash",
             ]
         )
     )

--- a/mtgjson5/pipeline/stages/identifiers.py
+++ b/mtgjson5/pipeline/stages/identifiers.py
@@ -130,6 +130,7 @@ def add_identifiers_struct(lf: pl.LazyFrame) -> pl.LazyFrame:
             .cast(pl.String),
             tcgplayerProductId=pl.col("tcgplayerId").cast(pl.String),
             tcgplayerEtchedProductId=pl.col("tcgplayerEtchedId").cast(pl.String),
+            tcgplayerAlternativeFoilId=pl.col("tcgplayerAlternativeFoilId"),
             cardKingdomId=pl.col("cardKingdomId"),
             cardKingdomFoilId=pl.col("cardKingdomFoilId"),
             cardKingdomEtchedId=pl.col("cardKingdomEtchedId"),
@@ -254,6 +255,26 @@ def join_identifiers(
     )
 
     return lf.drop("_side_for_join", strict=False)
+
+
+def join_tcg_alt_foil_lookup(
+    lf: pl.LazyFrame,
+    ctx: PipelineContext,
+) -> pl.LazyFrame:
+    """
+    Join alternative foil TCGPlayer product IDs by base tcgplayerId.
+    """
+    if ctx.tcg_alt_foil_lf is None:
+        return lf.with_columns(
+            pl.lit(None).cast(pl.String).alias("tcgplayerAlternativeFoilId"),
+        )
+
+    lf = (
+        lf.with_columns(pl.col("tcgplayerId").cast(pl.String).alias("_tcg_id_str"))
+        .join(ctx.tcg_alt_foil_lf, left_on="_tcg_id_str", right_on="tcgplayerProductId", how="left")
+        .drop("_tcg_id_str")
+    )
+    return lf
 
 
 def join_oracle_data(

--- a/mtgjson5/pipeline/stages/identifiers.py
+++ b/mtgjson5/pipeline/stages/identifiers.py
@@ -130,7 +130,7 @@ def add_identifiers_struct(lf: pl.LazyFrame) -> pl.LazyFrame:
             .cast(pl.String),
             tcgplayerProductId=pl.col("tcgplayerId").cast(pl.String),
             tcgplayerEtchedProductId=pl.col("tcgplayerEtchedId").cast(pl.String),
-            tcgplayerAlternativeFoilId=pl.col("tcgplayerAlternativeFoilId"),
+            tcgplayerAlternativeFoilProductId=pl.col("tcgplayerAlternativeFoilProductId"),
             cardKingdomId=pl.col("cardKingdomId"),
             cardKingdomFoilId=pl.col("cardKingdomFoilId"),
             cardKingdomEtchedId=pl.col("cardKingdomEtchedId"),
@@ -266,7 +266,7 @@ def join_tcg_alt_foil_lookup(
     """
     if ctx.tcg_alt_foil_lf is None:
         return lf.with_columns(
-            pl.lit(None).cast(pl.String).alias("tcgplayerAlternativeFoilId"),
+            pl.lit(None).cast(pl.String).alias("tcgplayerAlternativeFoilProductId"),
         )
 
     lf = (

--- a/mtgjson5/pipeline/stages/output.py
+++ b/mtgjson5/pipeline/stages/output.py
@@ -398,7 +398,7 @@ def _build_id_mappings(ctx: PipelineContext, lf: pl.LazyFrame) -> None:
     mapping_configs = [
         ("tcgplayerProductId", "tcg_to_uuid", "tcg_to_uuid_lf"),
         ("tcgplayerEtchedProductId", "tcg_etched_to_uuid", "tcg_etched_to_uuid_lf"),
-        ("tcgplayerAlternativeFoilId", "tcg_alt_foil_to_uuid", "tcg_alt_foil_to_uuid_lf"),
+        ("tcgplayerAlternativeFoilProductId", "tcg_alt_foil_to_uuid", "tcg_alt_foil_to_uuid_lf"),
         ("mtgoId", "mtgo_to_uuid", "mtgo_to_uuid_lf"),
         ("scryfallId", "scryfall_to_uuid", "scryfall_to_uuid_lf"),
     ]

--- a/mtgjson5/pipeline/stages/output.py
+++ b/mtgjson5/pipeline/stages/output.py
@@ -398,6 +398,7 @@ def _build_id_mappings(ctx: PipelineContext, lf: pl.LazyFrame) -> None:
     mapping_configs = [
         ("tcgplayerProductId", "tcg_to_uuid", "tcg_to_uuid_lf"),
         ("tcgplayerEtchedProductId", "tcg_etched_to_uuid", "tcg_etched_to_uuid_lf"),
+        ("tcgplayerAlternativeFoilId", "tcg_alt_foil_to_uuid", "tcg_alt_foil_to_uuid_lf"),
         ("mtgoId", "mtgo_to_uuid", "mtgo_to_uuid_lf"),
         ("scryfallId", "scryfall_to_uuid", "scryfall_to_uuid_lf"),
     ]


### PR DESCRIPTION
There are now 1,160 cards with `tcgplayerAlternativeFoilProductId`s which indicate an additional ID for that card that is not captured by an upstream provider. This is guaranteed to be non-duplicated across any other printing.