### PR TITLE
Fix missing non-foil TCGplayer SKUs for Surge Foil-anchored cards (MSC)

### DIFF
--- a/mtgjson5/data/context.py
+++ b/mtgjson5/data/context.py
@@ -1362,9 +1362,18 @@ class PipelineContext:
             how="inner",
         )
 
-        # Dedup filter: remove alt-foil productIds that already appear as any
-        # card's tcgplayerProductId or tcgplayerEtchedProductId. We gather known
-        # IDs from both uuid_cache (prior build) and Scryfall cards (current data).
+        # Decide, per (base, alt-foil) pair, which product Scryfall anchors on.
+        # We gather known IDs (any card's tcgplayerId or tcgplayerEtchedId) from
+        # both uuid_cache (prior build) and Scryfall cards (current data).
+        #
+        # - Normal: Scryfall points at the non-suffixed base product, so we map
+        #   base -> alt-foil (the suffixed product is the "alternative").
+        # - Flipped (e.g. MSC Surge Foil): Scryfall points at the *suffixed*
+        #   product and the non-suffixed "Regular" product is orphaned. We map
+        #   alt -> base so the regular product's SKUs/prices still attach to the
+        #   card via tcgplayerAlternativeFoilProductId.
+        # - Both known: the two products are distinct Scryfall cards, so emit no
+        #   mapping for the pair.
         known_ids: set[str] = set()
 
         # From uuid_cache (prior build's IDs)
@@ -1382,19 +1391,28 @@ class PipelineContext:
             for col in cards_ids.columns:
                 known_ids.update(cards_ids.select(col).drop_nulls().get_column(col).cast(pl.String).to_list())
 
-        LOGGER.info(f"tcg_alt_foil: {len(known_ids):,} known tcgplayer IDs for dedup")
+        LOGGER.info(f"tcg_alt_foil: {len(known_ids):,} known tcgplayer IDs")
 
-        if known_ids:
-            known_ids_series = pl.Series("_known", list(known_ids), dtype=pl.String)
-            joined = (
-                joined.with_columns(
-                    pl.col("productId").cast(pl.String).alias("_altIdStr"),
-                )
-                .filter(~pl.col("_altIdStr").is_in(known_ids_series))
-                .drop("_altIdStr")
-            )
+        known_ids_series = pl.Series("_known", list(known_ids), dtype=pl.String)
+        joined = joined.with_columns(
+            pl.col("productId").cast(pl.String).alias("_altIdStr"),
+            pl.col("_baseProductId").cast(pl.String).alias("_baseIdStr"),
+        ).with_columns(
+            pl.col("_altIdStr").is_in(known_ids_series.implode()).alias("_altKnown"),
+            pl.col("_baseIdStr").is_in(known_ids_series.implode()).alias("_baseKnown"),
+        )
 
