### PR TITLE
Add pipeline transform tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ disable_error_code = ["typeddict-item", "no-any-return"]
 
 [tool.pytest.ini_options]
 # -q (quiet mode): reduces output verbosity to show only test results, keeping CI logs clean
-addopts = "-q"
+addopts = "-q --import-mode=importlib"
 # VCR cassette recording modes:
 # - Local development: use --record-mode=once to record new cassettes
 # - CI/offline: use --record-mode=none to ensure no network access (enforced in tox config)

--- a/tests/mtgjson5/conftest.py
+++ b/tests/mtgjson5/conftest.py
@@ -1,0 +1,666 @@
+"""Shared fixtures and helpers for pipeline and assembly tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import polars as pl
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--update-golden",
+        action="store_true",
+        default=False,
+        help="Re-generate golden test files instead of asserting",
+    )
+
+
+@pytest.fixture(scope="session")
+def update_golden(request: pytest.FixtureRequest) -> bool:
+    return bool(request.config.getoption("--update-golden"))
+
+
+def make_face_struct(**overrides: Any) -> dict[str, Any]:
+    """Build a dict matching CardFace.polars_schema() struct fields."""
+    defaults: dict[str, Any] = {
+        "object": "card_face",
+        "name": "Test Face",
+        "mana_cost": "{1}{W}",
+        "type_line": "Creature — Human",
+        "oracle_text": "Test text",
+        "colors": ["W"],
+        "color_indicator": None,
+        "power": "2",
+        "toughness": "2",
+        "defense": None,
+        "loyalty": None,
+        "flavor_text": None,
+        "flavor_name": None,
+        "illustration_id": None,
+        "image_uris": None,
+        "artist": "Test Artist",
+        "artist_id": None,
+        "watermark": None,
+        "printed_name": None,
+        "printed_text": None,
+        "printed_type_line": None,
+        "cmc": None,
+        "oracle_id": None,
+        "layout": None,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def make_card_row(**overrides: Any) -> dict[str, Any]:
+    """Return a dict with sensible defaults for every column the pipeline expects.
+
+    Caller overrides only fields relevant to their test.
+    """
+    defaults: dict[str, Any] = {
+        "name": "Test Card",
+        "setCode": "TST",
+        "number": "1",
+        "layout": "normal",
+        "uuid": "test-uuid-001",
+        "scryfallId": "sf-001",
+        "side": None,
+        "faceId": 0,
+        "manaCost": "{1}{W}",
+        "type": "Creature — Human Warrior",
+        "text": "Test card text.",
+        "colors": ["W"],
+        "colorIdentity": ["W"],
+        "finishes": ["nonfoil"],
+        "rarity": "common",
+        "lang": "en",
+        "language": "en",
+        "manaValue": 2.0,
+        "promoTypes": None,
+        "frameEffects": None,
+        "keywords": None,
+        "power": None,
+        "toughness": None,
+        "boosterTypes": None,
+        "cardParts": None,
+        "faceName": None,
+        "otherFaceIds": None,
+        "_face_data": None,
+        "_row_id": 0,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def make_meld_triplet_lf(
+    set_code: str = "BRO",
+    lang: str = "en",
+) -> pl.LazyFrame:
+    """Build a 3-card LazyFrame with correct meld cardParts/faceName/number columns."""
+    card_parts = ["Urza, Lord Protector", "The Mightstone and Weakstone", "Urza, Planeswalker"]
+    rows = [
+        {
+            "setCode": set_code,
+            "language": lang,
+            "number": "225",
+            "faceName": "Urza, Lord Protector",
+            "uuid": "uuid-front1",
+            "cardParts": card_parts,
+            "otherFaceIds": None,
+        },
+        {
+            "setCode": set_code,
+            "language": lang,
+            "number": "238a",
+            "faceName": "The Mightstone and Weakstone",
+            "uuid": "uuid-front2",
+            "cardParts": card_parts,
+            "otherFaceIds": None,
+        },
+        {
+            "setCode": set_code,
+            "language": lang,
+            "number": "238b",
+            "faceName": "Urza, Planeswalker",
+            "uuid": "uuid-result",
+            "cardParts": card_parts,
+            "otherFaceIds": None,
+        },
+    ]
+    return pl.LazyFrame(
+        rows,
+        schema={
+            "setCode": pl.String,
+            "language": pl.String,
+            "number": pl.String,
+            "faceName": pl.String,
+            "uuid": pl.String,
+            "cardParts": pl.List(pl.String),
+            "otherFaceIds": pl.List(pl.String),
+        },
+    )
+
+
+def make_card_lf(rows: list[dict[str, Any]] | None = None) -> pl.LazyFrame:
+    """Wraps make_card_row defaults + explicit schema -> pl.LazyFrame."""
+    if rows is None:
+        rows = [make_card_row()]
+    from mtgjson5.models.scryfall.models import CardFace
+
+    face_struct_schema = CardFace.polars_schema()
+    full_rows = [make_card_row(**r) for r in rows]
+    return pl.LazyFrame(
+        full_rows,
+        schema={
+            "name": pl.String,
+            "setCode": pl.String,
+            "number": pl.String,
+            "layout": pl.String,
+            "uuid": pl.String,
+            "scryfallId": pl.String,
+            "side": pl.String,
+            "faceId": pl.Int64,
+            "manaCost": pl.String,
+            "type": pl.String,
+            "text": pl.String,
+            "colors": pl.List(pl.String),
+            "colorIdentity": pl.List(pl.String),
+            "finishes": pl.List(pl.String),
+            "rarity": pl.String,
+            "lang": pl.String,
+            "manaValue": pl.Float64,
+            "_face_data": face_struct_schema,
+            "_row_id": pl.UInt32,
+        },
+    )
+
+
+def make_full_card_df() -> pl.DataFrame:
+    """Return a DataFrame with representative column types for cross-format tests.
+
+    Includes: String, Int64, Float64, Boolean, List(String), Struct, and a null row.
+    """
+    return pl.DataFrame(
+        {
+            "uuid": ["card-001", "card-002", None],
+            "name": ["Alpha Card", "Beta Card", None],
+            "cmc": [3, 0, None],
+            "price": [1.99, 0.0, None],
+            "hasFoil": [True, False, None],
+            "colors": [["W", "U"], [], None],
+            "identifiers": [
+                {"scryfallId": "sf-001", "multiverseId": "123"},
+                {"scryfallId": "sf-002", "multiverseId": None},
+                None,
+            ],
+        },
+        schema={
+            "uuid": pl.String,
+            "name": pl.String,
+            "cmc": pl.Int64,
+            "price": pl.Float64,
+            "hasFoil": pl.Boolean,
+            "colors": pl.List(pl.String),
+            "identifiers": pl.Struct({"scryfallId": pl.String, "multiverseId": pl.String}),
+        },
+    )
+
+
+@pytest.fixture
+def simple_ctx():  # -> PipelineContext
+    """PipelineContext.for_testing() with empty meld_triplets and manual_overrides."""
+    from mtgjson5.data.context import PipelineContext
+
+    return PipelineContext.for_testing(
+        meld_triplets={},
+        manual_overrides={},
+    )
+
+
+@pytest.fixture
+def meld_ctx():  # -> PipelineContext
+    """PipelineContext.for_testing() with a sample meld triplet."""
+    from mtgjson5.data.context import PipelineContext
+
+    return PipelineContext.for_testing(
+        meld_triplets={
+            "Urza": [
+                "Urza, Lord Protector",
+                "The Mightstone and Weakstone",
+                "Urza, Planeswalker",
+            ]
+        },
+        manual_overrides={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Assembly-level helpers
+# ---------------------------------------------------------------------------
+
+_IDENTIFIERS_EMPTY: dict[str, Any] = {
+    "abuId": None,
+    "cardKingdomEtchedId": None,
+    "cardKingdomFoilId": None,
+    "cardKingdomId": None,
+    "cardsphereFoilId": None,
+    "cardsphereId": None,
+    "cardtraderId": None,
+    "csiId": None,
+    "deckboxId": None,
+    "mcmId": None,
+    "mcmMetaId": None,
+    "miniaturemarketId": None,
+    "mtgArenaId": None,
+    "mtgjsonFoilVersionId": None,
+    "mtgjsonNonFoilVersionId": None,
+    "mtgjsonV4Id": None,
+    "mtgoFoilId": None,
+    "mtgoId": None,
+    "multiverseId": None,
+    "mvpId": None,
+    "scgId": None,
+    "scryfallCardBackId": None,
+    "scryfallId": None,
+    "scryfallIllustrationId": None,
+    "scryfallOracleId": None,
+    "tcgplayerAlternativeFoilProductId": None,
+    "tcgplayerEtchedProductId": None,
+    "tcgplayerProductId": None,
+    "tntId": None,
+}
+
+_LEGALITIES_EMPTY: dict[str, Any] = {
+    "alchemy": None,
+    "brawl": None,
+    "commander": None,
+    "duel": None,
+    "explorer": None,
+    "future": None,
+    "gladiator": None,
+    "historic": None,
+    "historicbrawl": None,
+    "legacy": None,
+    "modern": None,
+    "oathbreaker": None,
+    "oldschool": None,
+    "pauper": None,
+    "paupercommander": None,
+    "penny": None,
+    "pioneer": None,
+    "predh": None,
+    "premodern": None,
+    "standard": None,
+    "standardbrawl": None,
+    "timeless": None,
+    "vintage": None,
+}
+
+_PURCHASE_URLS_EMPTY: dict[str, Any] = {
+    "cardKingdom": None,
+    "cardKingdomEtched": None,
+    "cardKingdomFoil": None,
+    "cardmarket": None,
+    "tcgplayer": None,
+    "tcgplayerAlternativeFoil": None,
+    "tcgplayerEtched": None,
+}
+
+
+def make_assembled_card(**overrides: Any) -> dict[str, Any]:
+    """Build a dict matching CardSet.polars_schema() for assembly-level tests.
+
+    All 87 fields are present with sensible defaults. Override only what matters.
+    """
+    defaults: dict[str, Any] = {
+        # -- scalars --
+        "artist": "Test Artist",
+        "asciiName": None,
+        "borderColor": "black",
+        "convertedManaCost": 2.0,
+        "defense": None,
+        "duelDeck": None,
+        "edhrecRank": None,
+        "edhrecSaltiness": None,
+        "faceConvertedManaCost": None,
+        "faceFlavorName": None,
+        "faceManaValue": None,
+        "faceName": None,
+        "facePrintedName": None,
+        "flavorName": None,
+        "flavorText": None,
+        "frameVersion": "2015",
+        "hand": None,
+        "hasAlternativeDeckLimit": None,
+        "hasContentWarning": None,
+        "isAlternative": None,
+        "isFullArt": None,
+        "isFunny": None,
+        "isGameChanger": None,
+        "isOnlineOnly": None,
+        "isOversized": None,
+        "isPromo": None,
+        "isRebalanced": None,
+        "isReprint": None,
+        "isReserved": None,
+        "isStorySpotlight": None,
+        "isTextless": None,
+        "isTimeshifted": None,
+        "language": "English",
+        "layout": "normal",
+        "life": None,
+        "loyalty": None,
+        "manaCost": "{1}{R}",
+        "manaValue": 2.0,
+        "name": "Test Card",
+        "number": "1",
+        "originalReleaseDate": None,
+        "originalText": None,
+        "originalType": None,
+        "power": None,
+        "printedName": None,
+        "printedText": None,
+        "printedType": None,
+        "rarity": "common",
+        "securityStamp": None,
+        "setCode": "TST",
+        "side": None,
+        "signature": None,
+        "text": "Test card text.",
+        "toughness": None,
+        "type": "Instant",
+        "uuid": "test-uuid-001",
+        "watermark": None,
+        # -- lists --
+        "artistIds": None,
+        "attractionLights": None,
+        "availability": ["paper"],
+        "boosterTypes": None,
+        "cardParts": None,
+        "colorIdentity": ["R"],
+        "colorIndicator": None,
+        "colors": ["R"],
+        "finishes": ["nonfoil"],
+        "frameEffects": None,
+        "keywords": None,
+        "originalPrintings": None,
+        "otherFaceIds": None,
+        "printings": None,
+        "producedMana": None,
+        "promoTypes": None,
+        "rebalancedPrintings": None,
+        "subsets": None,
+        "subtypes": [],
+        "supertypes": [],
+        "types": ["Instant"],
+        "variations": None,
+        # -- structs --
+        "identifiers": {**_IDENTIFIERS_EMPTY, "scryfallId": "sf-001", "scryfallOracleId": "oracle-001"},
+        "legalities": {**_LEGALITIES_EMPTY, "vintage": "Legal", "legacy": "Legal", "commander": "Legal"},
+        "leadershipSkills": None,
+        "purchaseUrls": _PURCHASE_URLS_EMPTY.copy(),
+        "relatedCards": None,
+        "sourceProducts": None,
+        # -- complex lists --
+        "foreignData": None,
+        "rulings": None,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def make_assembled_token(**overrides: Any) -> dict[str, Any]:
+    """Build a dict matching CardToken.polars_schema() for assembly-level tests."""
+    defaults: dict[str, Any] = {
+        "artist": "Token Artist",
+        "artistIds": None,
+        "asciiName": None,
+        "attractionLights": None,
+        "availability": ["paper"],
+        "boosterTypes": None,
+        "borderColor": "black",
+        "cardParts": None,
+        "colorIdentity": [],
+        "colorIndicator": None,
+        "colors": ["B"],
+        "edhrecSaltiness": None,
+        "faceFlavorName": None,
+        "faceName": None,
+        "facePrintedName": None,
+        "finishes": ["nonfoil"],
+        "flavorName": None,
+        "flavorText": None,
+        "frameEffects": None,
+        "frameVersion": "2015",
+        "identifiers": {**_IDENTIFIERS_EMPTY, "scryfallId": "sf-token-001"},
+        "isFullArt": None,
+        "isFunny": None,
+        "isOnlineOnly": None,
+        "isOversized": None,
+        "isPromo": None,
+        "isReprint": None,
+        "isTextless": None,
+        "keywords": None,
+        "language": "English",
+        "layout": "token",
+        "loyalty": None,
+        "manaCost": None,
+        "name": "Zombie",
+        "number": "T1",
+        "orientation": None,
+        "originalText": None,
+        "originalType": None,
+        "otherFaceIds": None,
+        "power": "2",
+        "printedName": None,
+        "printedText": None,
+        "printedType": None,
+        "producedMana": None,
+        "promoTypes": None,
+        "relatedCards": None,
+        "securityStamp": None,
+        "setCode": "TTST",
+        "side": None,
+        "signature": None,
+        "sourceProducts": None,
+        "subsets": None,
+        "subtypes": ["Zombie"],
+        "supertypes": [],
+        "text": None,
+        "tokenProducts": None,
+        "toughness": "2",
+        "type": "Token Creature — Zombie",
+        "types": ["Token", "Creature"],
+        "uuid": "uuid-zombie-001",
+        "watermark": None,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+@pytest.fixture(scope="session")
+def assembly_ctx(tmp_path_factory: pytest.TempPathFactory) -> AssemblyContext:
+    """Build a tiny AssemblyContext from synthetic parquet fixtures."""
+    from mtgjson5.build.context import AssemblyContext
+    from mtgjson5.models.cards import CardSet, CardToken
+
+    base = tmp_path_factory.mktemp("assembly")
+    parquet_dir = base / "_parquet"
+    tokens_dir = base / "_parquet_tokens"
+    output_dir = base / "output"
+    output_dir.mkdir()
+
+    card_schema = CardSet.polars_schema()
+    token_schema = CardToken.polars_schema()
+
+    # --- TST set: 4 cards ---
+    tst_cards = [
+        make_assembled_card(
+            name="Lightning Bolt",
+            number="1",
+            uuid="uuid-bolt-tst",
+            type="Instant",
+            types=["Instant"],
+            text="Lightning Bolt deals 3 damage to any target.",
+            manaCost="{R}",
+            manaValue=1.0,
+            convertedManaCost=1.0,
+            colors=["R"],
+            colorIdentity=["R"],
+            identifiers={**_IDENTIFIERS_EMPTY, "scryfallId": "sf-bolt-tst", "scryfallOracleId": "oracle-bolt"},
+            legalities={
+                **_LEGALITIES_EMPTY,
+                "vintage": "Legal",
+                "legacy": "Legal",
+                "modern": "Legal",
+                "commander": "Legal",
+            },
+        ),
+        make_assembled_card(
+            name="Wear // Tear",
+            number="2a",
+            uuid="uuid-wear",
+            layout="split",
+            side="a",
+            faceName="Wear",
+            type="Instant",
+            types=["Instant"],
+            text="Destroy target artifact.",
+            manaCost="{R}",
+            manaValue=3.0,
+            convertedManaCost=3.0,
+            colors=["R"],
+            colorIdentity=["R", "W"],
+            otherFaceIds=["uuid-tear"],
+            identifiers={**_IDENTIFIERS_EMPTY, "scryfallId": "sf-wt", "scryfallOracleId": "oracle-wt"},
+            legalities={**_LEGALITIES_EMPTY, "vintage": "Legal", "legacy": "Legal", "commander": "Legal"},
+        ),
+        make_assembled_card(
+            name="Wear // Tear",
+            number="2b",
+            uuid="uuid-tear",
+            layout="split",
+            side="b",
+            faceName="Tear",
+            type="Instant",
+            types=["Instant"],
+            text="Destroy target enchantment.",
+            manaCost="{W}",
+            manaValue=3.0,
+            convertedManaCost=3.0,
+            colors=["W"],
+            colorIdentity=["R", "W"],
+            otherFaceIds=["uuid-wear"],
+            identifiers={**_IDENTIFIERS_EMPTY, "scryfallId": "sf-wt", "scryfallOracleId": "oracle-wt"},
+            legalities={**_LEGALITIES_EMPTY, "vintage": "Legal", "legacy": "Legal", "commander": "Legal"},
+        ),
+        make_assembled_card(
+            name="Funny Card",
+            number="3",
+            uuid="uuid-funny",
+            type="Creature — Clown",
+            types=["Creature"],
+            subtypes=["Clown"],
+            text="This card is funny.",
+            isFunny=True,
+            power="1",
+            toughness="1",
+            identifiers={**_IDENTIFIERS_EMPTY, "scryfallId": "sf-funny", "scryfallOracleId": "oracle-funny"},
+            legalities=_LEGALITIES_EMPTY.copy(),
+        ),
+    ]
+
+    # --- TS2 set: 2 cards (Lightning Bolt reprint + Prodigal Sorcerer) ---
+    ts2_cards = [
+        make_assembled_card(
+            name="Lightning Bolt",
+            number="1",
+            uuid="uuid-bolt-ts2",
+            setCode="TS2",
+            type="Instant",
+            types=["Instant"],
+            text="Lightning Bolt deals 3 damage to any target.",
+            manaCost="{R}",
+            manaValue=1.0,
+            convertedManaCost=1.0,
+            colors=["R"],
+            colorIdentity=["R"],
+            isReprint=True,
+            identifiers={**_IDENTIFIERS_EMPTY, "scryfallId": "sf-bolt-ts2", "scryfallOracleId": "oracle-bolt"},
+            legalities={
+                **_LEGALITIES_EMPTY,
+                "vintage": "Legal",
+                "legacy": "Legal",
+                "modern": "Legal",
+                "commander": "Legal",
+                "pauper": "Legal",
+            },
+        ),
+        make_assembled_card(
+            name="Prodigal Sorcerer",
+            number="2",
+            uuid="uuid-sorcerer",
+            setCode="TS2",
+            type="Creature — Human Wizard",
+            types=["Creature"],
+            subtypes=["Human", "Wizard"],
+            text="{T}: Prodigal Sorcerer deals 1 damage to any target.",
+            manaCost="{2}{U}",
+            manaValue=3.0,
+            convertedManaCost=3.0,
+            colors=["U"],
+            colorIdentity=["U"],
+            power="1",
+            toughness="1",
+            identifiers={**_IDENTIFIERS_EMPTY, "scryfallId": "sf-sorcerer", "scryfallOracleId": "oracle-sorcerer"},
+            legalities={**_LEGALITIES_EMPTY, "vintage": "Legal", "legacy": "Legal", "commander": "Legal"},
+        ),
+    ]
+
+    # --- Token ---
+    token = make_assembled_token()
+
+    # Write parquet partitions
+    for code, cards in [("TST", tst_cards), ("TS2", ts2_cards)]:
+        path = parquet_dir / f"setCode={code}"
+        path.mkdir(parents=True)
+        pl.DataFrame(cards, schema=card_schema).write_parquet(path / "0.parquet")
+
+    t_path = tokens_dir / "setCode=TTST"
+    t_path.mkdir(parents=True)
+    pl.DataFrame([token], schema=token_schema).write_parquet(t_path / "0.parquet")
+
+    set_meta = {
+        "TST": {
+            "code": "TST",
+            "name": "Test Set",
+            "type": "expansion",
+            "releaseDate": "2025-01-01",
+            "keyruneCode": "TST",
+            "isFoilOnly": False,
+            "isOnlineOnly": False,
+            "tokenSetCode": "TTST",
+            "translations": {},
+        },
+        "TS2": {
+            "code": "TS2",
+            "name": "Test Set Two",
+            "type": "expansion",
+            "releaseDate": "2025-06-01",
+            "keyruneCode": "TS2",
+            "isFoilOnly": False,
+            "isOnlineOnly": False,
+            "tokenSetCode": None,
+            "translations": {},
+        },
+    }
+
+    return AssemblyContext(
+        parquet_dir=parquet_dir,
+        tokens_dir=tokens_dir,
+        set_meta=set_meta,
+        meta={"date": "2025-01-01", "version": "5.3.0+test"},
+        output_path=output_dir,
+    )

--- a/tests/mtgjson5/test_pipeline_transforms.py
+++ b/tests/mtgjson5/test_pipeline_transforms.py
@@ -1,0 +1,418 @@
+"""Tests for v2 pipeline core transformation functions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import polars as pl
+import pytest
+
+from mtgjson5.data.context import PipelineContext
+from mtgjson5.models.scryfall.models import CardFace
+from mtgjson5.pipeline.stages.basic_fields import (
+    add_mana_info,
+    format_planeswalker_text,
+    parse_type_line_expr,
+)
+from mtgjson5.pipeline.stages.derived import add_is_timeshifted
+from mtgjson5.pipeline.stages.explode import (
+    assign_meld_sides,
+    detect_aftermath_layout,
+    explode_card_faces,
+)
+
+
+
+# ---------------------------------------------------------------------------
+# Helpers (duplicated from conftest to avoid relative imports)
+# ---------------------------------------------------------------------------
+
+
+def make_face_struct(**overrides: Any) -> dict[str, Any]:
+    """Build a dict matching CardFace.polars_schema() struct fields."""
+    defaults: dict[str, Any] = {
+        "object": "card_face",
+        "name": "Test Face",
+        "mana_cost": "{1}{W}",
+        "type_line": "Creature — Human",
+        "oracle_text": "Test text",
+        "colors": ["W"],
+        "color_indicator": None,
+        "power": "2",
+        "toughness": "2",
+        "defense": None,
+        "loyalty": None,
+        "flavor_text": None,
+        "flavor_name": None,
+        "illustration_id": None,
+        "image_uris": None,
+        "artist": "Test Artist",
+        "artist_id": None,
+        "watermark": None,
+        "printed_name": None,
+        "printed_text": None,
+        "printed_type_line": None,
+        "cmc": None,
+        "oracle_id": None,
+        "layout": None,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def _make_card_row(**overrides: Any) -> dict[str, Any]:
+    defaults: dict[str, Any] = {
+        "name": "Test Card",
+        "setCode": "TST",
+        "number": "1",
+        "layout": "normal",
+        "uuid": "test-uuid-001",
+        "scryfallId": "sf-001",
+        "side": None,
+        "faceId": 0,
+        "manaCost": "{1}{W}",
+        "type": "Creature — Human Warrior",
+        "text": "Test card text.",
+        "colors": ["W"],
+        "colorIdentity": ["W"],
+        "finishes": ["nonfoil"],
+        "rarity": "common",
+        "lang": "en",
+        "language": "en",
+        "manaValue": 2.0,
+        "promoTypes": None,
+        "frameEffects": None,
+        "keywords": None,
+        "power": None,
+        "toughness": None,
+        "boosterTypes": None,
+        "cardParts": None,
+        "faceName": None,
+        "otherFaceIds": None,
+        "_face_data": None,
+        "_row_id": 0,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def make_card_lf(rows: list[dict[str, Any]] | None = None) -> pl.LazyFrame:
+    """Wraps make_card_row defaults + explicit schema -> pl.LazyFrame."""
+    if rows is None:
+        rows = [_make_card_row()]
+    face_struct_schema = CardFace.polars_schema()
+    full_rows = [_make_card_row(**r) for r in rows]
+    return pl.LazyFrame(
+        full_rows,
+        schema={
+            "name": pl.String,
+            "setCode": pl.String,
+            "number": pl.String,
+            "layout": pl.String,
+            "uuid": pl.String,
+            "scryfallId": pl.String,
+            "side": pl.String,
+            "faceId": pl.Int64,
+            "manaCost": pl.String,
+            "type": pl.String,
+            "text": pl.String,
+            "colors": pl.List(pl.String),
+            "colorIdentity": pl.List(pl.String),
+            "finishes": pl.List(pl.String),
+            "rarity": pl.String,
+            "lang": pl.String,
+            "manaValue": pl.Float64,
+            "_face_data": face_struct_schema,
+            "_row_id": pl.UInt32,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper to build a multi-face LazyFrame with cardFaces column
+# ---------------------------------------------------------------------------
+
+
+def _make_multiface_lf(card_faces_list: list[list[dict]], **base_overrides: Any) -> pl.LazyFrame:
+    """Build a LazyFrame with cardFaces as list of structs."""
+    face_struct = CardFace.polars_schema()
+    rows = []
+    for i, faces in enumerate(card_faces_list):
+        row = {
+            "name": base_overrides.get("name", f"Card {i}"),
+            "setCode": "TST",
+            "number": str(i + 1),
+            "layout": base_overrides.get("layout", "transform"),
+            "uuid": f"uuid-{i}",
+            "scryfallId": f"sf-{i}",
+            "manaCost": "{1}{W}",
+            "type": "Creature",
+            "text": "text",
+            "colors": ["W"],
+            "colorIdentity": ["W"],
+            "finishes": ["nonfoil"],
+            "rarity": "rare",
+            "lang": "en",
+            "manaValue": 2.0,
+            "cardFaces": faces,
+        }
+        row.update({k: v for k, v in base_overrides.items() if k not in ("name", "layout")})
+        rows.append(row)
+
+    schema: dict[str, Any] = {
+        "name": pl.String,
+        "setCode": pl.String,
+        "number": pl.String,
+        "layout": pl.String,
+        "uuid": pl.String,
+        "scryfallId": pl.String,
+        "manaCost": pl.String,
+        "type": pl.String,
+        "text": pl.String,
+        "colors": pl.List(pl.String),
+        "colorIdentity": pl.List(pl.String),
+        "finishes": pl.List(pl.String),
+        "rarity": pl.String,
+        "lang": pl.String,
+        "manaValue": pl.Float64,
+        "cardFaces": pl.List(face_struct),
+    }
+    return pl.LazyFrame(rows, schema=schema)
+
+
+# ---------------------------------------------------------------------------
+# TestExplodeCardFaces
+# ---------------------------------------------------------------------------
+
+
+class TestExplodeCardFaces:
+    def test_single_face_no_cardfaces_column(self):
+        """No cardFaces column -> faceId=0, side=None, _face_data=None."""
+        lf = make_card_lf([{"name": "Lightning Bolt"}])
+        # drop _face_data and _row_id so we test the "no cardFaces" fallback
+        lf = lf.drop(["_face_data", "_row_id"])
+        result = explode_card_faces(lf).collect()
+        assert len(result) == 1
+        assert result["faceId"][0] == 0
+        assert result["side"][0] is None
+        assert result["_face_data"][0] is None
+
+    def test_dual_face_card(self):
+        """cardFaces with 2 structs -> 2 rows."""
+        face_a = make_face_struct(name="Front")
+        face_b = make_face_struct(name="Back", mana_cost="", oracle_text="Back text")
+        lf = _make_multiface_lf([[face_a, face_b]])
+        result = explode_card_faces(lf).collect()
+        assert len(result) == 2
+        assert result["faceId"].to_list() == [0, 1]
+        assert result["side"].to_list() == ["a", "b"]
+        # _face_data should be populated
+        assert result["_face_data"][0] is not None
+        assert result["_face_data"][1] is not None
+
+    def test_triple_face_card(self):
+        """3 faces -> sides a/b/c."""
+        faces = [
+            make_face_struct(name="A"),
+            make_face_struct(name="B"),
+            make_face_struct(name="C"),
+        ]
+        lf = _make_multiface_lf([faces])
+        result = explode_card_faces(lf).collect()
+        assert len(result) == 3
+        assert result["side"].to_list() == ["a", "b", "c"]
+
+    def test_row_id_preserved(self):
+        """_row_id is set as sequential index."""
+        faces = [make_face_struct(name="Front"), make_face_struct(name="Back")]
+        lf = _make_multiface_lf([faces, faces])
+        result = explode_card_faces(lf).collect()
+        # Each original card gets a unique _row_id
+        row_ids = result["_row_id"].to_list()
+        # Card 0 has _row_id 0 for both faces, Card 1 has _row_id 1
+        assert row_ids == [0, 0, 1, 1]
+
+
+# ---------------------------------------------------------------------------
+# TestAssignMeldSides
+# ---------------------------------------------------------------------------
+
+
+class TestAssignMeldSides:
+    def test_meld_parts_get_side_a(self, meld_ctx: PipelineContext):
+        lf = make_card_lf(
+            [
+                {"name": "Urza, Lord Protector", "layout": "meld", "side": None},
+                {"name": "The Mightstone and Weakstone", "layout": "meld", "side": None, "_row_id": 1},
+            ]
+        )
+        result = assign_meld_sides(lf, meld_ctx).collect()
+        sides = result["side"].to_list()
+        assert sides == ["a", "a"]
+
+    def test_meld_result_gets_side_b(self, meld_ctx: PipelineContext):
+        lf = make_card_lf(
+            [
+                {"name": "Urza, Planeswalker", "layout": "meld", "side": None},
+            ]
+        )
+        result = assign_meld_sides(lf, meld_ctx).collect()
+        assert result["side"][0] == "b"
+
+    def test_non_meld_cards_unchanged(self, meld_ctx: PipelineContext):
+        lf = make_card_lf(
+            [
+                {"name": "Lightning Bolt", "layout": "normal", "side": None},
+            ]
+        )
+        result = assign_meld_sides(lf, meld_ctx).collect()
+        assert result["side"][0] is None
+
+    def test_empty_meld_triplets_passthrough(self, simple_ctx: PipelineContext):
+        lf = make_card_lf(
+            [
+                {"name": "Urza, Planeswalker", "layout": "meld", "side": None},
+            ]
+        )
+        result = assign_meld_sides(lf, simple_ctx).collect()
+        # With no meld_triplets, side stays None
+        assert result["side"][0] is None
+
+
+# ---------------------------------------------------------------------------
+# TestParseTypeLineExpr
+# ---------------------------------------------------------------------------
+
+
+class TestParseTypeLineExpr:
+    @pytest.mark.parametrize(
+        ("type_line", "expected_super", "expected_types", "expected_sub"),
+        [
+            ("Creature — Human Warrior", [], ["Creature"], ["Human", "Warrior"]),
+            ("Legendary Creature — Elf", ["Legendary"], ["Creature"], ["Elf"]),
+            ("Instant", [], ["Instant"], []),
+            ("Creature — Time Lord", [], ["Creature"], ["Time Lord"]),
+            ("Plane — Ravnica", [], ["Plane"], ["Ravnica"]),
+            (None, [], ["Card"], []),
+        ],
+        ids=[
+            "creature_subtypes",
+            "legendary_supertype",
+            "instant_no_subtypes",
+            "multi_word_subtype",
+            "plane_subtype",
+            "null_type",
+        ],
+    )
+    def test_parse_type_line(
+        self,
+        type_line: str | None,
+        expected_super: list[str],
+        expected_types: list[str],
+        expected_sub: list[str],
+    ):
+        lf = make_card_lf([{"type": type_line}])
+        result = parse_type_line_expr(lf).collect()
+        assert result["supertypes"].to_list()[0] == expected_super
+        assert result["types"].to_list()[0] == expected_types
+        assert result["subtypes"].to_list()[0] == expected_sub
+
+
+# ---------------------------------------------------------------------------
+# TestAddManaInfo
+# ---------------------------------------------------------------------------
+
+
+class TestAddManaInfo:
+    def test_mana_value_from_cmc(self):
+        lf = make_card_lf([{"manaValue": 3.0}])
+        result = add_mana_info(lf).collect()
+        assert result["manaValue"][0] == pytest.approx(3.0)
+        assert result["convertedManaCost"][0] == pytest.approx(3.0)
+
+    def test_face_mana_value_from_face_data(self):
+        face = make_face_struct(mana_cost="{2}{R}")
+        lf = make_card_lf([{"manaValue": 5.0, "_face_data": face}])
+        result = add_mana_info(lf).collect()
+        assert result["faceManaValue"][0] == pytest.approx(3.0)
+
+    def test_null_mana_cost_zero(self):
+        lf = make_card_lf([{"manaValue": None}])
+        result = add_mana_info(lf).collect()
+        assert result["manaValue"][0] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# TestFormatPlaneswalkerText
+# ---------------------------------------------------------------------------
+
+
+class TestFormatPlaneswalkerText:
+    @pytest.mark.parametrize(
+        ("input_text", "expected"),
+        [
+            ("+1: Draw a card.", "[+1]: Draw a card."),
+            ("−2: Deal 3 damage.", "[−2]: Deal 3 damage."),
+            ("0: Create a token.", "[0]: Create a token."),
+        ],
+        ids=["plus_ability", "minus_ability", "zero_ability"],
+    )
+    def test_format_text(self, input_text: str, expected: str):
+        lf = make_card_lf([{"text": input_text}])
+        result = format_planeswalker_text(lf).collect()
+        assert result["text"][0] == expected
+
+
+# ---------------------------------------------------------------------------
+# TestAddIsTimeshifted
+# ---------------------------------------------------------------------------
+
+
+class TestAddIsTimeshifted:
+    def test_future_frame_is_timeshifted(self):
+        lf = pl.LazyFrame(
+            {"frameVersion": ["future"], "setCode": ["FUT"]},
+        )
+        result = add_is_timeshifted(lf).collect()
+        assert result["isTimeshifted"][0] is True
+
+    def test_normal_frame_not_timeshifted(self):
+        lf = pl.LazyFrame(
+            {"frameVersion": ["2015"], "setCode": ["MH3"]},
+        )
+        result = add_is_timeshifted(lf).collect()
+        assert result["isTimeshifted"][0] is None
+
+    def test_tsb_set_always_timeshifted(self):
+        lf = pl.LazyFrame(
+            {"frameVersion": ["2003"], "setCode": ["TSB"]},
+        )
+        result = add_is_timeshifted(lf).collect()
+        assert result["isTimeshifted"][0] is True
+
+
+# ---------------------------------------------------------------------------
+# TestDetectAftermathLayout
+# ---------------------------------------------------------------------------
+
+
+class TestDetectAftermathLayout:
+    def test_aftermath_detected(self):
+        """Split card with 'Aftermath' in back face text -> layout='aftermath'."""
+        face_a = make_face_struct(name="Front", oracle_text="Deal 3 damage.")
+        face_b = make_face_struct(name="Back", oracle_text="Aftermath\nReturn target creature.")
+        lf = _make_multiface_lf([[face_a, face_b]], layout="split")
+        lf = explode_card_faces(lf)
+        result = detect_aftermath_layout(lf).collect()
+        layouts = result["layout"].to_list()
+        assert all(l == "aftermath" for l in layouts)
+
+    def test_normal_split_unchanged(self):
+        """Split card without 'Aftermath' stays split."""
+        face_a = make_face_struct(name="Front", oracle_text="Draw a card.")
+        face_b = make_face_struct(name="Back", oracle_text="Gain 3 life.")
+        lf = _make_multiface_lf([[face_a, face_b]], layout="split")
+        lf = explode_card_faces(lf)
+        result = detect_aftermath_layout(lf).collect()
+        layouts = result["layout"].to_list()
+        assert all(l == "split" for l in layouts)


### PR DESCRIPTION
## Summary
- Part of the v5.3 test suite expansion (442 tests total across all PRs)
- Includes shared test infrastructure (conftest.py, pytest importlib config)

### Files
- `tests/mtgjson5/test_pipeline_transforms.py`

## Test plan
- [x] `pytest tests/mtgjson5/ --record-mode=none` — 442 passed
- [x] `uv run tox` — all environments pass (format-check, lint, mypy, unit)