### PR TITLE
Fix mypy union-attr in Postgres dump header test

### DIFF
--- a/tests/mtgjson5/test_output_postgres.py
+++ b/tests/mtgjson5/test_output_postgres.py
@@ -202,6 +202,7 @@ class TestPostgresDumpHeader:
             output_path=tmp_path,
         )
         out = PostgresBuilder(ctx).write()
+        assert out is not None
         text = out.read_text(encoding="utf-8")
         assert "SET client_encoding = 'UTF8';" in text
         # Must precede any COPY data so psql decodes the whole dump correctly


### PR DESCRIPTION
Fixes a mypy `union-attr` error introduced by the merged PR #1673, which is currently failing CI on `master`.

`PostgresBuilder.write()` returns `pathlib.Path | None`, and the dump-header test called `.read_text()` on the result without narrowing. Added `assert out is not None` before the call.

`uv run tox` (format-check, lint, mypy, unit) all green.