-        # Pick single value per base product: prefer non-etched types, then first
+        # Drop pairs where both products are distinct known Scryfall cards.
+        joined = joined.filter(~(pl.col("_altKnown") & pl.col("_baseKnown")))
+
+        # Flip direction when Scryfall anchors on the suffixed (alt-foil) product.
+        flipped = pl.col("_altKnown") & ~pl.col("_baseKnown")
+        joined = joined.with_columns(
+            pl.when(flipped).then(pl.col("_altIdStr")).otherwise(pl.col("_baseIdStr")).alias("_keyId"),
+            pl.when(flipped).then(pl.col("_baseIdStr")).otherwise(pl.col("_altIdStr")).alias("_valueId"),
+        )
+
+        # Pick single value per key product: prefer non-etched types, then first
         joined = joined.sort(
             [
                 pl.col("_foilType").str.contains("(?i)etched").cast(pl.Int8),
@@ -1404,10 +1422,10 @@ class PipelineContext:
 
         joined_df: pl.DataFrame = joined.collect() if isinstance(joined, pl.LazyFrame) else joined
 
-        result = joined_df.unique(subset=["_baseProductId"], keep="first").select(
+        result = joined_df.unique(subset=["_keyId"], keep="first").select(
             [
-                pl.col("_baseProductId").cast(pl.String).alias("tcgplayerProductId"),
-                pl.col("productId").cast(pl.String).alias("tcgplayerAlternativeFoilProductId"),
+                pl.col("_keyId").alias("tcgplayerProductId"),
+                pl.col("_valueId").alias("tcgplayerAlternativeFoilProductId"),
             ]
         )
 

--- a/tests/mtgjson5/test_tcg_alt_foil_lookup.py
+++ b/tests/mtgjson5/test_tcg_alt_foil_lookup.py
@@ -82,7 +82,7 @@ class TestBuildTcgAltFoilLookup:
             ],
             known_tcg_ids=[2000, 2001],
         )
-        assert mapping == {}
+        assert not mapping
 
     def test_mixed_sets_resolve_independently(self) -> None:
         """Normal and flipped pairs in one build resolve to correct directions."""

--- a/tests/mtgjson5/test_tcg_alt_foil_lookup.py
+++ b/tests/mtgjson5/test_tcg_alt_foil_lookup.py
@@ -1,0 +1,98 @@
+"""Tests for PipelineContext._build_tcg_alt_foil_lookup.
+
+Covers the base <-> alt-foil TCGPlayer product pairing, including the "flipped"
+case (MSC Surge Foil) where Scryfall anchors the card on the *suffixed* product
+and the non-suffixed "Regular" product would otherwise be orphaned.
+See https://github.com/mtgjson/mtgjson/issues/1676.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from mtgjson5.data.context import PipelineContext
+
+
+def _build_lookup(products: list[dict], known_tcg_ids: list[int]) -> dict[str, str]:
+    """Run _build_tcg_alt_foil_lookup against fake data and return the mapping.
+
+    Args:
+        products: rows for the fake tcg_skus frame (productId, name, groupId).
+        known_tcg_ids: TCGPlayer product IDs that appear as a card's Scryfall
+            tcgplayerId (i.e. the products Scryfall anchors cards on).
+
+    Returns:
+        dict of tcgplayerProductId -> tcgplayerAlternativeFoilProductId.
+    """
+    tcg_skus = pl.LazyFrame(products, schema={"productId": pl.Int64, "name": pl.String, "groupId": pl.Int64})
+    cards = pl.LazyFrame({"tcgplayerId": known_tcg_ids}, schema={"tcgplayerId": pl.Int64})
+    # uuid_cache must be non-None; leave it empty so all known IDs come from cards.
+    uuid_cache = pl.LazyFrame({"tcgplayerId": []}, schema={"tcgplayerId": pl.Int64})
+
+    ctx = PipelineContext.for_testing(cards_lf=cards, uuid_cache_lf=uuid_cache)
+    ctx._test_data["_tcg_skus_lf"] = tcg_skus
+    ctx._build_tcg_alt_foil_lookup()
+
+    if ctx.tcg_alt_foil_lf is None:
+        return {}
+    df = ctx.tcg_alt_foil_lf.collect()
+    return dict(
+        zip(
+            df["tcgplayerProductId"].to_list(),
+            df["tcgplayerAlternativeFoilProductId"].to_list(),
+            strict=True,
+        )
+    )
+
+
+class TestBuildTcgAltFoilLookup:
+    def test_normal_case_base_is_anchor(self) -> None:
+        """Scryfall points at the non-suffixed base -> map base to alt-foil."""
+        mapping = _build_lookup(
+            products=[
+                {"productId": 1000, "name": "Normal Card", "groupId": 2},
+                {"productId": 1001, "name": "Normal Card (Rainbow Foil)", "groupId": 2},
+            ],
+            known_tcg_ids=[1000],
+        )
+        assert mapping == {"1000": "1001"}
+
+    def test_flipped_case_surge_foil_is_anchor(self) -> None:
+        """MSC case: Scryfall points at the suffixed Surge Foil product.
+
+        The orphaned Regular product must be attached via the flipped mapping so
+        its non-foil SKUs join to the card.
+        """
+        mapping = _build_lookup(
+            products=[
+                {"productId": 698032, "name": "Tombstone, Career Criminal", "groupId": 1},
+                {"productId": 698031, "name": "Tombstone, Career Criminal (Surge Foil)", "groupId": 1},
+            ],
+            known_tcg_ids=[698031],
+        )
+        # Key is the Scryfall-anchored surge product; value is the regular product.
+        assert mapping == {"698031": "698032"}
+
+    def test_both_products_known_emits_no_mapping(self) -> None:
+        """When both products are distinct Scryfall cards, emit no pairing."""
+        mapping = _build_lookup(
+            products=[
+                {"productId": 2000, "name": "Dual Card", "groupId": 3},
+                {"productId": 2001, "name": "Dual Card (Foil)", "groupId": 3},
+            ],
+            known_tcg_ids=[2000, 2001],
+        )
+        assert mapping == {}
+
+    def test_mixed_sets_resolve_independently(self) -> None:
+        """Normal and flipped pairs in one build resolve to correct directions."""
+        mapping = _build_lookup(
+            products=[
+                {"productId": 1000, "name": "Normal Card", "groupId": 2},
+                {"productId": 1001, "name": "Normal Card (Rainbow Foil)", "groupId": 2},
+                {"productId": 698032, "name": "Tombstone, Career Criminal", "groupId": 1},
+                {"productId": 698031, "name": "Tombstone, Career Criminal (Surge Foil)", "groupId": 1},
+            ],
+            known_tcg_ids=[1000, 698031],
+        )
+        assert mapping == {"1000": "1001", "698031": "698032"}


### PR DESCRIPTION
## Problem

Fixes #1676. For 52 MSC (Marvel Super Heroes Commander) cards, `TcgplayerSkus.json` only contained the Surge Foil product's foil SKUs — the Regular (non-foil) product and its SKUs were absent, even though the card's `finishes` array is `[nonfoil, foil]`.

Example — Tombstone, Career Criminal (0160), `uuid 474309ce-4270-5bc9-8078-f51d4b6ab395`:
- Present: productId `698031` (Surge Foil) + its foil skuIds
- Missing: productId `698032` (Regular) + its non-foil skuIds

## Root cause

Scryfall's `tcgplayer_id` for these cards points at the **Surge Foil** product (`698031`), not the **Regular** product (`698032`). `TcgplayerSkus` is built by joining flattened SKUs against the card's product-ID identifiers, so only the surge product's foil SKUs got attached; the regular product was referenced by nothing.

`_build_tcg_alt_foil_lookup` (`mtgjson5/data/context.py`) assumed the *non-suffixed* base product is always the card's anchor and the *suffixed* `(Surge Foil)` product is the alternative. That produced a `base -> alt` mapping (`698032 -> 698031`) which:
1. never joined — the card's `tcgplayerId` is the suffixed product (`698031`), not the base key (`698032`); and
2. was then deleted outright by the dedup step, because `698031` is a known Scryfall id.

Net result: `tcgplayerAlternativeFoilProductId` stayed null and the regular product was orphaned.

## Fix

Make the base ↔ alt-foil pairing **anchor-aware**: key the mapping on whichever product is a known Scryfall id and point it at the other product.

| Case | Mapping |
|---|---|
| Normal (Scryfall → base) | `base → alt-foil` (unchanged) |
| Flipped (Scryfall → Surge Foil, MSC) | `surge → regular` |
| Both products are distinct Scryfall cards | no mapping |

Tombstone now keeps `tcgplayerProductId = 698031` and gains `tcgplayerAlternativeFoilProductId = 698032`, which pulls the regular product's non-foil SKUs into `TcgplayerSkus` through the existing alt-foil join. The only behavioral change vs. before is the flipped case; normal and both-known pairs are untouched.

## Tests

- New `tests/mtgjson5/test_tcg_alt_foil_lookup.py` — flipped, normal (no-regression), both-known, and mixed cases.
- Related suites pass (scryfall overrides, assembly context, pipeline transforms, referral builder, tcgplayer transformer). `mypy` and `ruff` clean; also cleared a pre-existing `is_in` deprecation warning in the touched block.

## Note (out of scope)

Non-foil **prices** for these cards are still missing: the TCGplayer price builder only consumes `tcg_to_uuid` + `tcg_etched_to_uuid`, not the alt-foil map. Folding the alt-foil mapping into the price builder's product→UUID map would close that gap — happy to do it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)