### PR TITLE
Tickets/1542

### DIFF
--- a/mtgjson5/build/assemble.py
+++ b/mtgjson5/build/assemble.py
@@ -1083,7 +1083,7 @@ class TableAssembler:
         Returns:
             Dict mapping table name to DataFrame
         """
-        from .serializers import serialize_complex_types
+        from .serializers import normalize_optional_fields, serialize_complex_types
 
         tables: dict[str, pl.DataFrame] = {}
 
@@ -1095,6 +1095,7 @@ class TableAssembler:
         cards_cols = [c for c in cards_df.columns if c not in CARDS_TABLE_EXCLUDE and not c.startswith("_")]
 
         cards_for_export = cards_df.select(cards_cols)
+        cards_for_export = normalize_optional_fields(cards_for_export)
         tables["cards"] = serialize_complex_types(cards_for_export)
 
         # cardIdentifiers - unnest struct
@@ -1149,6 +1150,7 @@ class TableAssembler:
             token_schema = tokens_df.schema
             token_cols = [c for c in tokens_df.columns if c not in TOKENS_TABLE_EXCLUDE and not c.startswith("_")]
             tokens_for_export = tokens_df.select(token_cols)
+            tokens_for_export = normalize_optional_fields(tokens_for_export)
             tables["tokens"] = serialize_complex_types(tokens_for_export)
 
             if "identifiers" in token_schema and isinstance(token_schema["identifiers"], pl.Struct):

--- a/mtgjson5/build/serializers.py
+++ b/mtgjson5/build/serializers.py
@@ -39,9 +39,7 @@ def normalize_optional_fields(df: pl.DataFrame) -> pl.DataFrame:
 
     for field in OMIT_EMPTY_LIST_FIELDS:
         if field in schema and isinstance(schema[field], pl.List):
-            expressions.append(
-                pl.when(pl.col(field).list.len() == 0).then(None).otherwise(pl.col(field)).alias(field)
-            )
+            expressions.append(pl.when(pl.col(field).list.len() == 0).then(None).otherwise(pl.col(field)).alias(field))
 
     if expressions:
         df = df.with_columns(expressions)


### PR DESCRIPTION
fixes #1542:
Added normalize_optional_fields() so SQLite/CSV/Parquet outputs correctly use NULL for false optional bools (isOnlineOnly) and empty omit-list fields (otherFaceIds), matching v5.2 behavior.
<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
