### PR TITLE
Add build manifest and regression detection

### DIFF
--- a/mtgjson5/__main__.py
+++ b/mtgjson5/__main__.py
@@ -134,7 +134,7 @@ def dispatcher(args: argparse.Namespace) -> None:
     from mtgjson5.mtgjson_s3_handler import MtgjsonS3Handler
     from mtgjson5.pipeline.core import build_cards
     from mtgjson5.profiler import init_profiler
-    from mtgjson5.utils import generate_output_file_hashes
+    from mtgjson5.utils import generate_build_manifest, generate_output_file_hashes
 
     use_tracemalloc = getattr(args, "profile_tracemalloc", False)
     profiler = init_profiler(
@@ -328,6 +328,12 @@ def dispatcher(args: argparse.Namespace) -> None:
 
     generate_output_file_hashes(MtgjsonConfig().output_path)
     profiler.checkpoint("hashes_complete")
+
+    generate_build_manifest(
+        MtgjsonConfig().output_path,
+        assembly_results=results,
+    )
+    profiler.checkpoint("manifest_complete")
 
     if generate_types:
         from mtgjson5.models import write_typescript_interfaces

--- a/mtgjson5/__main__.py
+++ b/mtgjson5/__main__.py
@@ -207,6 +207,7 @@ def dispatcher(args: argparse.Namespace) -> None:
         GlobalCache().release_pipeline_frames()
         profiler.checkpoint("pipeline_frames_released")
 
+        results: dict[str, int] = {}
         if decks_only:
             # Only build deck files, skip set JSON assembly
             from mtgjson5.pipeline import build_expanded_decks_df
@@ -228,7 +229,7 @@ def dispatcher(args: argparse.Namespace) -> None:
             LOGGER.info(f"Model assembly results: {results}")
         else:
             set_codes = sets_to_build if sets_only else None
-            _, assembly_ctx = assemble_json_outputs(
+            results, assembly_ctx = assemble_json_outputs(
                 ctx,
                 parallel=True,
                 max_workers=30,

--- a/mtgjson5/utils.py
+++ b/mtgjson5/utils.py
@@ -191,6 +191,7 @@ def generate_build_manifest(
         directory: Build output directory to scan.
         assembly_results: Record counts from assembly (e.g. AllIdentifiers: 117449).
     """
+    import contextlib
     import datetime
     import subprocess
 
@@ -235,6 +236,7 @@ def generate_build_manifest(
             capture_output=True,
             text=True,
             timeout=5,
+            check=False,
         )
         if result.returncode == 0:
             git_commit = result.stdout.strip()
@@ -243,19 +245,15 @@ def generate_build_manifest(
 
     # Get version from config (if available)
     version = ""
-    try:
+    with contextlib.suppress(Exception):
         version = MtgjsonConfig().mtgjson_version
-    except Exception:
-        pass
 
     manifest = {
         "meta": {
             "version": version,
             "date": constants.MTGJSON_BUILD_DATE,
             "git_commit": git_commit,
-            "generated_at": datetime.datetime.now(datetime.timezone.utc).strftime(
-                "%Y-%m-%dT%H:%M:%SZ"
-            ),
+            "generated_at": datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "total_files": len(files),
             "total_size_bytes": total_size,
         },
@@ -268,10 +266,7 @@ def generate_build_manifest(
         json.dumps(manifest, indent=2, sort_keys=False),
         encoding="utf-8",
     )
-    LOGGER.info(
-        f"BuildManifest.json written: {len(files)} files, "
-        f"{total_size:,} bytes total"
-    )
+    LOGGER.info(f"BuildManifest.json written: {len(files)} files, {total_size:,} bytes total")
 
 
 def get_str_or_none(value: Any) -> str | None:

--- a/mtgjson5/utils.py
+++ b/mtgjson5/utils.py
@@ -181,6 +181,99 @@ def generate_output_file_hashes(directory: pathlib.Path) -> None:
             hash_file.write(generated_hash)
 
 
+def generate_build_manifest(
+    directory: pathlib.Path,
+    assembly_results: dict[str, int],
+) -> None:
+    """Generate BuildManifest.json cataloging all output files with sizes.
+
+    Args:
+        directory: Build output directory to scan.
+        assembly_results: Record counts from assembly (e.g. AllIdentifiers: 117449).
+    """
+    import datetime
+    import subprocess
+
+    excluded_dirs = {"data-models", "types"}
+    excluded_names = {"AllMTGJSONTypes.ts", "BuildManifest.json"}
+
+    files: dict[str, dict[str, int]] = {}
+    total_size = 0
+
+    for file in sorted(directory.rglob("*")):
+        if file.is_dir():
+            continue
+
+        relative = file.relative_to(directory)
+        relative_str = relative.as_posix()
+
+        # Skip excluded directories
+        if relative.parts[0] in excluded_dirs:
+            continue
+
+        # Skip excluded file names
+        if file.name in excluded_names:
+            continue
+
+        # Skip hash sidecars, logs, and profile output
+        if file.name.endswith(f".{constants.HASH_TO_GENERATE.name}"):
+            continue
+        if file.suffix == ".log":
+            continue
+        if file.name in ("profile_report.json", "profile_summary.log"):
+            continue
+
+        size = file.stat().st_size
+        files[relative_str] = {"size_bytes": size}
+        total_size += size
+
+    # Get git commit hash
+    git_commit = ""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            git_commit = result.stdout.strip()
+    except Exception:
+        pass
+
+    # Get version from config (if available)
+    version = ""
+    try:
+        version = MtgjsonConfig().mtgjson_version
+    except Exception:
+        pass
+
+    manifest = {
+        "meta": {
+            "version": version,
+            "date": constants.MTGJSON_BUILD_DATE,
+            "git_commit": git_commit,
+            "generated_at": datetime.datetime.now(datetime.timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
+            "total_files": len(files),
+            "total_size_bytes": total_size,
+        },
+        "record_counts": assembly_results,
+        "files": files,
+    }
+
+    manifest_path = directory / "BuildManifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=False),
+        encoding="utf-8",
+    )
+    LOGGER.info(
+        f"BuildManifest.json written: {len(files)} files, "
+        f"{total_size:,} bytes total"
+    )
+
+
 def get_str_or_none(value: Any) -> str | None:
     """
     Given a value, get its string representation

--- a/scripts/compare_manifests.py
+++ b/scripts/compare_manifests.py
@@ -4,6 +4,10 @@
 Usage:
     python scripts/compare_manifests.py <previous> <current> [options]
 
+Arguments accept local file paths or URLs (http/https). If the previous
+manifest is not found (missing file or unreachable URL), the comparison
+is skipped with a pass status - treating it as a first build.
+
 Exit codes:
     0 - pass (no issues)
     1 - warn (minor regressions detected)
@@ -15,6 +19,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import urllib.request
 from pathlib import Path
 
 
@@ -151,12 +156,31 @@ def compare_manifests(
     }
 
 
+def _load_manifest(location: str) -> dict | None:
+    """Load a manifest from a file path or URL.
+
+    Returns the parsed dict, or None if the location is a local path that
+    doesn't exist (first-build case).
+    """
+    if location.startswith(("http://", "https://")):
+        try:
+            with urllib.request.urlopen(location, timeout=30) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except (urllib.error.URLError, urllib.error.HTTPError):
+            return None
+
+    path = Path(location)
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Compare two MTGJSON BuildManifest.json files."
     )
-    parser.add_argument("previous", help="Path to previous BuildManifest.json")
-    parser.add_argument("current", help="Path to current BuildManifest.json")
+    parser.add_argument("previous", help="Path or URL to previous BuildManifest.json")
+    parser.add_argument("current", help="Path or URL to current BuildManifest.json")
     parser.add_argument(
         "--size-warn-pct",
         type=float,
@@ -192,12 +216,15 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    prev_path = Path(args.previous)
-    curr_path = Path(args.current)
+    previous = _load_manifest(args.previous)
+    current = _load_manifest(args.current)
 
-    # Handle missing previous manifest (first build)
-    if not prev_path.exists():
-        current = json.loads(curr_path.read_text(encoding="utf-8"))
+    if current is None:
+        print(f"Error: cannot load current manifest: {args.current}", file=sys.stderr)
+        return 2
+
+    # Handle missing previous manifest (first build or unreachable URL)
+    if previous is None:
         report = {
             "status": "pass",
             "note": "No previous manifest found — first build comparison skipped.",
@@ -217,8 +244,6 @@ def main() -> int:
             "record_count_changes": [],
         }
     else:
-        previous = json.loads(prev_path.read_text(encoding="utf-8"))
-        current = json.loads(curr_path.read_text(encoding="utf-8"))
         report = compare_manifests(
             previous,
             current,

--- a/scripts/compare_manifests.py
+++ b/scripts/compare_manifests.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Compare two MTGJSON BuildManifest.json files and report regressions.
+
+Usage:
+    python scripts/compare_manifests.py <previous> <current> [options]
+
+Exit codes:
+    0 - pass (no issues)
+    1 - warn (minor regressions detected)
+    2 - fail (major regressions detected)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def compare_manifests(
+    previous: dict,
+    current: dict,
+    *,
+    size_warn_pct: float = 2.0,
+    size_fail_pct: float = 10.0,
+    count_warn_pct: float = 1.0,
+    count_fail_pct: float = 5.0,
+) -> dict:
+    """Compare two manifest dicts and return a structured report.
+
+    Args:
+        previous: Previous build manifest.
+        current: Current build manifest.
+        size_warn_pct: Size decrease % to trigger a warning.
+        size_fail_pct: Size decrease % to trigger a failure.
+        count_warn_pct: Record count decrease % to trigger a warning.
+        count_fail_pct: Record count decrease % to trigger a failure.
+
+    Returns:
+        Report dict with status, summary, and detailed findings.
+    """
+    prev_files = previous.get("files", {})
+    curr_files = current.get("files", {})
+    prev_counts = previous.get("record_counts", {})
+    curr_counts = current.get("record_counts", {})
+
+    missing_files = []
+    new_files = []
+    size_changes = []
+    record_count_changes = []
+
+    worst_severity = "pass"
+
+    def escalate(severity: str) -> None:
+        nonlocal worst_severity
+        order = {"pass": 0, "info": 0, "warn": 1, "fail": 2}
+        if order.get(severity, 0) > order.get(worst_severity, 0):
+            worst_severity = severity
+
+    # Check for missing files
+    for path, prev_info in prev_files.items():
+        if path not in curr_files:
+            missing_files.append({
+                "path": path,
+                "previous_size_bytes": prev_info["size_bytes"],
+            })
+            escalate("fail")
+
+    # Check for new files
+    for path, curr_info in curr_files.items():
+        if path not in prev_files:
+            new_files.append({
+                "path": path,
+                "size_bytes": curr_info["size_bytes"],
+            })
+
+    # Check size changes for files present in both
+    for path in sorted(prev_files.keys() & curr_files.keys()):
+        prev_size = prev_files[path]["size_bytes"]
+        curr_size = curr_files[path]["size_bytes"]
+
+        if prev_size == 0:
+            continue
+
+        change_pct = ((curr_size - prev_size) / prev_size) * 100
+
+        # Only flag decreases
+        if change_pct < 0:
+            abs_change = abs(change_pct)
+            if abs_change >= size_fail_pct:
+                severity = "fail"
+            elif abs_change >= size_warn_pct:
+                severity = "warn"
+            else:
+                continue
+
+            size_changes.append({
+                "path": path,
+                "previous_size_bytes": prev_size,
+                "current_size_bytes": curr_size,
+                "change_pct": round(change_pct, 2),
+                "severity": severity,
+            })
+            escalate(severity)
+
+    # Check record count changes
+    for key in sorted(prev_counts.keys() | curr_counts.keys()):
+        prev_count = prev_counts.get(key)
+        curr_count = curr_counts.get(key)
+
+        if prev_count is None or curr_count is None:
+            continue
+        if prev_count == 0:
+            continue
+
+        change_pct = ((curr_count - prev_count) / prev_count) * 100
+
+        if change_pct < 0:
+            abs_change = abs(change_pct)
+            if abs_change >= count_fail_pct:
+                severity = "fail"
+            elif abs_change >= count_warn_pct:
+                severity = "warn"
+            else:
+                continue
+
+            record_count_changes.append({
+                "key": key,
+                "previous_count": prev_count,
+                "current_count": curr_count,
+                "change_pct": round(change_pct, 2),
+                "severity": severity,
+            })
+            escalate(severity)
+
+    return {
+        "status": worst_severity,
+        "summary": {
+            "previous_date": previous.get("meta", {}).get("date", ""),
+            "current_date": current.get("meta", {}).get("date", ""),
+            "previous_file_count": previous.get("meta", {}).get("total_files", 0),
+            "current_file_count": current.get("meta", {}).get("total_files", 0),
+            "previous_total_size": previous.get("meta", {}).get("total_size_bytes", 0),
+            "current_total_size": current.get("meta", {}).get("total_size_bytes", 0),
+        },
+        "missing_files": missing_files,
+        "new_files": new_files,
+        "size_changes": size_changes,
+        "record_count_changes": record_count_changes,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare two MTGJSON BuildManifest.json files."
+    )
+    parser.add_argument("previous", help="Path to previous BuildManifest.json")
+    parser.add_argument("current", help="Path to current BuildManifest.json")
+    parser.add_argument(
+        "--size-warn-pct",
+        type=float,
+        default=2.0,
+        help="Size decrease %% for warnings (default: 2.0)",
+    )
+    parser.add_argument(
+        "--size-fail-pct",
+        type=float,
+        default=10.0,
+        help="Size decrease %% for failures (default: 10.0)",
+    )
+    parser.add_argument(
+        "--count-warn-pct",
+        type=float,
+        default=1.0,
+        help="Record count decrease %% for warnings (default: 1.0)",
+    )
+    parser.add_argument(
+        "--count-fail-pct",
+        type=float,
+        default=5.0,
+        help="Record count decrease %% for failures (default: 5.0)",
+    )
+    parser.add_argument(
+        "--output",
+        help="Write JSON report to file (default: stdout)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Only output JSON, no human-readable summary",
+    )
+    args = parser.parse_args()
+
+    prev_path = Path(args.previous)
+    curr_path = Path(args.current)
+
+    # Handle missing previous manifest (first build)
+    if not prev_path.exists():
+        current = json.loads(curr_path.read_text(encoding="utf-8"))
+        report = {
+            "status": "pass",
+            "note": "No previous manifest found — first build comparison skipped.",
+            "summary": {
+                "previous_date": "",
+                "current_date": current.get("meta", {}).get("date", ""),
+                "previous_file_count": 0,
+                "current_file_count": current.get("meta", {}).get("total_files", 0),
+                "previous_total_size": 0,
+                "current_total_size": current.get("meta", {}).get(
+                    "total_size_bytes", 0
+                ),
+            },
+            "missing_files": [],
+            "new_files": [],
+            "size_changes": [],
+            "record_count_changes": [],
+        }
+    else:
+        previous = json.loads(prev_path.read_text(encoding="utf-8"))
+        current = json.loads(curr_path.read_text(encoding="utf-8"))
+        report = compare_manifests(
+            previous,
+            current,
+            size_warn_pct=args.size_warn_pct,
+            size_fail_pct=args.size_fail_pct,
+            count_warn_pct=args.count_warn_pct,
+            count_fail_pct=args.count_fail_pct,
+        )
+
+    report_json = json.dumps(report, indent=2)
+
+    if args.output:
+        Path(args.output).write_text(report_json, encoding="utf-8")
+    else:
+        print(report_json)
+
+    if not args.quiet:
+        status = report["status"].upper()
+        summary = report["summary"]
+        print(f"\n{'='*60}", file=sys.stderr)
+        print(f"Build Manifest Comparison: {status}", file=sys.stderr)
+        print(f"{'='*60}", file=sys.stderr)
+        print(
+            f"Previous: {summary['previous_date']} "
+            f"({summary['previous_file_count']} files, "
+            f"{summary['previous_total_size']:,} bytes)",
+            file=sys.stderr,
+        )
+        print(
+            f"Current:  {summary['current_date']} "
+            f"({summary['current_file_count']} files, "
+            f"{summary['current_total_size']:,} bytes)",
+            file=sys.stderr,
+        )
+
+        if report.get("note"):
+            print(f"\nNote: {report['note']}", file=sys.stderr)
+
+        if report["missing_files"]:
+            print(f"\nMISSING FILES ({len(report['missing_files'])}):", file=sys.stderr)
+            for f in report["missing_files"]:
+                print(f"  - {f['path']} (was {f['previous_size_bytes']:,} bytes)", file=sys.stderr)
+
+        if report["new_files"]:
+            print(f"\nNEW FILES ({len(report['new_files'])}):", file=sys.stderr)
+            for f in report["new_files"]:
+                print(f"  + {f['path']} ({f['size_bytes']:,} bytes)", file=sys.stderr)
+
+        if report["size_changes"]:
+            print(f"\nSIZE CHANGES ({len(report['size_changes'])}):", file=sys.stderr)
+            for c in report["size_changes"]:
+                print(
+                    f"  [{c['severity'].upper()}] {c['path']}: "
+                    f"{c['change_pct']:+.1f}% "
+                    f"({c['previous_size_bytes']:,} -> {c['current_size_bytes']:,})",
+                    file=sys.stderr,
+                )
+
+        if report["record_count_changes"]:
+            print(
+                f"\nRECORD COUNT CHANGES ({len(report['record_count_changes'])}):",
+                file=sys.stderr,
+            )
+            for c in report["record_count_changes"]:
+                print(
+                    f"  [{c['severity'].upper()}] {c['key']}: "
+                    f"{c['change_pct']:+.1f}% "
+                    f"({c['previous_count']:,} -> {c['current_count']:,})",
+                    file=sys.stderr,
+                )
+
+        print(f"\nResult: {status}", file=sys.stderr)
+        print(f"{'='*60}", file=sys.stderr)
+
+    exit_code_map = {"pass": 0, "warn": 1, "fail": 2}
+    return exit_code_map.get(report["status"], 2)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/compare_manifests.py
+++ b/scripts/compare_manifests.py
@@ -66,19 +66,23 @@ def compare_manifests(
     # Check for missing files
     for path, prev_info in prev_files.items():
         if path not in curr_files:
-            missing_files.append({
-                "path": path,
-                "previous_size_bytes": prev_info["size_bytes"],
-            })
+            missing_files.append(
+                {
+                    "path": path,
+                    "previous_size_bytes": prev_info["size_bytes"],
+                }
+            )
             escalate("fail")
 
     # Check for new files
     for path, curr_info in curr_files.items():
         if path not in prev_files:
-            new_files.append({
-                "path": path,
-                "size_bytes": curr_info["size_bytes"],
-            })
+            new_files.append(
+                {
+                    "path": path,
+                    "size_bytes": curr_info["size_bytes"],
+                }
+            )
 
     # Check size changes for files present in both
     for path in sorted(prev_files.keys() & curr_files.keys()):
@@ -100,13 +104,15 @@ def compare_manifests(
             else:
                 continue
 
-            size_changes.append({
-                "path": path,
-                "previous_size_bytes": prev_size,
-                "current_size_bytes": curr_size,
-                "change_pct": round(change_pct, 2),
-                "severity": severity,
-            })
+            size_changes.append(
+                {
+                    "path": path,
+                    "previous_size_bytes": prev_size,
+                    "current_size_bytes": curr_size,
+                    "change_pct": round(change_pct, 2),
+                    "severity": severity,
+                }
+            )
             escalate(severity)
 
     # Check record count changes
@@ -130,13 +136,15 @@ def compare_manifests(
             else:
                 continue
 
-            record_count_changes.append({
-                "key": key,
-                "previous_count": prev_count,
-                "current_count": curr_count,
-                "change_pct": round(change_pct, 2),
-                "severity": severity,
-            })
+            record_count_changes.append(
+                {
+                    "key": key,
+                    "previous_count": prev_count,
+                    "current_count": curr_count,
+                    "change_pct": round(change_pct, 2),
+                    "severity": severity,
+                }
+            )
             escalate(severity)
 
     return {
@@ -176,9 +184,7 @@ def _load_manifest(location: str) -> dict | None:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="Compare two MTGJSON BuildManifest.json files."
-    )
+    parser = argparse.ArgumentParser(description="Compare two MTGJSON BuildManifest.json files.")
     parser.add_argument("previous", help="Path or URL to previous BuildManifest.json")
     parser.add_argument("current", help="Path or URL to current BuildManifest.json")
     parser.add_argument(
@@ -234,9 +240,7 @@ def main() -> int:
                 "previous_file_count": 0,
                 "current_file_count": current.get("meta", {}).get("total_files", 0),
                 "previous_total_size": 0,
-                "current_total_size": current.get("meta", {}).get(
-                    "total_size_bytes", 0
-                ),
+                "current_total_size": current.get("meta", {}).get("total_size_bytes", 0),
             },
             "missing_files": [],
             "new_files": [],
@@ -263,9 +267,9 @@ def main() -> int:
     if not args.quiet:
         status = report["status"].upper()
         summary = report["summary"]
-        print(f"\n{'='*60}", file=sys.stderr)
+        print(f"\n{'=' * 60}", file=sys.stderr)
         print(f"Build Manifest Comparison: {status}", file=sys.stderr)
-        print(f"{'='*60}", file=sys.stderr)
+        print(f"{'=' * 60}", file=sys.stderr)
         print(
             f"Previous: {summary['previous_date']} "
             f"({summary['previous_file_count']} files, "
@@ -316,7 +320,7 @@ def main() -> int:
                 )
 
         print(f"\nResult: {status}", file=sys.stderr)
-        print(f"{'='*60}", file=sys.stderr)
+        print(f"{'=' * 60}", file=sys.stderr)
 
     exit_code_map = {"pass": 0, "warn": 1, "fail": 2}
     return exit_code_map.get(report["status"], 2)

--- a/tests/mtgjson5/test_build_manifest.py
+++ b/tests/mtgjson5/test_build_manifest.py
@@ -1,0 +1,115 @@
+"""Tests for build manifest generation."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+from mtgjson5.utils import generate_build_manifest
+
+
+class TestGenerateBuildManifest:
+    def test_creates_manifest_file(self, tmp_path: pathlib.Path):
+        """Manifest file is created in the output directory."""
+        (tmp_path / "AllPrintings.json").write_text('{"data": {}}')
+        (tmp_path / "10E.json").write_text('{"data": {}}')
+
+        generate_build_manifest(tmp_path, assembly_results={})
+
+        manifest_path = tmp_path / "BuildManifest.json"
+        assert manifest_path.exists()
+
+    def test_manifest_contains_meta(self, tmp_path: pathlib.Path):
+        """Manifest meta section has required fields."""
+        (tmp_path / "AllPrintings.json").write_text('{"data": {}}')
+
+        generate_build_manifest(tmp_path, assembly_results={})
+
+        manifest = json.loads((tmp_path / "BuildManifest.json").read_text())
+        meta = manifest["meta"]
+        assert "date" in meta
+        assert "generated_at" in meta
+        assert "total_files" in meta
+        assert "total_size_bytes" in meta
+        assert meta["total_files"] == 1
+
+    def test_manifest_lists_all_files(self, tmp_path: pathlib.Path):
+        """Every non-excluded file appears in the manifest."""
+        (tmp_path / "AllPrintings.json").write_bytes(b"x" * 100)
+        (tmp_path / "10E.json").write_bytes(b"y" * 50)
+        (tmp_path / "AllPrintings.json.sha256").write_text("abc123")
+
+        generate_build_manifest(tmp_path, assembly_results={})
+
+        manifest = json.loads((tmp_path / "BuildManifest.json").read_text())
+        files = manifest["files"]
+        assert "AllPrintings.json" in files
+        assert "10E.json" in files
+        assert "AllPrintings.json.sha256" not in files
+        assert files["AllPrintings.json"]["size_bytes"] == 100
+        assert files["10E.json"]["size_bytes"] == 50
+
+    def test_manifest_includes_subdirectory_files(self, tmp_path: pathlib.Path):
+        """Files in subdirectories use forward-slash relative paths."""
+        decks = tmp_path / "decks"
+        decks.mkdir()
+        (decks / "SomeDeck.json").write_bytes(b"d" * 30)
+
+        generate_build_manifest(tmp_path, assembly_results={})
+
+        manifest = json.loads((tmp_path / "BuildManifest.json").read_text())
+        assert "decks/SomeDeck.json" in manifest["files"]
+
+    def test_manifest_excludes_special_files(self, tmp_path: pathlib.Path):
+        """Log files, profile files, sha256 files, and the manifest itself are excluded."""
+        (tmp_path / "AllPrintings.json").write_bytes(b"x" * 10)
+        (tmp_path / "mtgjson_2026.log").write_text("log")
+        (tmp_path / "profile_report.json").write_text("{}")
+        (tmp_path / "profile_summary.log").write_text("summary")
+        (tmp_path / "AllMTGJSONTypes.ts").write_text("types")
+        (tmp_path / "BuildManifest.json").write_text("old manifest")
+        dm = tmp_path / "data-models"
+        dm.mkdir()
+        (dm / "page.md").write_text("docs")
+        types_dir = tmp_path / "types"
+        types_dir.mkdir()
+        (types_dir / "Card.ts").write_text("type")
+
+        generate_build_manifest(tmp_path, assembly_results={})
+
+        manifest = json.loads((tmp_path / "BuildManifest.json").read_text())
+        files = manifest["files"]
+        assert len(files) == 1
+        assert "AllPrintings.json" in files
+
+    def test_manifest_includes_record_counts(self, tmp_path: pathlib.Path):
+        """Assembly results are stored in record_counts."""
+        (tmp_path / "AllPrintings.json").write_bytes(b"x")
+
+        results = {"AllPrintings": 882, "AllIdentifiers": 117449, "sets": 882}
+        generate_build_manifest(tmp_path, assembly_results=results)
+
+        manifest = json.loads((tmp_path / "BuildManifest.json").read_text())
+        assert manifest["record_counts"] == results
+
+    def test_manifest_total_size(self, tmp_path: pathlib.Path):
+        """total_size_bytes is the sum of all included file sizes."""
+        (tmp_path / "a.json").write_bytes(b"x" * 100)
+        (tmp_path / "b.json").write_bytes(b"y" * 200)
+
+        generate_build_manifest(tmp_path, assembly_results={})
+
+        manifest = json.loads((tmp_path / "BuildManifest.json").read_text())
+        assert manifest["meta"]["total_size_bytes"] == 300
+
+    def test_manifest_files_sorted(self, tmp_path: pathlib.Path):
+        """File entries are sorted by path."""
+        (tmp_path / "ZNR.json").write_bytes(b"z")
+        (tmp_path / "10E.json").write_bytes(b"a")
+        (tmp_path / "AllPrintings.json").write_bytes(b"b")
+
+        generate_build_manifest(tmp_path, assembly_results={})
+
+        manifest = json.loads((tmp_path / "BuildManifest.json").read_text())
+        keys = list(manifest["files"].keys())
+        assert keys == sorted(keys)

--- a/tests/mtgjson5/test_compare_manifests.py
+++ b/tests/mtgjson5/test_compare_manifests.py
@@ -32,7 +32,7 @@ def _run_compare(
     if extra_args:
         cmd.extend(extra_args)
 
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=10, check=False)
     report = json.loads(report_path.read_text())
     return result.returncode, report
 
@@ -123,7 +123,7 @@ class TestSizeChanges:
         """A 1% decrease is below the 2% warn threshold."""
         prev = _make_manifest({"AllPrintings.json": 1000})
         curr = _make_manifest({"AllPrintings.json": 990}, date="2026-04-02")
-        exit_code, report = _run_compare(prev, curr, tmp_path)
+        exit_code, _report = _run_compare(prev, curr, tmp_path)
         assert exit_code == 0
 
 
@@ -155,7 +155,7 @@ class TestRecordCountChanges:
             record_counts={"AllIdentifiers": 105000},
             date="2026-04-02",
         )
-        exit_code, report = _run_compare(prev, curr, tmp_path)
+        exit_code, _report = _run_compare(prev, curr, tmp_path)
         assert exit_code == 0
 
 
@@ -164,9 +164,7 @@ class TestCustomThresholds:
         """A 3% decrease with --size-warn-pct 5 should pass."""
         prev = _make_manifest({"AllPrintings.json": 1000})
         curr = _make_manifest({"AllPrintings.json": 970}, date="2026-04-02")
-        exit_code, report = _run_compare(
-            prev, curr, tmp_path, extra_args=["--size-warn-pct", "5"]
-        )
+        exit_code, _report = _run_compare(prev, curr, tmp_path, extra_args=["--size-warn-pct", "5"])
         assert exit_code == 0
 
 
@@ -186,7 +184,7 @@ class TestPreviousManifestMissing:
             "--output",
             str(report_path),
         ]
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10, check=False)
         report = json.loads(report_path.read_text())
         assert result.returncode == 0
         assert report["status"] == "pass"

--- a/tests/mtgjson5/test_compare_manifests.py
+++ b/tests/mtgjson5/test_compare_manifests.py
@@ -1,0 +1,193 @@
+"""Tests for manifest comparison logic."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+
+
+def _run_compare(
+    prev: dict,
+    curr: dict,
+    tmp_path: pathlib.Path,
+    extra_args: list[str] | None = None,
+) -> tuple[int, dict]:
+    """Helper: write two manifests, run comparison, return (exit_code, report)."""
+    prev_path = tmp_path / "previous.json"
+    curr_path = tmp_path / "current.json"
+    report_path = tmp_path / "report.json"
+    prev_path.write_text(json.dumps(prev))
+    curr_path.write_text(json.dumps(curr))
+
+    cmd = [
+        sys.executable,
+        str(pathlib.Path("scripts/compare_manifests.py").resolve()),
+        str(prev_path),
+        str(curr_path),
+        "--output",
+        str(report_path),
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    report = json.loads(report_path.read_text())
+    return result.returncode, report
+
+
+def _make_manifest(
+    files: dict[str, int],
+    record_counts: dict[str, int] | None = None,
+    date: str = "2026-04-01",
+) -> dict:
+    """Build a minimal valid manifest dict."""
+    total = sum(files.values())
+    return {
+        "meta": {
+            "version": "5.3.0",
+            "date": date,
+            "git_commit": "abc1234",
+            "generated_at": f"{date}T04:00:00Z",
+            "total_files": len(files),
+            "total_size_bytes": total,
+        },
+        "record_counts": record_counts or {},
+        "files": {k: {"size_bytes": v} for k, v in files.items()},
+    }
+
+
+class TestIdenticalManifests:
+    def test_identical_manifests_pass(self, tmp_path: pathlib.Path):
+        m = _make_manifest({"AllPrintings.json": 1000, "10E.json": 500})
+        exit_code, report = _run_compare(m, m, tmp_path)
+        assert exit_code == 0
+        assert report["status"] == "pass"
+        assert report["missing_files"] == []
+        assert report["new_files"] == []
+        assert report["size_changes"] == []
+
+
+class TestMissingFiles:
+    def test_missing_file_is_fail(self, tmp_path: pathlib.Path):
+        prev = _make_manifest({"AllPrintings.json": 1000, "OLD.json": 500})
+        curr = _make_manifest({"AllPrintings.json": 1000})
+        exit_code, report = _run_compare(prev, curr, tmp_path)
+        assert exit_code == 2
+        assert report["status"] == "fail"
+        assert len(report["missing_files"]) == 1
+        assert report["missing_files"][0]["path"] == "OLD.json"
+
+
+class TestNewFiles:
+    def test_new_file_is_info(self, tmp_path: pathlib.Path):
+        prev = _make_manifest({"AllPrintings.json": 1000})
+        curr = _make_manifest({"AllPrintings.json": 1000, "NEW.json": 500})
+        exit_code, report = _run_compare(prev, curr, tmp_path)
+        assert exit_code == 0
+        assert report["status"] == "pass"
+        assert len(report["new_files"]) == 1
+        assert report["new_files"][0]["path"] == "NEW.json"
+
+
+class TestSizeChanges:
+    def test_small_decrease_warns(self, tmp_path: pathlib.Path):
+        """A 5% decrease should warn (default warn threshold is 2%)."""
+        prev = _make_manifest({"AllPrintings.json": 1000})
+        curr = _make_manifest({"AllPrintings.json": 950}, date="2026-04-02")
+        exit_code, report = _run_compare(prev, curr, tmp_path)
+        assert exit_code == 1
+        assert report["status"] == "warn"
+        assert len(report["size_changes"]) == 1
+        assert report["size_changes"][0]["severity"] == "warn"
+
+    def test_large_decrease_fails(self, tmp_path: pathlib.Path):
+        """A 15% decrease should fail (default fail threshold is 10%)."""
+        prev = _make_manifest({"AllPrintings.json": 1000})
+        curr = _make_manifest({"AllPrintings.json": 850}, date="2026-04-02")
+        exit_code, report = _run_compare(prev, curr, tmp_path)
+        assert exit_code == 2
+        assert report["status"] == "fail"
+        assert report["size_changes"][0]["severity"] == "fail"
+
+    def test_size_increase_not_flagged(self, tmp_path: pathlib.Path):
+        """Size increases are informational, never warn/fail."""
+        prev = _make_manifest({"AllPrintings.json": 1000})
+        curr = _make_manifest({"AllPrintings.json": 2000}, date="2026-04-02")
+        exit_code, report = _run_compare(prev, curr, tmp_path)
+        assert exit_code == 0
+        assert report["status"] == "pass"
+
+    def test_tiny_decrease_ignored(self, tmp_path: pathlib.Path):
+        """A 1% decrease is below the 2% warn threshold."""
+        prev = _make_manifest({"AllPrintings.json": 1000})
+        curr = _make_manifest({"AllPrintings.json": 990}, date="2026-04-02")
+        exit_code, report = _run_compare(prev, curr, tmp_path)
+        assert exit_code == 0
+
+
+class TestRecordCountChanges:
+    def test_count_decrease_warns(self, tmp_path: pathlib.Path):
+        """A 2% record count decrease should warn (default warn threshold is 1%)."""
+        prev = _make_manifest(
+            {"AllIdentifiers.json": 1000},
+            record_counts={"AllIdentifiers": 100000},
+        )
+        curr = _make_manifest(
+            {"AllIdentifiers.json": 980},
+            record_counts={"AllIdentifiers": 98000},
+            date="2026-04-02",
+        )
+        exit_code, report = _run_compare(prev, curr, tmp_path)
+        assert exit_code == 1
+        assert len(report["record_count_changes"]) == 1
+        assert report["record_count_changes"][0]["severity"] == "warn"
+
+    def test_count_increase_not_flagged(self, tmp_path: pathlib.Path):
+        """Record count increases are informational."""
+        prev = _make_manifest(
+            {"AllIdentifiers.json": 1000},
+            record_counts={"AllIdentifiers": 100000},
+        )
+        curr = _make_manifest(
+            {"AllIdentifiers.json": 1100},
+            record_counts={"AllIdentifiers": 105000},
+            date="2026-04-02",
+        )
+        exit_code, report = _run_compare(prev, curr, tmp_path)
+        assert exit_code == 0
+
+
+class TestCustomThresholds:
+    def test_custom_size_warn_threshold(self, tmp_path: pathlib.Path):
+        """A 3% decrease with --size-warn-pct 5 should pass."""
+        prev = _make_manifest({"AllPrintings.json": 1000})
+        curr = _make_manifest({"AllPrintings.json": 970}, date="2026-04-02")
+        exit_code, report = _run_compare(
+            prev, curr, tmp_path, extra_args=["--size-warn-pct", "5"]
+        )
+        assert exit_code == 0
+
+
+class TestPreviousManifestMissing:
+    def test_missing_previous_passes(self, tmp_path: pathlib.Path):
+        """When previous manifest doesn't exist, report pass with a note."""
+        curr_path = tmp_path / "current.json"
+        report_path = tmp_path / "report.json"
+        curr = _make_manifest({"AllPrintings.json": 1000})
+        curr_path.write_text(json.dumps(curr))
+
+        cmd = [
+            sys.executable,
+            str(pathlib.Path("scripts/compare_manifests.py").resolve()),
+            str(tmp_path / "nonexistent.json"),
+            str(curr_path),
+            "--output",
+            str(report_path),
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        report = json.loads(report_path.read_text())
+        assert result.returncode == 0
+        assert report["status"] == "pass"
+        assert "first_build" in report or "note" in report


### PR DESCRIPTION
Generates a BuildManifest.json with every build that catalogs all output files (path, size) and record counts from assembly (AllIdentifiers: 117449, sets: 882, etc.).
Adds a standalone scripts/compare_manifests.py that diffs two manifests and produces a structured JSON report with pass/warn/fail severity.
Manifest generation runs automatically after hash generation in the build pipeline.

Manifest generation happens at the end of every build, right after SHA256 hashes are generated. It scans the output directory and writes BuildManifest.json with:
- Build metadata (version, date, git commit)
- Record counts from assembly results
- Every output file with its size in bytes

Comparison script takes two manifests (previous and current) and checks for:
- Missing files: always fail
- Size decreases: warn at 2%, fail at 10% (configurable)
- Record count decreases: warn at 1%, fail at 5% (configurable)
- Size/count increases are informational only

Exit codes: 0 = pass, 1 = warn, 2 = fail

Arguments accept local file paths or URLs - the previous manifest can be fetched directly from the file server.

-- integration --
The manifest travels with the build output files. The migration/copy script can integrate with a few lines:

Fetch previous manifest from file server:
PREV_URL="https://mtgjson.com/api/v5/BuildManifest.json"

Compare against current build:
python scripts/compare_manifests.py \
"$PREV_URL" \
/path/to/current_build/BuildManifest.json \
--output /tmp/report.json

Thresholds are configurable via --size-warn-pct, --size-fail-pct, --count-warn-pct, --count-fail-pct. 
If no previous manifest exists (first build or URL unreachable), the script passes with a note.

<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
