### PR TITLE
fix price builder

### DIFF
--- a/mtgjson5/__main__.py
+++ b/mtgjson5/__main__.py
@@ -196,6 +196,15 @@ def dispatcher(args: argparse.Namespace) -> None:
         else:
             LOGGER.info(f"Price files written: {all_prices_path}, {today_prices_path}")
 
+        # Write parquet price files
+        from mtgjson5.build.formats.parquet import ParquetBuilder
+        from mtgjson5.mtgjson_config import MtgjsonConfig
+
+        parquet_dir = MtgjsonConfig().output_path / "parquet"
+        parquet_dir.mkdir(parents=True, exist_ok=True)
+        LOGGER.info("Writing price parquet files...")
+        ParquetBuilder.write_prices(parquet_dir)
+
     if args.compress:
         if args.parallel:
             compress_mtgjson_contents_parallel(MtgjsonConfig().output_path)

--- a/mtgjson5/__main__.py
+++ b/mtgjson5/__main__.py
@@ -198,7 +198,6 @@ def dispatcher(args: argparse.Namespace) -> None:
 
         # Write parquet price files
         from mtgjson5.build.formats.parquet import ParquetBuilder
-        from mtgjson5.mtgjson_config import MtgjsonConfig
 
         parquet_dir = MtgjsonConfig().output_path / "parquet"
         parquet_dir.mkdir(parents=True, exist_ok=True)

--- a/mtgjson5/build/formats/parquet.py
+++ b/mtgjson5/build/formats/parquet.py
@@ -132,7 +132,8 @@ class ParquetBuilder:
         if rows:
             _write(pl.DataFrame(rows), output_dir / "TcgplayerSkus.parquet")
 
-    def _write_prices(self, output_dir: pathlib.Path) -> None:
+    @staticmethod
+    def write_prices(output_dir: pathlib.Path) -> None:
         """Write AllPrices.parquet and AllPricesToday.parquet."""
         from mtgjson5.build.price_builder import PolarsPriceBuilder
 
@@ -186,7 +187,6 @@ class ParquetBuilder:
         self._write_deck_list(output_dir)
         self._write_all_decks(output_dir)
         self._write_tcgplayer_skus(output_dir)
-        self._write_prices(output_dir)
 
         LOGGER.info(f"Wrote Parquet files to {output_dir}")
         return output_dir

--- a/mtgjson5/build/price_builder.py
+++ b/mtgjson5/build/price_builder.py
@@ -730,49 +730,26 @@ class PolarsPriceBuilder:
 
     def build_prices_parquet(self) -> tuple[pl.DataFrame, pl.DataFrame]:
         """
-        Build prices returning DataFrames instead of dicts.
+        Build parquet price DataFrames from existing partitions.
+
+        Expects build_prices() to have already run (fetching, partitioning,
+        and S3 sync). This just loads the archive and splits out today.
 
         Returns:
             Tuple of (all_prices_df, today_prices_df)
         """
-        LOGGER.info("Polars Price Builder - Building Prices (Parquet mode, V2)")
+        LOGGER.info("Polars Price Builder - Loading prices for parquet export")
 
-        if not self.all_printings_path.is_file():
-            LOGGER.info("AllPrintings not found, cannot build prices")
-            empty = pl.DataFrame(schema=PRICE_SCHEMA)
-            return empty, empty
-
-        LOGGER.info("Fetching today's prices from V2 providers")
-        today_df = self.build_today_prices()
-
-        if len(today_df) == 0:
-            LOGGER.warning("No price data generated")
-            empty = pl.DataFrame(schema=PRICE_SCHEMA)
-            return empty, empty
-
-        # Save today's prices to partition
-        LOGGER.info("Saving today's prices to partition")
-        self.save_prices_partitioned(today_df)
-
-        # Sync partitions with S3 to get historical data
-        LOGGER.info("Syncing partitions with S3")
-        downloaded = self.sync_missing_partitions_from_s3(days=90)
-        if downloaded > 0:
-            LOGGER.info(f"Downloaded {downloaded} partitions from S3")
-
-        # Upload today's partition to S3
-        try:
-            LOGGER.info("Uploading today's partition to S3")
-            if self.sync_partition_to_s3(self.today_date):
-                LOGGER.info("S3 upload complete")
-            else:
-                LOGGER.warning("S3 upload failed (continuing)")
-        except Exception as e:
-            LOGGER.error(f"S3 upload failed (continuing): {e}")
-
-        # Load archive from partitions, filtered to 90 days for output
+        # Load archive from partitions, filtered to 90 days
         LOGGER.info("Loading archive from partitions (90 day window)")
         archive_df = self.load_partitioned_archive(days=90).collect()
+
+        if len(archive_df) == 0:
+            LOGGER.warning("No price data in partitions")
+            empty = pl.DataFrame(schema=PRICE_SCHEMA)
+            return empty, empty
+
+        today_df = archive_df.filter(pl.col("date") == self.today_date)
 
         return archive_df, today_df
 

--- a/mtgjson5/build/price_builder.py
+++ b/mtgjson5/build/price_builder.py
@@ -750,20 +750,31 @@ class PolarsPriceBuilder:
             empty = pl.DataFrame(schema=PRICE_SCHEMA)
             return empty, empty
 
-        LOGGER.info("Loading price archive")
-        archive_lf = self.load_archive()
+        # Save today's prices to partition
+        LOGGER.info("Saving today's prices to partition")
+        self.save_prices_partitioned(today_df)
 
-        LOGGER.info("Merging archive with today's prices")
-        merged_lf = self.merge_prices(archive_lf, today_df.lazy())
+        # Sync partitions with S3 to get historical data
+        LOGGER.info("Syncing partitions with S3")
+        downloaded = self.sync_missing_partitions_from_s3(days=90)
+        if downloaded > 0:
+            LOGGER.info(f"Downloaded {downloaded} partitions from S3")
 
-        LOGGER.info("Pruning old price data")
-        pruned_lf = self.prune_prices(merged_lf)
+        # Upload today's partition to S3
+        try:
+            LOGGER.info("Uploading today's partition to S3")
+            if self.sync_partition_to_s3(self.today_date):
+                LOGGER.info("S3 upload complete")
+            else:
+                LOGGER.warning("S3 upload failed (continuing)")
+        except Exception as e:
+            LOGGER.error(f"S3 upload failed (continuing): {e}")
 
-        LOGGER.info("Saving updated archive")
-        all_prices_df = pruned_lf.collect()
-        self.save_archive(all_prices_df.lazy())
+        # Load archive from partitions, filtered to 90 days for output
+        LOGGER.info("Loading archive from partitions (90 day window)")
+        archive_df = self.load_partitioned_archive(days=90).collect()
 
-        return all_prices_df, today_df
+        return archive_df, today_df
 
     def load_archive_only(self) -> pl.LazyFrame:
         """Load existing archive without building new prices."""


### PR DESCRIPTION
AllPrices.parquet was being restricted to just 'todays' prices - now saves today's partition, syncs with S3, and uses self.load_partitioned_archive(days=90) to load the full 90-day history from date-partitioned directories in order to build the full 3 month price snapshot

<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
