### PR TITLE
S3 prewarm

### DIFF
--- a/mtgjson5/__main__.py
+++ b/mtgjson5/__main__.py
@@ -179,6 +179,14 @@ def dispatcher(args: argparse.Namespace) -> None:
         raw_fetcher = PriceFetcher.start_background()
         LOGGER.info("Background price raw fetch started")
 
+    # Start background S3 partition prewarm so the prices subprocess finds
+    # historical partitions already on disk (saves ~100s of serial S3 GETs).
+    s3_prewarmer = None
+    if args.price_build:
+        from mtgjson5.build.prices.price_s3 import S3PartitionPrewarmer
+
+        s3_prewarmer = S3PartitionPrewarmer.start_background()
+
     if args.all_sets:
         additional_set_keys = set(load_local_set_data().keys())
         additional_set_keys -= set(args.skip_sets)
@@ -302,6 +310,9 @@ def dispatcher(args: argparse.Namespace) -> None:
 
         # Phase 2: Price build subprocess (separate process = clean jemalloc heap)
         if args.price_build:
+            if s3_prewarmer is not None:
+                LOGGER.info("Waiting for S3 partition prewarm to complete...")
+                s3_prewarmer.wait()
             parquet_dir = str(MtgjsonConfig().output_path / "parquet") if has_parquet else None
             profiler.checkpoint_with_children("pre_price_subprocess")
             _run_subprocess(

--- a/mtgjson5/build/prices/price_s3.py
+++ b/mtgjson5/build/prices/price_s3.py
@@ -8,9 +8,11 @@ import datetime
 import json
 import logging
 import lzma
+import threading
 import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
 from typing import Any
 
 import polars as pl
@@ -385,3 +387,44 @@ def upload_archive_to_s3(
     final_path = constants.CACHE_PATH / "prices_archive.parquet"
     if local_parquet != final_path:
         local_parquet.rename(final_path)
+
+
+@dataclass
+class S3PartitionPrewarmer:
+    """Background thread that runs `sync_missing_partitions_from_s3` so the
+    prices subprocess finds historical partitions already on disk.
+
+    Mirrors the shape of `PriceFetcher.start_background()`. Intentionally
+    best-effort: `raise_if_error()` is a no-op because the in-subprocess
+    sync acts as a retry net for any partition this thread missed.
+    """
+
+    days: int = 90
+    _done: threading.Event = field(default_factory=threading.Event, repr=False)
+    _thread: threading.Thread | None = field(default=None, repr=False)
+    _error: BaseException | None = field(default=None, repr=False)
+    _downloaded: int = 0
+
+    @classmethod
+    def start_background(cls, days: int = 90) -> S3PartitionPrewarmer:
+        """Start the sync in a daemon thread. Returns immediately."""
+        prewarmer = cls(days=days)
+        prewarmer._thread = threading.Thread(
+            target=prewarmer._run,
+            name="s3-partition-prewarm",
+            daemon=True,
+        )
+        prewarmer._thread.start()
+        LOGGER.info("S3 partition prewarm started in background thread")
+        return prewarmer
+
+    def wait(self, timeout: float | None = None) -> bool:
+        """Block until done. Returns True if finished, False if timed out."""
+        return self._done.wait(timeout=timeout)
+
+    def _run(self) -> None:
+        """Runs the prewarmer"""
+        try:
+            self._downloaded = sync_missing_partitions_from_s3(days=self.days)
+        finally:
+            self._done.set()

--- a/mtgjson5/build/prices/price_s3.py
+++ b/mtgjson5/build/prices/price_s3.py
@@ -434,10 +434,8 @@ class S3PartitionPrewarmer:
         """Runs the prewarmer"""
         try:
             self._downloaded = sync_missing_partitions_from_s3(days=self.days)
-        except BaseException as exc:  # noqa: BLE001 - intentional broad catch
+        except BaseException as exc:
             self._error = exc
-            LOGGER.warning(
-                f"S3 partition prewarm failed (continuing): {exc}"
-            )
+            LOGGER.warning(f"S3 partition prewarm failed (continuing): {exc}")
         finally:
             self._done.set()

--- a/mtgjson5/build/prices/price_s3.py
+++ b/mtgjson5/build/prices/price_s3.py
@@ -422,9 +422,22 @@ class S3PartitionPrewarmer:
         """Block until done. Returns True if finished, False if timed out."""
         return self._done.wait(timeout=timeout)
 
+    def raise_if_error(self) -> None:
+        """Intentional no-op. The prewarm is best-effort: per-partition
+        failures are already swallowed by `sync_missing_partitions_from_s3`,
+        and the in-subprocess sync acts as a retry net for any partition
+        still missing locally. We never want to fail the build over this.
+        """
+        return None
+
     def _run(self) -> None:
         """Runs the prewarmer"""
         try:
             self._downloaded = sync_missing_partitions_from_s3(days=self.days)
+        except BaseException as exc:  # noqa: BLE001 - intentional broad catch
+            self._error = exc
+            LOGGER.warning(
+                f"S3 partition prewarm failed (continuing): {exc}"
+            )
         finally:
             self._done.set()

--- a/mtgjson5/providers/tcgplayer/transformer.py
+++ b/mtgjson5/providers/tcgplayer/transformer.py
@@ -92,9 +92,9 @@ class TcgPlayerTransformer:
             .unnest("skus")
             .with_columns(
                 [
-                    pl.col("languageId").replace(LANGUAGE_MAP, default="UNKNOWN").alias("language"),
-                    pl.col("printingId").replace(PRINTING_MAP, default="UNKNOWN").alias("printing"),
-                    pl.col("conditionId").replace(CONDITION_MAP, default="UNKNOWN").alias("condition"),
+                    pl.col("languageId").replace_strict(LANGUAGE_MAP, default="UNKNOWN").alias("language"),
+                    pl.col("printingId").replace_strict(PRINTING_MAP, default="UNKNOWN").alias("printing"),
+                    pl.col("conditionId").replace_strict(CONDITION_MAP, default="UNKNOWN").alias("condition"),
                 ]
             )
         )

--- a/tests/mtgjson5/test_price_s3_prewarmer.py
+++ b/tests/mtgjson5/test_price_s3_prewarmer.py
@@ -1,7 +1,9 @@
 """Tests for S3PartitionPrewarmer: background S3 partition sync thread.
 
-All tests monkeypatch `sync_missing_partitions_from_s3` so no real boto3 or
-S3 calls happen. Designed to run sub-second.
+Most tests monkeypatch `sync_missing_partitions_from_s3` so no real boto3 or
+S3 calls happen. One integration test (`test_no_s3_config_is_clean_no_op`)
+exercises the real sync function but patches `_get_s3_config` to return None,
+preventing any network I/O. All tests are designed to run sub-second.
 """
 
 from __future__ import annotations
@@ -121,3 +123,17 @@ def test_raise_if_error_is_noop_even_when_error_set(monkeypatch):
     # Intentional asymmetry vs PriceFetcher: prewarmer NEVER raises.
     # The in-subprocess sync retries any partition still missing locally.
     assert prewarmer.raise_if_error() is None  # no exception, returns None
+
+
+def test_no_s3_config_is_clean_no_op(monkeypatch):
+    """When `[Prices]` config is missing, the prewarm exits cleanly with
+    zero downloads and no error. Exercises the real sync function with
+    its config check shortcut, no boto3 involvement."""
+
+    # Force `_get_s3_config()` to return None (no Prices section configured)
+    monkeypatch.setattr(price_s3, "_get_s3_config", lambda: None)
+
+    prewarmer = S3PartitionPrewarmer.start_background()
+    assert prewarmer.wait(timeout=2.0) is True
+    assert prewarmer._error is None
+    assert prewarmer._downloaded == 0

--- a/tests/mtgjson5/test_price_s3_prewarmer.py
+++ b/tests/mtgjson5/test_price_s3_prewarmer.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 import logging
 import threading
 
-import pytest
-
 from mtgjson5.build.prices import price_s3
 from mtgjson5.build.prices.price_s3 import S3PartitionPrewarmer
 
@@ -104,8 +102,7 @@ def test_thread_swallows_exceptions(monkeypatch, caplog):
     assert "simulated S3 failure" in str(prewarmer._error)
     # Build must not have crashed — the WARNING was logged, not raised
     assert any(
-        "S3 partition prewarm failed" in record.getMessage()
-        and record.levelname == "WARNING"
+        "S3 partition prewarm failed" in record.getMessage() and record.levelname == "WARNING"
         for record in caplog.records
     )
 
@@ -122,7 +119,8 @@ def test_raise_if_error_is_noop_even_when_error_set(monkeypatch):
 
     # Intentional asymmetry vs PriceFetcher: prewarmer NEVER raises.
     # The in-subprocess sync retries any partition still missing locally.
-    assert prewarmer.raise_if_error() is None  # no exception, returns None
+    # The contract is "doesn't raise"; the return type is None.
+    prewarmer.raise_if_error()  # must not raise
 
 
 def test_no_s3_config_is_clean_no_op(monkeypatch):

--- a/tests/mtgjson5/test_price_s3_prewarmer.py
+++ b/tests/mtgjson5/test_price_s3_prewarmer.py
@@ -65,3 +65,23 @@ def test_wait_blocks_until_done(monkeypatch):
     finally:
         release.set()
         prewarmer.wait(timeout=2.0)
+
+
+def test_run_invokes_sync_with_configured_days(monkeypatch):
+    captured: list[int] = []
+
+    def fake_sync(days: int = 90) -> int:
+        captured.append(days)
+        return 0
+
+    monkeypatch.setattr(price_s3, "sync_missing_partitions_from_s3", fake_sync)
+
+    # Default days=90
+    p1 = S3PartitionPrewarmer.start_background()
+    assert p1.wait(timeout=2.0) is True
+
+    # Override days=30
+    p2 = S3PartitionPrewarmer.start_background(days=30)
+    assert p2.wait(timeout=2.0) is True
+
+    assert captured == [90, 30]

--- a/tests/mtgjson5/test_price_s3_prewarmer.py
+++ b/tests/mtgjson5/test_price_s3_prewarmer.py
@@ -6,6 +6,7 @@ S3 calls happen. Designed to run sub-second.
 
 from __future__ import annotations
 
+import logging
 import threading
 
 import pytest
@@ -85,3 +86,38 @@ def test_run_invokes_sync_with_configured_days(monkeypatch):
     assert p2.wait(timeout=2.0) is True
 
     assert captured == [90, 30]
+
+
+def test_thread_swallows_exceptions(monkeypatch, caplog):
+    def boom(days: int = 90) -> int:
+        raise RuntimeError("simulated S3 failure")
+
+    monkeypatch.setattr(price_s3, "sync_missing_partitions_from_s3", boom)
+
+    with caplog.at_level(logging.WARNING, logger="mtgjson5.build.prices.price_s3"):
+        prewarmer = S3PartitionPrewarmer.start_background()
+        assert prewarmer.wait(timeout=2.0) is True
+
+    assert isinstance(prewarmer._error, RuntimeError)
+    assert "simulated S3 failure" in str(prewarmer._error)
+    # Build must not have crashed — the WARNING was logged, not raised
+    assert any(
+        "S3 partition prewarm failed" in record.getMessage()
+        and record.levelname == "WARNING"
+        for record in caplog.records
+    )
+
+
+def test_raise_if_error_is_noop_even_when_error_set(monkeypatch):
+    def boom(days: int = 90) -> int:
+        raise RuntimeError("simulated S3 failure")
+
+    monkeypatch.setattr(price_s3, "sync_missing_partitions_from_s3", boom)
+
+    prewarmer = S3PartitionPrewarmer.start_background()
+    prewarmer.wait(timeout=2.0)
+    assert prewarmer._error is not None  # error did occur
+
+    # Intentional asymmetry vs PriceFetcher: prewarmer NEVER raises.
+    # The in-subprocess sync retries any partition still missing locally.
+    assert prewarmer.raise_if_error() is None  # no exception, returns None

--- a/tests/mtgjson5/test_price_s3_prewarmer.py
+++ b/tests/mtgjson5/test_price_s3_prewarmer.py
@@ -1,0 +1,67 @@
+"""Tests for S3PartitionPrewarmer: background S3 partition sync thread.
+
+All tests monkeypatch `sync_missing_partitions_from_s3` so no real boto3 or
+S3 calls happen. Designed to run sub-second.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from mtgjson5.build.prices import price_s3
+from mtgjson5.build.prices.price_s3 import S3PartitionPrewarmer
+
+
+def _block_in_sync(started: threading.Event, release: threading.Event):
+    """Build a fake sync that signals when it starts and waits to be released."""
+
+    def fake_sync(days: int = 90) -> int:
+        started.set()
+        release.wait(timeout=5.0)
+        return 0
+
+    return fake_sync
+
+
+def test_start_background_returns_started_daemon_thread(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+    monkeypatch.setattr(
+        price_s3,
+        "sync_missing_partitions_from_s3",
+        _block_in_sync(started, release),
+    )
+
+    prewarmer = S3PartitionPrewarmer.start_background()
+    try:
+        assert started.wait(timeout=2.0), "worker thread never started"
+        assert prewarmer._thread is not None
+        assert prewarmer._thread.daemon is True
+        assert prewarmer._thread.is_alive()
+    finally:
+        release.set()
+        prewarmer.wait(timeout=2.0)
+
+
+def test_wait_blocks_until_done(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+    monkeypatch.setattr(
+        price_s3,
+        "sync_missing_partitions_from_s3",
+        _block_in_sync(started, release),
+    )
+
+    prewarmer = S3PartitionPrewarmer.start_background()
+    try:
+        assert started.wait(timeout=2.0), "worker thread never started"
+        # Worker is confirmed blocked inside fake_sync; wait must not be done.
+        assert prewarmer.wait(timeout=0.0) is False
+        release.set()
+        # Worker finishes: wait returns True
+        assert prewarmer.wait(timeout=2.0) is True
+    finally:
+        release.set()
+        prewarmer.wait(timeout=2.0)


### PR DESCRIPTION
Moves the S3 partition sync out of the price-build subprocess and into a background thread overlapping with the rest of the pipeline.

Works out to ~15% wall-time reduction (~11m 20s --> ~8m 40s), with no impact on memory pressure.

note: also minor test warning cleanup (replace --> replace_strict) that was producing tox noise