### PR TITLE
Add cardmarketFoil to purchaseUrls

### DIFF
--- a/mtgjson5/build/referral_builder.py
+++ b/mtgjson5/build/referral_builder.py
@@ -381,20 +381,24 @@ def _build_cardmarket_entries_from_parquet(
             return None
 
         # Extract needed fields from parquet
-        mcm_data_lf = cards_lf.select(
-            [
-                pl.col("uuid"),
-                pl.col("identifiers").struct.field("scryfallId").alias("_scryfall_id"),
-                pl.col("identifiers").struct.field("mcmId"),
-                pl.col("identifiers").struct.field("mcmMetaId"),
-            ]
-        ).filter(pl.col("mcmId").is_not_null())
+        select_cols = [
+            pl.col("uuid"),
+            pl.col("identifiers").struct.field("scryfallId").alias("_scryfall_id"),
+            pl.col("identifiers").struct.field("mcmId"),
+            pl.col("identifiers").struct.field("mcmMetaId"),
+        ]
+        if "finishes" in parquet_schema.names():
+            select_cols.append(pl.col("finishes"))
+        mcm_data_lf = cards_lf.select(select_cols).filter(pl.col("mcmId").is_not_null())
 
         # Join scryfall URLs with parquet data
+        base_lf = mcm_data_lf.join(cm_urls_lf, on="_scryfall_id", how="inner").filter(pl.col("_cm_url").is_not_null())
+
+        entries = []
+
+        # Non-foil entries
         joined = (
-            mcm_data_lf.join(cm_urls_lf, on="_scryfall_id", how="inner")
-            .filter(pl.col("_cm_url").is_not_null())
-            .with_columns(
+            base_lf.with_columns(
                 [
                     # Hash: sha256(mcm_id + uuid + BUFFER + mcm_meta_id)[:16]
                     plh.concat_str(
@@ -416,9 +420,43 @@ def _build_cardmarket_entries_from_parquet(
             .unique(subset=["hash"])
             .collect()
         )
-
         if len(joined) > 0:
-            return joined
+            entries.append(joined)
+
+        # Foil entries: same URL with &isFoil=Y appended
+        foil_base_lf = base_lf
+        if "finishes" in parquet_schema.names():
+            foil_base_lf = base_lf.filter(pl.col("finishes").list.contains("foil"))
+        foil_joined = (
+            foil_base_lf.with_columns(
+                [
+                    # Hash: sha256(mcm_id + uuid + BUFFER + mcm_meta_id + "foil")[:16]
+                    plh.concat_str(
+                        [
+                            pl.col("mcmId").cast(pl.String),
+                            pl.col("uuid"),
+                            pl.lit(constants.CARD_MARKET_BUFFER),
+                            pl.col("mcmMetaId").cast(pl.String).fill_null(""),
+                            pl.lit("foil"),
+                        ]
+                    )
+                    .chash.sha2_256()
+                    .str.slice(0, 16)
+                    .alias("hash"),
+                    (pl.col("_cm_url").str.replace_all("scryfall", "mtgjson") + pl.lit("&isFoil=Y")).alias(
+                        "referral_url"
+                    ),
+                ]
+            )
+            .select(["hash", "referral_url"])
+            .unique(subset=["hash"])
+            .collect()
+        )
+        if len(foil_joined) > 0:
+            entries.append(foil_joined)
+
+        if entries:
+            return pl.concat(entries)
 
     except Exception as e:
         LOGGER.warning(f"Failed to build Cardmarket referrals: {e}")

--- a/mtgjson5/models/submodels.py
+++ b/mtgjson5/models/submodels.py
@@ -496,6 +496,11 @@ class PurchaseUrls(TypedDict, total=False):
             "introduced": "v4.4.0",
             "optional": True,
         },
+        "cardmarketFoil": {
+            "description": "The URL to purchase a foil product on [Cardmarket](https://www.cardmarket.com/en/Magic?utm_campaign=card_prices&utm_medium=text&utm_source=mtgjson).",
+            "introduced": "v5.3.0",
+            "optional": True,
+        },
         "tcgplayer": {
             "description": "The URL to purchase a product on [TCGplayer](https://www.tcgplayer.com?partner=mtgjson&utm_campaign=affiliate&utm_medium=mtgjson&utm_source=mtgjson).",
             "introduced": "v4.4.0",
@@ -517,6 +522,7 @@ class PurchaseUrls(TypedDict, total=False):
     cardKingdomEtched: str
     cardKingdomFoil: str
     cardmarket: str
+    cardmarketFoil: str
     tcgplayer: str
     tcgplayerEtched: str
     tcgplayerAlternativeFoil: str

--- a/mtgjson5/pipeline/stages/derived.py
+++ b/mtgjson5/pipeline/stages/derived.py
@@ -153,6 +153,19 @@ def add_purchase_urls_struct(
                 .chash.sha2_256()
                 .str.slice(0, 16)
                 .alias("_cm_hash"),
+                # Cardmarket Foil: hash(mcm_id + uuid + BUFFER + mcm_meta_id + "foil")
+                plh.concat_str(  # pylint: disable=no-member
+                    [
+                        mcm_id.cast(pl.String),
+                        pl.col("uuid"),
+                        pl.lit(CARD_MARKET_BUFFER),
+                        pl.col("identifiers").struct.field("mcmMetaId").cast(pl.String).fill_null(""),
+                        pl.lit("foil"),
+                    ]
+                )
+                .chash.sha2_256()
+                .str.slice(0, 16)
+                .alias("_cmf_hash"),
             ]
         )
         .with_columns(
@@ -174,6 +187,10 @@ def add_purchase_urls_struct(
                     .then(pl.lit(redirect_base) + pl.col("_cm_hash"))
                     .otherwise(None)
                     .alias("cardmarket"),
+                    pl.when(mcm_id.is_not_null() & pl.col("finishes").list.contains("foil"))
+                    .then(pl.lit(redirect_base) + pl.col("_cmf_hash"))
+                    .otherwise(None)
+                    .alias("cardmarketFoil"),
                     pl.when(tcg_id.is_not_null())
                     .then(pl.lit(redirect_base) + pl.col("_tcg_hash"))
                     .otherwise(None)
@@ -195,6 +212,7 @@ def add_purchase_urls_struct(
                 "_ckf_hash",
                 "_cke_hash",
                 "_cm_hash",
+                "_cmf_hash",
                 "_tcg_hash",
                 "_tcge_hash",
                 "_tcga_hash",


### PR DESCRIPTION
Add a foil variant of the Cardmarket purchase URL that appends &isFoil=Y to the redirect target. 
Only populated for cards whose finishes include "foil".

- Add cardmarketFoil field to PurchaseUrls TypedDict
- Generate distinct foil hash in pipeline (discriminator suffix)
- Build foil referral map entries gated on finishes

<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
