### PR TITLE
Fix/pin foil version dtype

### DIFF
--- a/mtgjson5/pipeline/stages/derived.py
+++ b/mtgjson5/pipeline/stages/derived.py
@@ -509,24 +509,24 @@ def link_foil_nonfoil_versions(lf: pl.LazyFrame) -> pl.LazyFrame:
             version_links[first_uuid] = (first_foil, first_nonfoil)
             version_links[uuid] = (None, first_uuid)  # nonfoilVersionId = first
 
-    # Create lookup DataFrame
+    # Pin String dtype so all-None batches don't get inferred as Null,
+    # which would diverge the identifiers struct schema across partitions.
     links_df = pl.DataFrame(
         {
             "uuid": list(version_links.keys()),
             "_foil_version": [v[0] for v in version_links.values()],
             "_nonfoil_version": [v[1] for v in version_links.values()],
-        }
+        },
+        schema={"uuid": pl.String, "_foil_version": pl.String, "_nonfoil_version": pl.String},
     ).lazy()
 
-    # Join back to main LazyFrame
     lf = lf.join(links_df, on="uuid", how="left")
 
-    # Update identifiers struct with version IDs
     lf = lf.with_columns(
         pl.col("identifiers").struct.with_fields(
             [
-                pl.col("_foil_version").alias("mtgjsonFoilVersionId"),
-                pl.col("_nonfoil_version").alias("mtgjsonNonFoilVersionId"),
+                pl.col("_foil_version").cast(pl.String).alias("mtgjsonFoilVersionId"),
+                pl.col("_nonfoil_version").cast(pl.String).alias("mtgjsonNonFoilVersionId"),
             ]
         )
     )

--- a/mtgjson5/pipeline/stages/output.py
+++ b/mtgjson5/pipeline/stages/output.py
@@ -483,10 +483,7 @@ def build_id_mappings_from_parquet(ctx: PipelineContext) -> None:
             [
                 pl.col("uuid").cast(pl.String),
                 pl.struct(
-                    [
-                        pl.col("identifiers").struct.field(name).cast(pl.String).alias(name)
-                        for name in needed_id_fields
-                    ]
+                    [pl.col("identifiers").struct.field(name).cast(pl.String).alias(name) for name in needed_id_fields]
                 ).alias("identifiers"),
                 pl.col("finishes"),
             ]

--- a/mtgjson5/pipeline/stages/output.py
+++ b/mtgjson5/pipeline/stages/output.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import polars as pl
@@ -457,11 +458,39 @@ def _build_mcm_finishes_cache(lf: pl.LazyFrame) -> None:
 
 
 def build_id_mappings_from_parquet(ctx: PipelineContext) -> None:
-    """Build ID -> UUID mappings by scanning all partitioned parquet files."""
+    """Build ID -> UUID mappings by scanning all partitioned parquet files.
+
+    Projects only the identifier fields the downstream helpers need and casts
+    each to String per-partition before concat. Without this, struct-field
+    dtype drift between partitions (e.g. an all-null column inferred as Null
+    in one partition vs String in another) causes pl.concat to panic and
+    silently disables the price builder's ID mappings.
+    """
     cards_dir = constants.CACHE_PATH / "_parquet"
     tokens_dir = constants.CACHE_PATH / "_parquet_tokens"
 
-    id_cols = ["uuid", "identifiers", "finishes"]
+    needed_id_fields = [
+        "tcgplayerProductId",
+        "tcgplayerEtchedProductId",
+        "tcgplayerAlternativeFoilProductId",
+        "mtgoId",
+        "scryfallId",
+        "mcmId",
+    ]
+
+    def _normalized(pq_file: Path) -> pl.LazyFrame:
+        return pl.scan_parquet(pq_file).select(
+            [
+                pl.col("uuid").cast(pl.String),
+                pl.struct(
+                    [
+                        pl.col("identifiers").struct.field(name).cast(pl.String).alias(name)
+                        for name in needed_id_fields
+                    ]
+                ).alias("identifiers"),
+                pl.col("finishes"),
+            ]
+        )
 
     frames: list[pl.LazyFrame] = []
     for parquet_dir in [cards_dir, tokens_dir]:
@@ -471,7 +500,7 @@ def build_id_mappings_from_parquet(ctx: PipelineContext) -> None:
             if set_dir.is_dir() and set_dir.name.startswith("setCode="):
                 pq_file = set_dir / "0.parquet"
                 if pq_file.exists():
-                    frames.append(pl.scan_parquet(pq_file).select(id_cols))
+                    frames.append(_normalized(pq_file))
 
     if not frames:
         LOGGER.warning("No parquet partitions found for ID mapping build")


### PR DESCRIPTION
Fixes intermittent build failure where pl.concat in build_id_mappings_from_parquet panicked on identifier struct schema mismatch, silently zeroing out the price builder output.

Root cause: link_foil_nonfoil_versions built links_df from a Python dict whose dtype polars inferred from values - all-None batches inferred as Null, then overwrote the String-typed struct fields. Partitions written by foil-link-affected batches diverged from other batches in the same build.

Changes:
- derived.py: pin pl.String schema on links_df construction + explicit cast in with_fields
- output.py: rebuild identifiers struct per-partition with only the fields needed by downstream helpers, all cast to String, before concat