### PR TITLE
Add PDH and PreDH leadershipSkills

### DIFF
--- a/mtgjson5/models/submodels.py
+++ b/mtgjson5/models/submodels.py
@@ -369,12 +369,17 @@ class LeadershipSkills(TypedDict):
             "description": "If the card can be your commander in the [Pauper Commander](https://mtg.wiki/page/Pauper_Commander) format.",
             "introduced": "v5.3.1",
         },
+        "predh": {
+            "description": "If the card can be your commander in the [PreDH](https://articles.starcitygames.com/magic-the-gathering/commander-sub-format-predh-is-the-new-magic-rage/) format.",
+            "introduced": "v5.3.1",
+        },
     }
 
     brawl: bool
     commander: bool
     oathbreaker: bool
     pauper_commander: bool
+    predh: bool
 
 
 class Legalities(TypedDict, total=False):

--- a/mtgjson5/models/submodels.py
+++ b/mtgjson5/models/submodels.py
@@ -365,11 +365,16 @@ class LeadershipSkills(TypedDict):
             "description": "If the card can be your commander in the [Oathbreaker](https://oathbreakermtg.org/) format.",
             "introduced": "v4.5.1",
         },
+        "pauper_commander": {
+            "description": "If the card can be your commander in the [Pauper Commander](https://mtg.wiki/page/Pauper_Commander) format.",
+            "introduced": "v5.3.1",
+        },
     }
 
     brawl: bool
     commander: bool
     oathbreaker: bool
+    pauper_commander: bool
 
 
 class Legalities(TypedDict, total=False):

--- a/mtgjson5/pipeline/stages/relationships.py
+++ b/mtgjson5/pipeline/stages/relationships.py
@@ -255,18 +255,26 @@ def add_leadership_skills_expr(
     # Oathbreaker legal = is a planeswalker
     is_oathbreaker_legal = pl.col("type").str.contains("Planeswalker")
 
+    # Pauper commander legal check based on rarity
+    is_pauper_commander_legal = (
+        (pl.col("rarity") == "uncommon")
+        & (is_creature | (is_vehicle_or_spacecraft & has_power_toughness))
+        & is_front_face
+    )
+
     # Brawl legal = set is in Standard AND (commander or oathbreaker eligible)
     standard_sets = ctx.standard_legal_sets
     is_in_standard = pl.col("setCode").is_in(standard_sets or set())
     is_brawl_legal = is_in_standard & (is_commander_legal | is_oathbreaker_legal)
 
     return lf.with_columns(
-        pl.when(is_commander_legal | is_oathbreaker_legal | is_brawl_legal)
+        pl.when(is_commander_legal | is_oathbreaker_legal | is_brawl_legal | is_pauper_commander_legal)
         .then(
             pl.struct(
                 brawl=is_brawl_legal,
                 commander=is_commander_legal,
                 oathbreaker=is_oathbreaker_legal,
+                pauper_commander=is_pauper_commander_legal,
             )
         )
         .otherwise(pl.lit(None))

--- a/mtgjson5/pipeline/stages/relationships.py
+++ b/mtgjson5/pipeline/stages/relationships.py
@@ -263,9 +263,9 @@ def add_leadership_skills_expr(
     )
 
     # Predh commanders are all of the same checks as regular commander, but also checked as legal in predh
-    is_predh_legal = (
-        is_commander_legal
-        & (pl.col("legalities").struct.field("predh").is_not_null() & (pl.col("legalities").struct.field("predh") == "Legal"))
+    is_predh_legal = is_commander_legal & (
+        pl.col("legalities").struct.field("predh").is_not_null()
+        & (pl.col("legalities").struct.field("predh") == "Legal")
     )
 
     # Brawl legal = set is in Standard AND (commander or oathbreaker eligible)

--- a/mtgjson5/pipeline/stages/relationships.py
+++ b/mtgjson5/pipeline/stages/relationships.py
@@ -262,19 +262,26 @@ def add_leadership_skills_expr(
         & is_front_face
     )
 
+    # Predh commanders are all of the same checks as regular commander, but also checked as legal in predh
+    is_predh_legal = (
+        is_commander_legal
+        & (pl.col("legalities").struct.field("predh").is_not_null() & (pl.col("legalities").struct.field("predh") == "Legal"))
+    )
+
     # Brawl legal = set is in Standard AND (commander or oathbreaker eligible)
     standard_sets = ctx.standard_legal_sets
     is_in_standard = pl.col("setCode").is_in(standard_sets or set())
     is_brawl_legal = is_in_standard & (is_commander_legal | is_oathbreaker_legal)
 
     return lf.with_columns(
-        pl.when(is_commander_legal | is_oathbreaker_legal | is_brawl_legal | is_pauper_commander_legal)
+        pl.when(is_commander_legal | is_oathbreaker_legal | is_brawl_legal | is_pauper_commander_legal | is_predh_legal)
         .then(
             pl.struct(
                 brawl=is_brawl_legal,
                 commander=is_commander_legal,
                 oathbreaker=is_oathbreaker_legal,
                 pauper_commander=is_pauper_commander_legal,
+                predh=is_predh_legal,
             )
         )
         .otherwise(pl.lit(None))


### PR DESCRIPTION
These two formats use leaders/commanders in their game, but aren't yet present in the `leadershipSkills` struct.  This adds both of them with checks regarding their respective formats.

PDH (Pauper Commander) checks can all be done on basic values already found on the card similar to current Brawl, Oathbreaker, and Commander checks.  Scryfall legalities data didn't seem to include anything on legality "as a commander", and even though Scryfall does offer an `is:pauperCommander` search option, I didn't see that data anywhere.
- Example card as of this PR: ["Ajani's Pridemate"](https://scryfall.com/card/fdn/135/ajanis-pridemate) isn't legal in Pauper, doesn't show up in a Scryfall search for `legal:pauperCommander`, but is legal as the Commander if you search for it using `is:pauperCommander`.  [PDH rules here](https://pdhhomebase.com/rules/)

The best way I found to check for PreDH was to just check in `legalities`, which does require that stage to happen before the `leadershipSkills` in `relationships.py` does.  Luckily, that stage already does, I just wanted to point out the dependency.  Otherwise, it would need to be changed to check if a card's original printing was before 2011-06-17 (first commander product release date), and I didn't see a clear way to determine that at the current stage where `leadershipSkills` are done.
- Example card as of this PR: ["Jhoira of the Ghitu"](https://scryfall.com/card/mma/177/jhoira-of-the-ghitu) was printed in MMA (Modern Masters), and many other times after the cutoff date, but the original printing was in FUT (Future Sight) which is before the cutoff date, and therefore legal in the format and as a commander.