### PR TITLE
Add table assembler tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ disable_error_code = ["typeddict-item", "no-any-return"]
 
 [tool.pytest.ini_options]
 # -q (quiet mode): reduces output verbosity to show only test results, keeping CI logs clean
-addopts = "-q"
+addopts = "-q --import-mode=importlib"
 # VCR cassette recording modes:
 # - Local development: use --record-mode=once to record new cassettes
 # - CI/offline: use --record-mode=none to ensure no network access (enforced in tox config)

--- a/tests/mtgjson5/conftest.py
+++ b/tests/mtgjson5/conftest.py
@@ -1,0 +1,666 @@
+"""Shared fixtures and helpers for pipeline and assembly tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import polars as pl
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--update-golden",
+        action="store_true",
+        default=False,
+        help="Re-generate golden test files instead of asserting",
+    )
+
+
+@pytest.fixture(scope="session")
+def update_golden(request: pytest.FixtureRequest) -> bool:
+    return bool(request.config.getoption("--update-golden"))
+
+
+def make_face_struct(**overrides: Any) -> dict[str, Any]:
+    """Build a dict matching CardFace.polars_schema() struct fields."""
+    defaults: dict[str, Any] = {
+        "object": "card_face",
+        "name": "Test Face",
+        "mana_cost": "{1}{W}",
+        "type_line": "Creature — Human",
+        "oracle_text": "Test text",
+        "colors": ["W"],
+        "color_indicator": None,
+        "power": "2",
+        "toughness": "2",
+        "defense": None,
+        "loyalty": None,
+        "flavor_text": None,
+        "flavor_name": None,
+        "illustration_id": None,
+        "image_uris": None,
+        "artist": "Test Artist",
+        "artist_id": None,
+        "watermark": None,
+        "printed_name": None,
+        "printed_text": None,
+        "printed_type_line": None,
+        "cmc": None,
+        "oracle_id": None,
+        "layout": None,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def make_card_row(**overrides: Any) -> dict[str, Any]:
+    """Return a dict with sensible defaults for every column the pipeline expects.
+
+    Caller overrides only fields relevant to their test.
+    """
+    defaults: dict[str, Any] = {
+        "name": "Test Card",
+        "setCode": "TST",
+        "number": "1",
+        "layout": "normal",
+        "uuid": "test-uuid-001",
+        "scryfallId": "sf-001",
+        "side": None,
+        "faceId": 0,
+        "manaCost": "{1}{W}",
+        "type": "Creature — Human Warrior",
+        "text": "Test card text.",
+        "colors": ["W"],
+        "colorIdentity": ["W"],
+        "finishes": ["nonfoil"],
+        "rarity": "common",
+        "lang": "en",
+        "language": "en",
+        "manaValue": 2.0,
+        "promoTypes": None,
+        "frameEffects": None,
+        "keywords": None,
+        "power": None,
+        "toughness": None,
+        "boosterTypes": None,
+        "cardParts": None,
+        "faceName": None,
+        "otherFaceIds": None,
+        "_face_data": None,
+        "_row_id": 0,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def make_meld_triplet_lf(
+    set_code: str = "BRO",
+    lang: str = "en",
+) -> pl.LazyFrame:
+    """Build a 3-card LazyFrame with correct meld cardParts/faceName/number columns."""
+    card_parts = ["Urza, Lord Protector", "The Mightstone and Weakstone", "Urza, Planeswalker"]
+    rows = [
+        {
+            "setCode": set_code,
+            "language": lang,
+            "number": "225",
+            "faceName": "Urza, Lord Protector",
+            "uuid": "uuid-front1",
+            "cardParts": card_parts,
+            "otherFaceIds": None,
+        },
+        {
+            "setCode": set_code,
+            "language": lang,
+            "number": "238a",
+            "faceName": "The Mightstone and Weakstone",
+            "uuid": "uuid-front2",
+            "cardParts": card_parts,
+            "otherFaceIds": None,
+        },
+        {
+            "setCode": set_code,
+            "language": lang,
+            "number": "238b",
+            "faceName": "Urza, Planeswalker",
+            "uuid": "uuid-result",
+            "cardParts": card_parts,
+            "otherFaceIds": None,
+        },
+    ]
+    return pl.LazyFrame(
+        rows,
+        schema={
+            "setCode": pl.String,
+            "language": pl.String,
+            "number": pl.String,
+            "faceName": pl.String,
+            "uuid": pl.String,
+            "cardParts": pl.List(pl.String),
+            "otherFaceIds": pl.List(pl.String),
+        },
+    )
+
+
+def make_card_lf(rows: list[dict[str, Any]] | None = None) -> pl.LazyFrame:
+    """Wraps make_card_row defaults + explicit schema -> pl.LazyFrame."""
+    if rows is None:
+        rows = [make_card_row()]
+    from mtgjson5.models.scryfall.models import CardFace
+
+    face_struct_schema = CardFace.polars_schema()
+    full_rows = [make_card_row(**r) for r in rows]
+    return pl.LazyFrame(
+        full_rows,
+        schema={
+            "name": pl.String,
+            "setCode": pl.String,
+            "number": pl.String,
+            "layout": pl.String,
+            "uuid": pl.String,
+            "scryfallId": pl.String,
+            "side": pl.String,
+            "faceId": pl.Int64,
+            "manaCost": pl.String,
+            "type": pl.String,
+            "text": pl.String,
+            "colors": pl.List(pl.String),
+            "colorIdentity": pl.List(pl.String),
+            "finishes": pl.List(pl.String),
+            "rarity": pl.String,
+            "lang": pl.String,
+            "manaValue": pl.Float64,
+            "_face_data": face_struct_schema,
+            "_row_id": pl.UInt32,
+        },
+    )
+
+
+def make_full_card_df() -> pl.DataFrame:
+    """Return a DataFrame with representative column types for cross-format tests.
+
+    Includes: String, Int64, Float64, Boolean, List(String), Struct, and a null row.
+    """
+    return pl.DataFrame(
+        {
+            "uuid": ["card-001", "card-002", None],
+            "name": ["Alpha Card", "Beta Card", None],
+            "cmc": [3, 0, None],
+            "price": [1.99, 0.0, None],
+            "hasFoil": [True, False, None],
+            "colors": [["W", "U"], [], None],
+            "identifiers": [
+                {"scryfallId": "sf-001", "multiverseId": "123"},
+                {"scryfallId": "sf-002", "multiverseId": None},
+                None,
+            ],
+        },
+        schema={
+            "uuid": pl.String,
+            "name": pl.String,
+            "cmc": pl.Int64,
+            "price": pl.Float64,
+            "hasFoil": pl.Boolean,
+            "colors": pl.List(pl.String),
+            "identifiers": pl.Struct({"scryfallId": pl.String, "multiverseId": pl.String}),
+        },
+    )
+
+
+@pytest.fixture
+def simple_ctx():  # -> PipelineContext
+    """PipelineContext.for_testing() with empty meld_triplets and manual_overrides."""
+    from mtgjson5.data.context import PipelineContext
+
+    return PipelineContext.for_testing(
+        meld_triplets={},
+        manual_overrides={},
+    )
+
+
+@pytest.fixture
+def meld_ctx():  # -> PipelineContext
+    """PipelineContext.for_testing() with a sample meld triplet."""
+    from mtgjson5.data.context import PipelineContext
+
+    return PipelineContext.for_testing(
+        meld_triplets={
+            "Urza": [
+                "Urza, Lord Protector",
+                "The Mightstone and Weakstone",
+                "Urza, Planeswalker",
+            ]
+        },
+        manual_overrides={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Assembly-level helpers
+# ---------------------------------------------------------------------------
+
+_IDENTIFIERS_EMPTY: dict[str, Any] = {
+    "abuId": None,
+    "cardKingdomEtchedId": None,
+    "cardKingdomFoilId": None,
+    "cardKingdomId": None,
+    "cardsphereFoilId": None,
+    "cardsphereId": None,
+    "cardtraderId": None,
+    "csiId": None,
+    "deckboxId": None,
+    "mcmId": None,
+    "mcmMetaId": None,
+    "miniaturemarketId": None,
+    "mtgArenaId": None,
+    "mtgjsonFoilVersionId": None,
+    "mtgjsonNonFoilVersionId": None,
+    "mtgjsonV4Id": None,
+    "mtgoFoilId": None,
+    "mtgoId": None,
+    "multiverseId": None,
+    "mvpId": None,
+    "scgId": None,
+    "scryfallCardBackId": None,
+    "scryfallId": None,
+    "scryfallIllustrationId": None,
+    "scryfallOracleId": None,
+    "tcgplayerAlternativeFoilProductId": None,
+    "tcgplayerEtchedProductId": None,
+    "tcgplayerProductId": None,
+    "tntId": None,
+}
+
+_LEGALITIES_EMPTY: dict[str, Any] = {
+    "alchemy": None,
+    "brawl": None,
+    "commander": None,
+    "duel": None,
+    "explorer": None,
+    "future": None,
+    "gladiator": None,
+    "historic": None,
+    "historicbrawl": None,
+    "legacy": None,
+    "modern": None,
+    "oathbreaker": None,
+    "oldschool": None,
+    "pauper": None,
+    "paupercommander": None,
+    "penny": None,
+    "pioneer": None,
+    "predh": None,
+    "premodern": None,
+    "standard": None,
+    "standardbrawl": None,
+    "timeless": None,
+    "vintage": None,
+}
+
+_PURCHASE_URLS_EMPTY: dict[str, Any] = {
+    "cardKingdom": None,
+    "cardKingdomEtched": None,
+    "cardKingdomFoil": None,
+    "cardmarket": None,
+    "tcgplayer": None,
+    "tcgplayerAlternativeFoil": None,
+    "tcgplayerEtched": None,
+}
+
+
+def make_assembled_card(**overrides: Any) -> dict[str, Any]:
+    """Build a dict matching CardSet.polars_schema() for assembly-level tests.
+
+    All 87 fields are present with sensible defaults. Override only what matters.
+    """
+    defaults: dict[str, Any] = {
+        # -- scalars --
+        "artist": "Test Artist",
+        "asciiName": None,
+        "borderColor": "black",
+        "convertedManaCost": 2.0,
+        "defense": None,
+        "duelDeck": None,
+        "edhrecRank": None,
+        "edhrecSaltiness": None,
+        "faceConvertedManaCost": None,
+        "faceFlavorName": None,
+        "faceManaValue": None,
+        "faceName": None,
+        "facePrintedName": None,
+        "flavorName": None,
+        "flavorText": None,
+        "frameVersion": "2015",
+        "hand": None,
+        "hasAlternativeDeckLimit": None,
+        "hasContentWarning": None,
+        "isAlternative": None,
+        "isFullArt": None,
+        "isFunny": None,
+        "isGameChanger": None,
+        "isOnlineOnly": None,
+        "isOversized": None,
+        "isPromo": None,
+        "isRebalanced": None,
+        "isReprint": None,
+        "isReserved": None,
+        "isStorySpotlight": None,
+        "isTextless": None,
+        "isTimeshifted": None,
+        "language": "English",
+        "layout": "normal",
+        "life": None,
+        "loyalty": None,
+        "manaCost": "{1}{R}",
+        "manaValue": 2.0,
+        "name": "Test Card",
+        "number": "1",
+        "originalReleaseDate": None,
+        "originalText": None,
+        "originalType": None,
+        "power": None,
+        "printedName": None,
+        "printedText": None,
+        "printedType": None,
+        "rarity": "common",
+        "securityStamp": None,
+        "setCode": "TST",
+        "side": None,
+        "signature": None,
+        "text": "Test card text.",
+        "toughness": None,
+        "type": "Instant",
+        "uuid": "test-uuid-001",
+        "watermark": None,
+        # -- lists --
+        "artistIds": None,
+        "attractionLights": None,
+        "availability": ["paper"],
+        "boosterTypes": None,
+        "cardParts": None,
+        "colorIdentity": ["R"],
+        "colorIndicator": None,
+        "colors": ["R"],
+        "finishes": ["nonfoil"],
+        "frameEffects": None,
+        "keywords": None,
+        "originalPrintings": None,
+        "otherFaceIds": None,
+        "printings": None,
+        "producedMana": None,
+        "promoTypes": None,
+        "rebalancedPrintings": None,
+        "subsets": None,
+        "subtypes": [],
+        "supertypes": [],
+        "types": ["Instant"],
+        "variations": None,
+        # -- structs --
+        "identifiers": {**_IDENTIFIERS_EMPTY, "scryfallId": "sf-001", "scryfallOracleId": "oracle-001"},
+        "legalities": {**_LEGALITIES_EMPTY, "vintage": "Legal", "legacy": "Legal", "commander": "Legal"},
+        "leadershipSkills": None,
+        "purchaseUrls": _PURCHASE_URLS_EMPTY.copy(),
+        "relatedCards": None,
+        "sourceProducts": None,
+        # -- complex lists --
+        "foreignData": None,
+        "rulings": None,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def make_assembled_token(**overrides: Any) -> dict[str, Any]:
+    """Build a dict matching CardToken.polars_schema() for assembly-level tests."""
+    defaults: dict[str, Any] = {
+        "artist": "Token Artist",
+        "artistIds": None,
+        "asciiName": None,
+        "attractionLights": None,
+        "availability": ["paper"],
+        "boosterTypes": None,
+        "borderColor": "black",
+        "cardParts": None,
+        "colorIdentity": [],
+        "colorIndicator": None,
+        "colors": ["B"],
+        "edhrecSaltiness": None,
+        "faceFlavorName": None,
+        "faceName": None,
+        "facePrintedName": None,
+        "finishes": ["nonfoil"],
+        "flavorName": None,
+        "flavorText": None,
+        "frameEffects": None,
+        "frameVersion": "2015",
+        "identifiers": {**_IDENTIFIERS_EMPTY, "scryfallId": "sf-token-001"},
+        "isFullArt": None,
+        "isFunny": None,
+        "isOnlineOnly": None,
+        "isOversized": None,
+        "isPromo": None,
+        "isReprint": None,
+        "isTextless": None,
+        "keywords": None,
+        "language": "English",
+        "layout": "token",
+        "loyalty": None,
+        "manaCost": None,
+        "name": "Zombie",
+        "number": "T1",
+        "orientation": None,
+        "originalText": None,
+        "originalType": None,
+        "otherFaceIds": None,
+        "power": "2",
+        "printedName": None,
+        "printedText": None,
+        "printedType": None,
+        "producedMana": None,
+        "promoTypes": None,
+        "relatedCards": None,
+        "securityStamp": None,
+        "setCode": "TTST",
+        "side": None,
+        "signature": None,
+        "sourceProducts": None,
+        "subsets": None,
+        "subtypes": ["Zombie"],
+        "supertypes": [],
+        "text": None,
+        "tokenProducts": None,
+        "toughness": "2",
+        "type": "Token Creature — Zombie",
+        "types": ["Token", "Creature"],
+        "uuid": "uuid-zombie-001",
+        "watermark": None,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+@pytest.fixture(scope="session")
+def assembly_ctx(tmp_path_factory: pytest.TempPathFactory) -> AssemblyContext:
+    """Build a tiny AssemblyContext from synthetic parquet fixtures."""
+    from mtgjson5.build.context import AssemblyContext
+    from mtgjson5.models.cards import CardSet, CardToken
+
+    base = tmp_path_factory.mktemp("assembly")
+    parquet_dir = base / "_parquet"
+    tokens_dir = base / "_parquet_tokens"
+    output_dir = base / "output"
+    output_dir.mkdir()
+
+    card_schema = CardSet.polars_schema()
+    token_schema = CardToken.polars_schema()
+
+    # --- TST set: 4 cards ---
+    tst_cards = [
+        make_assembled_card(
+            name="Lightning Bolt",
+            number="1",
+            uuid="uuid-bolt-tst",
+            type="Instant",
+            types=["Instant"],
+            text="Lightning Bolt deals 3 damage to any target.",
+            manaCost="{R}",
+            manaValue=1.0,
+            convertedManaCost=1.0,
+            colors=["R"],
+            colorIdentity=["R"],
+            identifiers={**_IDENTIFIERS_EMPTY, "scryfallId": "sf-bolt-tst", "scryfallOracleId": "oracle-bolt"},
+            legalities={
+                **_LEGALITIES_EMPTY,
+                "vintage": "Legal",
+                "legacy": "Legal",
+                "modern": "Legal",
+                "commander": "Legal",
+            },
+        ),
+        make_assembled_card(
+            name="Wear // Tear",
+            number="2a",
+            uuid="uuid-wear",
+            layout="split",
+            side="a",
+            faceName="Wear",
+            type="Instant",
+            types=["Instant"],
+            text="Destroy target artifact.",
+            manaCost="{R}",
+            manaValue=3.0,
+            convertedManaCost=3.0,
+            colors=["R"],
+            colorIdentity=["R", "W"],
+            otherFaceIds=["uuid-tear"],
+            identifiers={**_IDENTIFIERS_EMPTY, "scryfallId": "sf-wt", "scryfallOracleId": "oracle-wt"},
+            legalities={**_LEGALITIES_EMPTY, "vintage": "Legal", "legacy": "Legal", "commander": "Legal"},
+        ),
+        make_assembled_card(
+            name="Wear // Tear",
+            number="2b",
+            uuid="uuid-tear",
+            layout="split",
+            side="b",
+            faceName="Tear",
+            type="Instant",
+            types=["Instant"],
+            text="Destroy target enchantment.",
+            manaCost="{W}",
+            manaValue=3.0,
+            convertedManaCost=3.0,
+            colors=["W"],
+            colorIdentity=["R", "W"],
+            otherFaceIds=["uuid-wear"],
+            identifiers={**_IDENTIFIERS_EMPTY, "scryfallId": "sf-wt", "scryfallOracleId": "oracle-wt"},
+            legalities={**_LEGALITIES_EMPTY, "vintage": "Legal", "legacy": "Legal", "commander": "Legal"},
+        ),
+        make_assembled_card(
+            name="Funny Card",
+            number="3",
+            uuid="uuid-funny",
+            type="Creature — Clown",
+            types=["Creature"],
+            subtypes=["Clown"],
+            text="This card is funny.",
+            isFunny=True,
+            power="1",
+            toughness="1",
+            identifiers={**_IDENTIFIERS_EMPTY, "scryfallId": "sf-funny", "scryfallOracleId": "oracle-funny"},
+            legalities=_LEGALITIES_EMPTY.copy(),
+        ),
+    ]
+
+    # --- TS2 set: 2 cards (Lightning Bolt reprint + Prodigal Sorcerer) ---
+    ts2_cards = [
+        make_assembled_card(
+            name="Lightning Bolt",
+            number="1",
+            uuid="uuid-bolt-ts2",
+            setCode="TS2",
+            type="Instant",
+            types=["Instant"],
+            text="Lightning Bolt deals 3 damage to any target.",
+            manaCost="{R}",
+            manaValue=1.0,
+            convertedManaCost=1.0,
+            colors=["R"],
+            colorIdentity=["R"],
+            isReprint=True,
+            identifiers={**_IDENTIFIERS_EMPTY, "scryfallId": "sf-bolt-ts2", "scryfallOracleId": "oracle-bolt"},
+            legalities={
+                **_LEGALITIES_EMPTY,
+                "vintage": "Legal",
+                "legacy": "Legal",
+                "modern": "Legal",
+                "commander": "Legal",
+                "pauper": "Legal",
+            },
+        ),
+        make_assembled_card(
+            name="Prodigal Sorcerer",
+            number="2",
+            uuid="uuid-sorcerer",
+            setCode="TS2",
+            type="Creature — Human Wizard",
+            types=["Creature"],
+            subtypes=["Human", "Wizard"],
+            text="{T}: Prodigal Sorcerer deals 1 damage to any target.",
+            manaCost="{2}{U}",
+            manaValue=3.0,
+            convertedManaCost=3.0,
+            colors=["U"],
+            colorIdentity=["U"],
+            power="1",
+            toughness="1",
+            identifiers={**_IDENTIFIERS_EMPTY, "scryfallId": "sf-sorcerer", "scryfallOracleId": "oracle-sorcerer"},
+            legalities={**_LEGALITIES_EMPTY, "vintage": "Legal", "legacy": "Legal", "commander": "Legal"},
+        ),
+    ]
+
+    # --- Token ---
+    token = make_assembled_token()
+
+    # Write parquet partitions
+    for code, cards in [("TST", tst_cards), ("TS2", ts2_cards)]:
+        path = parquet_dir / f"setCode={code}"
+        path.mkdir(parents=True)
+        pl.DataFrame(cards, schema=card_schema).write_parquet(path / "0.parquet")
+
+    t_path = tokens_dir / "setCode=TTST"
+    t_path.mkdir(parents=True)
+    pl.DataFrame([token], schema=token_schema).write_parquet(t_path / "0.parquet")
+
+    set_meta = {
+        "TST": {
+            "code": "TST",
+            "name": "Test Set",
+            "type": "expansion",
+            "releaseDate": "2025-01-01",
+            "keyruneCode": "TST",
+            "isFoilOnly": False,
+            "isOnlineOnly": False,
+            "tokenSetCode": "TTST",
+            "translations": {},
+        },
+        "TS2": {
+            "code": "TS2",
+            "name": "Test Set Two",
+            "type": "expansion",
+            "releaseDate": "2025-06-01",
+            "keyruneCode": "TS2",
+            "isFoilOnly": False,
+            "isOnlineOnly": False,
+            "tokenSetCode": None,
+            "translations": {},
+        },
+    }
+
+    return AssemblyContext(
+        parquet_dir=parquet_dir,
+        tokens_dir=tokens_dir,
+        set_meta=set_meta,
+        meta={"date": "2025-01-01", "version": "5.3.0+test"},
+        output_path=output_dir,
+    )

--- a/tests/mtgjson5/test_table_assembler.py
+++ b/tests/mtgjson5/test_table_assembler.py
@@ -1,0 +1,405 @@
+"""Tests for TableAssembler — build_all normalization and build_boosters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import polars as pl
+
+from mtgjson5.build.assemble import TableAssembler
+from mtgjson5.models.schemas import (
+    CARDS_TABLE_EXCLUDE,
+    SETS_TABLE_EXCLUDE,
+    TOKENS_TABLE_EXCLUDE,
+)
+
+# =============================================================================
+# Helpers — synthetic DataFrames
+# =============================================================================
+
+
+def _make_cards_df(rows: list[dict[str, Any]] | None = None) -> pl.DataFrame:
+    """Build a minimal cards DataFrame exercising all normalization paths."""
+    if rows is None:
+        rows = [
+            {
+                "uuid": "uuid-001",
+                "name": "Lightning Bolt",
+                "setCode": "M10",
+                "number": "1",
+                "type": "Instant",
+                "colors": ["R"],
+                "identifiers": {"scryfallId": "sf-001", "multiverseId": "12345"},
+                "legalities": {"vintage": "Legal", "modern": "Legal"},
+                "rulings": [
+                    {"publishedAt": "2020-01-01", "comment": "Good card.", "source": "wotc"},
+                ],
+                "foreignData": [
+                    {"language": "German", "name": "Blitzschlag", "uuid": "foreign-uuid-should-drop"},
+                ],
+                "purchaseUrls": {"tcgplayer": "https://tcg.example.com"},
+            },
+            {
+                "uuid": "uuid-002",
+                "name": "Giant Growth",
+                "setCode": "M10",
+                "number": "2",
+                "type": "Instant",
+                "colors": ["G"],
+                "identifiers": {"scryfallId": "sf-002", "multiverseId": "12346"},
+                "legalities": {"vintage": "Legal", "modern": "Legal"},
+                "rulings": [],
+                "foreignData": [],
+                "purchaseUrls": {"tcgplayer": "https://tcg2.example.com"},
+            },
+        ]
+    return pl.DataFrame(
+        rows,
+        schema={
+            "uuid": pl.String,
+            "name": pl.String,
+            "setCode": pl.String,
+            "number": pl.String,
+            "type": pl.String,
+            "colors": pl.List(pl.String),
+            "identifiers": pl.Struct({"scryfallId": pl.String, "multiverseId": pl.String}),
+            "legalities": pl.Struct({"vintage": pl.String, "modern": pl.String}),
+            "rulings": pl.List(pl.Struct({"publishedAt": pl.String, "comment": pl.String, "source": pl.String})),
+            "foreignData": pl.List(pl.Struct({"language": pl.String, "name": pl.String, "uuid": pl.String})),
+            "purchaseUrls": pl.Struct({"tcgplayer": pl.String}),
+        },
+    )
+
+
+def _make_tokens_df() -> pl.DataFrame:
+    return pl.DataFrame(
+        [
+            {
+                "uuid": "tok-001",
+                "name": "Soldier Token",
+                "setCode": "M10",
+                "number": "T1",
+                "type": "Token Creature — Soldier",
+                "colors": ["W"],
+                "identifiers": {"scryfallId": "sf-tok-001"},
+            },
+        ],
+        schema={
+            "uuid": pl.String,
+            "name": pl.String,
+            "setCode": pl.String,
+            "number": pl.String,
+            "type": pl.String,
+            "colors": pl.List(pl.String),
+            "identifiers": pl.Struct({"scryfallId": pl.String}),
+        },
+    )
+
+
+def _make_sets_df() -> pl.DataFrame:
+    return pl.DataFrame(
+        [
+            {
+                "code": "M10",
+                "name": "Magic 2010",
+                "type": "core",
+                "releaseDate": "2009-07-17",
+                "translations": {"French": "Magic 2010", "German": "Hauptset 2010"},
+            },
+        ],
+        schema={
+            "code": pl.String,
+            "name": pl.String,
+            "type": pl.String,
+            "releaseDate": pl.String,
+            "translations": pl.Struct({"French": pl.String, "German": pl.String}),
+        },
+    )
+
+
+def _make_booster_config() -> dict[str, dict[str, Any]]:
+    return {
+        "TST": {
+            "default": {
+                "sheets": {
+                    "common": {
+                        "foil": False,
+                        "balanceColors": True,
+                        "totalWeight": 100,
+                        "cards": {"uuid-001": 10, "uuid-002": 10},
+                    },
+                    "rare": {
+                        "foil": True,
+                        "balanceColors": False,
+                        "totalWeight": 50,
+                        "cards": {"uuid-003": 50},
+                    },
+                },
+                "boosters": [
+                    {
+                        "weight": 5,
+                        "contents": {"common": 10, "rare": 1},
+                    },
+                    {
+                        "weight": 1,
+                        "contents": {"rare": 2},
+                    },
+                ],
+            },
+        },
+    }
+
+
+# =============================================================================
+# TestBuildAllCards
+# =============================================================================
+
+
+class TestBuildAllCards:
+    def test_cards_table_excludes_normalized_columns(self):
+        tables = TableAssembler.build_all(_make_cards_df())
+        assert "cards" in tables
+        for excluded in CARDS_TABLE_EXCLUDE:
+            assert excluded not in tables["cards"].columns
+
+    def test_uuid_deduplication(self):
+        row = {
+            "uuid": "uuid-dup",
+            "name": "Dup Card",
+            "setCode": "TST",
+            "number": "1",
+            "type": "Creature",
+            "colors": ["W"],
+            "identifiers": {"scryfallId": "sf-dup", "multiverseId": None},
+            "legalities": {"vintage": "Legal", "modern": None},
+            "rulings": [],
+            "foreignData": [],
+            "purchaseUrls": {"tcgplayer": None},
+        }
+        df = _make_cards_df([row, row])
+        tables = TableAssembler.build_all(df)
+        assert len(tables["cards"]) == 1
+
+    def test_complex_types_serialized(self):
+        tables = TableAssembler.build_all(_make_cards_df())
+        # colors should be serialized to a string (comma-separated)
+        assert tables["cards"].schema["colors"] == pl.String
+
+    def test_internal_columns_excluded(self):
+        df = _make_cards_df()
+        df = df.with_columns(pl.lit("internal").alias("_debug"))
+        tables = TableAssembler.build_all(df)
+        assert "_debug" not in tables["cards"].columns
+
+
+# =============================================================================
+# TestBuildAllCardIdentifiers
+# =============================================================================
+
+
+class TestBuildAllCardIdentifiers:
+    def test_card_identifiers_created(self):
+        tables = TableAssembler.build_all(_make_cards_df())
+        assert "cardIdentifiers" in tables
+        assert "uuid" in tables["cardIdentifiers"].columns
+        assert "scryfallId" in tables["cardIdentifiers"].columns
+
+    def test_struct_unnested(self):
+        tables = TableAssembler.build_all(_make_cards_df())
+        ci = tables["cardIdentifiers"]
+        # identifiers struct should be unnested into separate columns
+        assert "identifiers" not in ci.columns
+        assert "multiverseId" in ci.columns
+
+    def test_null_identifiers_filtered(self):
+        df = _make_cards_df()
+        # Set identifiers to null for one row
+        df = df.with_columns(
+            pl.when(pl.col("uuid") == "uuid-002")
+            .then(pl.lit(None, dtype=df.schema["identifiers"]))
+            .otherwise(pl.col("identifiers"))
+            .alias("identifiers")
+        )
+        tables = TableAssembler.build_all(df)
+        assert len(tables["cardIdentifiers"]) == 1
+
+
+# =============================================================================
+# TestBuildAllCardLegalities
+# =============================================================================
+
+
+class TestBuildAllCardLegalities:
+    def test_card_legalities_created(self):
+        tables = TableAssembler.build_all(_make_cards_df())
+        assert "cardLegalities" in tables
+        assert "uuid" in tables["cardLegalities"].columns
+
+    def test_format_columns(self):
+        tables = TableAssembler.build_all(_make_cards_df())
+        cl = tables["cardLegalities"]
+        assert "vintage" in cl.columns
+        assert "modern" in cl.columns
+
+
+# =============================================================================
+# TestBuildAllCardRulings
+# =============================================================================
+
+
+class TestBuildAllCardRulings:
+    def test_card_rulings_created(self):
+        tables = TableAssembler.build_all(_make_cards_df())
+        assert "cardRulings" in tables
+        # Only the first card has rulings
+        assert len(tables["cardRulings"]) == 1
+
+    def test_column_renaming(self):
+        tables = TableAssembler.build_all(_make_cards_df())
+        cr = tables["cardRulings"]
+        assert "date" in cr.columns
+        assert "text" in cr.columns
+        assert "publishedAt" not in cr.columns
+        assert "comment" not in cr.columns
+
+    def test_source_column_dropped(self):
+        tables = TableAssembler.build_all(_make_cards_df())
+        assert "source" not in tables["cardRulings"].columns
+
+    def test_uuid_fk_preserved(self):
+        tables = TableAssembler.build_all(_make_cards_df())
+        assert tables["cardRulings"]["uuid"][0] == "uuid-001"
+
+
+# =============================================================================
+# TestBuildAllCardForeignData
+# =============================================================================
+
+
+class TestBuildAllCardForeignData:
+    def test_card_foreign_data_created(self):
+        tables = TableAssembler.build_all(_make_cards_df())
+        assert "cardForeignData" in tables
+        assert len(tables["cardForeignData"]) == 1
+
+    def test_uuid_conflict_resolution(self):
+        tables = TableAssembler.build_all(_make_cards_df())
+        fd = tables["cardForeignData"]
+        # struct's own uuid field should be dropped, card's uuid kept
+        assert fd["uuid"][0] == "uuid-001"
+        assert "foreign-uuid-should-drop" not in fd["uuid"].to_list()
+
+
+# =============================================================================
+# TestBuildAllCardPurchaseUrls
+# =============================================================================
+
+
+class TestBuildAllCardPurchaseUrls:
+    def test_card_purchase_urls_created(self):
+        tables = TableAssembler.build_all(_make_cards_df())
+        assert "cardPurchaseUrls" in tables
+        assert "uuid" in tables["cardPurchaseUrls"].columns
+
+    def test_struct_unnested(self):
+        tables = TableAssembler.build_all(_make_cards_df())
+        pu = tables["cardPurchaseUrls"]
+        assert "tcgplayer" in pu.columns
+        assert "purchaseUrls" not in pu.columns
+
+
+# =============================================================================
+# TestBuildAllTokens
+# =============================================================================
+
+
+class TestBuildAllTokens:
+    def test_tokens_table_created(self):
+        tables = TableAssembler.build_all(_make_cards_df(), tokens_df=_make_tokens_df())
+        assert "tokens" in tables
+        for excluded in TOKENS_TABLE_EXCLUDE:
+            if excluded in _make_tokens_df().columns:
+                assert excluded not in tables["tokens"].columns
+
+    def test_token_identifiers_created(self):
+        tables = TableAssembler.build_all(_make_cards_df(), tokens_df=_make_tokens_df())
+        assert "tokenIdentifiers" in tables
+        assert "uuid" in tables["tokenIdentifiers"].columns
+        assert "scryfallId" in tables["tokenIdentifiers"].columns
+
+
+# =============================================================================
+# TestBuildAllSets
+# =============================================================================
+
+
+class TestBuildAllSets:
+    def test_sets_table_created(self):
+        tables = TableAssembler.build_all(_make_cards_df(), sets_df=_make_sets_df())
+        assert "sets" in tables
+        for excluded in SETS_TABLE_EXCLUDE:
+            if excluded in _make_sets_df().columns:
+                assert excluded not in tables["sets"].columns
+
+    def test_set_translations_created(self):
+        tables = TableAssembler.build_all(_make_cards_df(), sets_df=_make_sets_df())
+        assert "setTranslations" in tables
+        st = tables["setTranslations"]
+        assert "code" in st.columns
+        assert "language" in st.columns
+        assert "translation" in st.columns
+
+
+# =============================================================================
+# TestBuildBoosters
+# =============================================================================
+
+
+class TestBuildBoosters:
+    def test_four_tables_created(self):
+        tables = TableAssembler.build_boosters(_make_booster_config())
+        assert "setBoosterSheets" in tables
+        assert "setBoosterSheetCards" in tables
+        assert "setBoosterContents" in tables
+        assert "setBoosterContentWeights" in tables
+
+    def test_sheet_fields(self):
+        tables = TableAssembler.build_boosters(_make_booster_config())
+        sheets = tables["setBoosterSheets"]
+        for col in ["setCode", "boosterName", "sheetName", "sheetIsFoil", "sheetHasBalanceColors", "sheetTotalWeight"]:
+            assert col in sheets.columns
+        assert len(sheets) == 2  # common + rare
+
+    def test_sheet_cards(self):
+        tables = TableAssembler.build_boosters(_make_booster_config())
+        sc = tables["setBoosterSheetCards"]
+        for col in ["setCode", "boosterName", "sheetName", "cardUuid", "cardWeight"]:
+            assert col in sc.columns
+        assert len(sc) == 3  # uuid-001, uuid-002 in common + uuid-003 in rare
+
+    def test_empty_config_returns_empty_dataframes(self):
+        tables = TableAssembler.build_boosters({})
+        assert len(tables) == 4
+        for df in tables.values():
+            assert len(df) == 0
+
+
+# =============================================================================
+# TestRelationalIntegrity
+# =============================================================================
+
+
+class TestRelationalIntegrity:
+    def test_normalized_tables_have_uuid_fk(self):
+        tables = TableAssembler.build_all(_make_cards_df())
+        card_uuids = set(tables["cards"]["uuid"].to_list())
+        for tname in ["cardIdentifiers", "cardLegalities", "cardPurchaseUrls"]:
+            if tname in tables:
+                fk_uuids = set(tables[tname]["uuid"].to_list())
+                assert fk_uuids.issubset(card_uuids), f"{tname} uuids not subset of cards.uuid"
+
+    def test_set_translations_code_fk(self):
+        tables = TableAssembler.build_all(_make_cards_df(), sets_df=_make_sets_df())
+        set_codes = set(tables["sets"]["code"].to_list())
+        trans_codes = set(tables["setTranslations"]["code"].to_list())
+        assert trans_codes.issubset(set_codes)


### PR DESCRIPTION
## Summary
- Part of the v5.3 test suite expansion (442 tests total across all PRs)
- Includes shared test infrastructure (conftest.py, pytest importlib config)

### Files
- `tests/mtgjson5/test_table_assembler.py`

## Test plan
- [x] `pytest tests/mtgjson5/ --record-mode=none` — 442 passed
- [x] `uv run tox` — all environments pass (format-check, lint, mypy, unit)