### PR TITLE
Drop the special casing of etched sets

### DIFF
--- a/mtgjson5/pipeline/stages/sealed.py
+++ b/mtgjson5/pipeline/stages/sealed.py
@@ -747,8 +747,10 @@ def _ctp_get_card_obj_from_card(card_content: dict[str, Any]) -> list[_CTPCard]:
 def _ctp_get_cards_in_pack(data: dict, set_code: str, booster_code: str) -> list[_CTPCard]:
     """Return cards reachable from a booster pack definition.
 
-    Traverses every sheet referenced by boosters for *booster_code* and resolves
-    finishes using the same special-case logic as the reference compiler.
+    Traverses every sheet referenced by boosters for *booster_code* and assigns
+    each card a finish: "etched" if the sheet name contains "etched" (or the
+    card's only finish is "etched"), "foil" if it's a foil sheet and the card
+    has a foil printing, otherwise "nonfoil".
     """
     try:
         booster_data = data[set_code].get("booster")
@@ -771,27 +773,15 @@ def _ctp_get_cards_in_pack(data: dict, set_code: str, booster_code: str) -> list
 
         for card_uuid in cards_in_sheet:
             finish = "nonfoil"
-            code = ""
+            finishes: list[str] = []
 
             if sheet_data["sheets"][sheet]["foil"]:
-                finishes: list[str] = []
                 for source_code in sheet_data["sourceSetCodes"]:
                     if source_code not in data:
                         continue
                     for c in data[source_code]["cards"]:
                         if card_uuid == c["uuid"]:
                             finishes = c["finishes"]
-                            code = source_code
-
-                            # MH2 special case: only numbers 262-441 get etched treatment
-                            if code == "MH2":
-                                try:
-                                    num = int(c["number"])
-                                except (ValueError, TypeError):
-                                    code = ""
-                                else:
-                                    if num < 262 or num > 441:
-                                        code = ""
 
                 # "etched" in sheet name or single finish "etched" → etched
                 if ("etched" in sheet.lower() or len(finishes) == 1) and "etched" in finishes:
@@ -800,10 +790,6 @@ def _ctp_get_cards_in_pack(data: dict, set_code: str, booster_code: str) -> list
                     finish = "foil"
 
             return_value.add(_CTPCard(card_uuid, finish))
-
-            # Upstream does not track etched version of these cards — duplicate
-            if code and code in ("H1R", "MH2", "STA"):
-                return_value.add(_CTPCard(card_uuid, "etched"))
 
     return list(return_value)
 


### PR DESCRIPTION
This was yielding too many false positives and can be simplified.

**Example**
for Seal of Removal from MH2, the etched card was reported to be found in several products, while it's actually only found in collector boosters as reported on the [original collecting article](https://magic.wizards.com/en/news/feature/collecting-modern-horizons-2-2021-05-21)

> Now, let's look at the Collector Booster! The Collector Booster for Modern Horizons 2 comes with a guaranteed combination of four rare or mythic rares and is filled with all the coolest treatments! The Collector Booster is the only place that you can find foil-etched cards in Modern Horizons 2 products as well as the only place that extended-art cards are offered.

see for comparison
* https://mtg.wtf/pack/mh2-draft
* https://mtg.wtf/pack/mh2-set
* https://mtg.wtf/pack/mh2-collector

_before_

```json
    "de6a3d2b-91a9-57cc-84e2-2f7a4b99a8e0": {
        "etched": [
            "Modern Horizons 2 3 Booster Draft Pack",
            "Modern Horizons 2 Bundle",
            "Modern Horizons 2 Collector Booster Box",
            "Modern Horizons 2 Collector Booster Box Case",
            "Modern Horizons 2 Collector Booster Hanger Pack",
            "Modern Horizons 2 Collector Booster Pack",
            "Modern Horizons 2 Draft Booster Box",
            "Modern Horizons 2 Draft Booster Box Case",
            "Modern Horizons 2 Draft Booster Pack",
            "Modern Horizons 2 Set Booster Box",
            "Modern Horizons 2 Set Booster Box Case",
            "Modern Horizons 2 Set Booster Hanger Pack",
            "Modern Horizons 2 Set Booster Pack"
        ],
        "foil": [
            "Modern Horizons 2 3 Booster Draft Pack",
            "Modern Horizons 2 Bundle",
            "Modern Horizons 2 Collector Booster Box",
            "Modern Horizons 2 Collector Booster Box Case",
            "Modern Horizons 2 Collector Booster Hanger Pack",
            "Modern Horizons 2 Collector Booster Pack",
            "Modern Horizons 2 Draft Booster Box",
            "Modern Horizons 2 Draft Booster Box Case",
            "Modern Horizons 2 Draft Booster Pack",
            "Modern Horizons 2 Set Booster Box",
            "Modern Horizons 2 Set Booster Box Case",
            "Modern Horizons 2 Set Booster Hanger Pack",
            "Modern Horizons 2 Set Booster Pack"
        ],
        "nonfoil": [
            "Modern Horizons 2 3 Booster Draft Pack",
            "Modern Horizons 2 Bundle",
            "Modern Horizons 2 Draft Booster Box",
            "Modern Horizons 2 Draft Booster Box Case",
            "Modern Horizons 2 Draft Booster Pack",
            "Modern Horizons 2 Set Booster Box",
            "Modern Horizons 2 Set Booster Box Case",
            "Modern Horizons 2 Set Booster Hanger Pack",
            "Modern Horizons 2 Set Booster Pack"
        ]
    },
```

after
```json
    "de6a3d2b-91a9-57cc-84e2-2f7a4b99a8e0": {
        "etched": [
            "Modern Horizons 2 Collector Booster Box",
            "Modern Horizons 2 Collector Booster Box Case",
            "Modern Horizons 2 Collector Booster Hanger Pack",
            "Modern Horizons 2 Collector Booster Pack"
        ],
        "foil": [
            "Modern Horizons 2 3 Booster Draft Pack",
            "Modern Horizons 2 Bundle",
            "Modern Horizons 2 Collector Booster Box",
            "Modern Horizons 2 Collector Booster Box Case",
            "Modern Horizons 2 Collector Booster Hanger Pack",
            "Modern Horizons 2 Collector Booster Pack",
            "Modern Horizons 2 Draft Booster Box",
            "Modern Horizons 2 Draft Booster Box Case",
            "Modern Horizons 2 Draft Booster Pack",
            "Modern Horizons 2 Set Booster Box",
            "Modern Horizons 2 Set Booster Box Case",
            "Modern Horizons 2 Set Booster Hanger Pack",
            "Modern Horizons 2 Set Booster Pack"
        ],
        "nonfoil": [
            "Modern Horizons 2 3 Booster Draft Pack",
            "Modern Horizons 2 Bundle",
            "Modern Horizons 2 Draft Booster Box",
            "Modern Horizons 2 Draft Booster Box Case",
            "Modern Horizons 2 Draft Booster Pack",
            "Modern Horizons 2 Set Booster Box",
            "Modern Horizons 2 Set Booster Box Case",
            "Modern Horizons 2 Set Booster Hanger Pack",
            "Modern Horizons 2 Set Booster Pack"
        ]
    },
```