### PR TITLE
Add AllDecks.parquet output

### DIFF
--- a/mtgjson5/build/assemble.py
+++ b/mtgjson5/build/assemble.py
@@ -1551,6 +1551,7 @@ class CompiledListAssembler:
     """Assembles CompiledList.json - sorted list of compiled output files."""
 
     COMPILED_FILES = [
+        "AllDecks",
         "AllIdentifiers",
         "AllPrices",
         "AllPricesToday",

--- a/mtgjson5/build/formats/parquet.py
+++ b/mtgjson5/build/formats/parquet.py
@@ -95,8 +95,13 @@ class ParquetBuilder:
 
         meta_cols = [c for c in ("code", "name", "type", "releaseDate") if c in decks_df.columns]
         board_cols = [
-            "mainBoard", "sideBoard", "commander",
-            "displayCommander", "tokens", "planes", "schemes",
+            "mainBoard",
+            "sideBoard",
+            "commander",
+            "displayCommander",
+            "tokens",
+            "planes",
+            "schemes",
         ]
         available = [c for c in board_cols if c in decks_df.columns]
 

--- a/mtgjson5/consts/outputs.py
+++ b/mtgjson5/consts/outputs.py
@@ -17,6 +17,7 @@ ALL_PARQUETS_DIRECTORY: Final[str] = "AllPrintingsParquetFiles"
 # All compiled output file names (used by compression to distinguish set files from compiled files)
 COMPILED_OUTPUT_NAMES: Final[frozenset[str]] = frozenset(
     {
+        "AllDecks",
         "AllPrintings",
         "AtomicCards",
         "AllPrices",

--- a/mtgjson5/data/cache.py
+++ b/mtgjson5/data/cache.py
@@ -911,7 +911,7 @@ class GlobalCache:
                     entry = entries[0]
                     rows.append(
                         {
-                            "multiverse_id": str(mv_id),
+                            "multiverseId": str(mv_id),
                             "originalText": entry.get("original_text"),
                             "originalType": entry.get("original_types"),
                         }


### PR DESCRIPTION
Deck data is currently only available as individual JSON files or metadata-only DeckList.parquet.
This adds a single queryable file for all deck card references, joinable with cards.parquet on uuid for full card data - and chainable further through cardIdentifiers.parquet and TcgplayerSkus.parquet for SKU lookups.

- Adds AllDecks.parquet to the parquet export: a flat join table with one row per card-in-deck entry
- Schema: code, name, type, releaseDate, board, uuid, count, isFoil, isEtched
- Registers AllDecks in COMPILED_OUTPUT_NAMES and CompiledListAssembler.COMPILED_FILES
<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
