### PR TITLE
Deduplicate Card Kingdom prices and reduce AllPrices row explosion

### DIFF
--- a/mtgjson5/providers/cardkingdom/transformer.py
+++ b/mtgjson5/providers/cardkingdom/transformer.py
@@ -143,15 +143,19 @@ class CardKingdomTransformer:
         """
         df_with_flags = CardKingdomTransformer.add_derived_columns(df)
 
-        return df_with_flags.filter(pl.col("scryfall_id").is_not_null()).select(
-            [
-                pl.col("id").cast(pl.String).alias("ck_id"),
-                "scryfall_id",
-                pl.col("is_foil_bool").alias("is_foil"),
-                "is_etched",
-                "price_retail",
-                "price_buy",
-                "qty_retail",
-                "qty_buying",
-            ]
+        return (
+            df_with_flags.filter(pl.col("scryfall_id").is_not_null())
+            .select(
+                [
+                    pl.col("id").cast(pl.String).alias("ck_id"),
+                    "scryfall_id",
+                    pl.col("is_foil_bool").alias("is_foil"),
+                    "is_etched",
+                    "price_retail",
+                    "price_buy",
+                    "qty_retail",
+                    "qty_buying",
+                ]
+            )
+            .unique(subset=["ck_id"], keep="first")
         )


### PR DESCRIPTION
fixed three bugs introduced in v5.3.0:
1. V1/V2 API duplication - CK data fetched from both V1 and V2 endpoints were combined without dedupe
2. Missing qty checks - _convert_ck_pricing emitted prices for out-of-stock items, old code required qty_retail > 0
3. Multi-UUID scryfall mapping - scryfall_to_uuid mapped each scryfall ID to all card faces, duplicating prices for multi-faced cards
<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
