### PR TITLE
Add client_encoding and BIGINT weight columns to Postgres dump

### DIFF
--- a/mtgjson5/build/formats/postgres.py
+++ b/mtgjson5/build/formats/postgres.py
@@ -18,8 +18,14 @@ if TYPE_CHECKING:
     from ..context import AssemblyContext
 
 
-def _polars_to_postgres_type(dtype: pl.DataType) -> str:
+# Integer columns whose values exceed PostgreSQL INTEGER (2^31-1) and need BIGINT
+_POSTGRES_BIGINT_COLUMNS: set[str] = {"sheetTotalWeight", "cardWeight"}
+
+
+def _polars_to_postgres_type(dtype: pl.DataType, col_name: str) -> str:
     """Map Polars dtype to PostgreSQL type."""
+    if col_name in _POSTGRES_BIGINT_COLUMNS:
+        return "BIGINT"
     if dtype.is_integer():
         return "INTEGER"
     if dtype.is_float():
@@ -52,7 +58,7 @@ class PostgresBuilder:
         serialized = serialize_complex_types(df)
 
         schema = serialized.schema
-        col_defs = ",\n    ".join([f'"{c}" {_polars_to_postgres_type(schema[c])}' for c in serialized.columns])
+        col_defs = ",\n    ".join([f'"{c}" {_polars_to_postgres_type(schema[c], c)}' for c in serialized.columns])
         f.write(f'DROP TABLE IF EXISTS "{table_name}" CASCADE;\n')
         f.write(f'CREATE TABLE "{table_name}" (\n    {col_defs}\n);\n\n')
 
@@ -119,6 +125,7 @@ class PostgresBuilder:
 
         with open(output_path, "w", encoding="utf-8") as f:
             f.write(f"-- MTGJSON PostgreSQL Dump\n-- Generated: {datetime.now().strftime('%Y-%m-%d')}\n")
+            f.write("SET client_encoding = 'UTF8';\n")
             f.write("BEGIN;\n\n")
 
             total_rows = 0

--- a/tests/mtgjson5/test_output_postgres.py
+++ b/tests/mtgjson5/test_output_postgres.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import types
+
 import polars as pl
 
+from mtgjson5.build.formats.postgres import PostgresBuilder, _polars_to_postgres_type
 from mtgjson5.build.serializers import escape_postgres, serialize_complex_types
 
 # =============================================================================
@@ -156,3 +159,50 @@ class TestPostgresBoolAndEscaping:
         assert "\\t" in data_line
         assert "\\n" in data_line
         assert "\\\\" in data_line
+
+
+# =============================================================================
+# TestPostgresTypeMapping
+# =============================================================================
+
+
+class TestPostgresTypeMapping:
+    def test_wide_weight_columns_use_bigint(self):
+        # sheetTotalWeight/cardWeight can exceed INTEGER's 2^31-1 range
+        assert _polars_to_postgres_type(pl.Int64, "sheetTotalWeight") == "BIGINT"
+        assert _polars_to_postgres_type(pl.Int64, "cardWeight") == "BIGINT"
+
+    def test_ordinary_integer_columns_use_integer(self):
+        assert _polars_to_postgres_type(pl.Int64, "edhrecRank") == "INTEGER"
+
+    def test_bigint_applied_in_create_table(self):
+        import io
+
+        df = pl.DataFrame(
+            {"setCode": ["TST"], "sheetTotalWeight": [171_600_000_000]},
+            schema={"setCode": pl.String, "sheetTotalWeight": pl.Int64},
+        )
+        buf = io.StringIO()
+        PostgresBuilder._write_table(buf, "setBoosterSheets", df)
+        create_stmt = buf.getvalue()
+        assert '"sheetTotalWeight" BIGINT' in create_stmt
+
+
+# =============================================================================
+# TestPostgresDumpHeader
+# =============================================================================
+
+
+class TestPostgresDumpHeader:
+    def test_header_declares_utf8_client_encoding(self, tmp_path):
+        df = pl.DataFrame({"uuid": ["a"], "name": ["Alpha"]})
+        ctx = types.SimpleNamespace(
+            normalized_tables={"cards": df},
+            normalized_boosters={},
+            output_path=tmp_path,
+        )
+        out = PostgresBuilder(ctx).write()
+        text = out.read_text(encoding="utf-8")
+        assert "SET client_encoding = 'UTF8';" in text
+        # Must precede any COPY data so psql decodes the whole dump correctly
+        assert text.index("SET client_encoding") < text.index("COPY ")


### PR DESCRIPTION
sets proper client_encoding value at top of .psql file and BIGINT over INTEGER for weight columns 

<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
