### PR TITLE
Pricebuilder fix

### DIFF
--- a/mtgjson5/build/price_builder.py
+++ b/mtgjson5/build/price_builder.py
@@ -768,9 +768,10 @@ class PolarsPriceBuilder:
         pruned_lf = self.prune_prices(merged_lf)
 
         LOGGER.info("Saving updated archive")
-        self.save_archive(pruned_lf)
+        all_prices_df = pruned_lf.collect()
+        self.save_archive(all_prices_df.lazy())
 
-        return pruned_lf.collect(), today_df
+        return all_prices_df, today_df
 
     def load_archive_only(self) -> pl.LazyFrame:
         """Load existing archive without building new prices."""

--- a/mtgjson5/build/serializers.py
+++ b/mtgjson5/build/serializers.py
@@ -39,9 +39,7 @@ def normalize_optional_fields(df: pl.DataFrame) -> pl.DataFrame:
 
     for field in OMIT_EMPTY_LIST_FIELDS:
         if field in schema and isinstance(schema[field], pl.List):
-            expressions.append(
-                pl.when(pl.col(field).list.len() == 0).then(None).otherwise(pl.col(field)).alias(field)
-            )
+            expressions.append(pl.when(pl.col(field).list.len() == 0).then(None).otherwise(pl.col(field)).alias(field))
 
     if expressions:
         df = df.with_columns(expressions)


### PR DESCRIPTION
build_prices_parquet() was calling collect twice on the same LazyFrame which overwrites prices_archive.parquet.
The second collect re-evaluated the lazy plan, re-scanning the now-overwritten file, causing an "Invalid thrift: bad data" error.
Now collects once and passes the materialized DataFrame to save_archive()
<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
