### PR TITLE
Add hareruyaId sealed identifier and warn on dropped identifiers

### DIFF
--- a/mtgjson5/models/sealed.py
+++ b/mtgjson5/models/sealed.py
@@ -4,6 +4,7 @@ MTGJSON sealed product and booster models.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from pydantic import BaseModel, Field, model_validator
@@ -27,6 +28,18 @@ from .submodels import (
 
 if TYPE_CHECKING:
     from polars import DataFrame
+
+LOGGER = logging.getLogger(__name__)
+
+# Identifier keys recognised by the Identifiers model. Any sealed-product
+# identifier coming from mtg-sealed-content that is not in this set is silently
+# dropped by Pydantic during validation, so we warn about it (see
+# SealedProduct.warn_on_dropped_identifiers).
+_KNOWN_IDENTIFIER_FIELDS: frozenset[str] = frozenset(Identifiers.__annotations__)
+
+# Track identifier keys we've already warned about so a single unknown key
+# doesn't produce one warning per product across the whole build.
+_WARNED_DROPPED_IDENTIFIERS: set[str] = set()
 
 
 class SealedProduct(PolarsMixin, BaseModel):
@@ -106,6 +119,33 @@ class SealedProduct(PolarsMixin, BaseModel):
         description="Links that navigate to websites where the product can be purchased. See the [Purchase Urls](/data-models/purchase-urls/) Data Model.",
         json_schema_extra={"introduced": "v5.2.0"},
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def warn_on_dropped_identifiers(cls, data: Any) -> Any:
+        """Warn when a source identifier key is not recognised by the model.
+
+        Sealed-product identifiers come straight from mtg-sealed-content and can
+        contain any key. Pydantic silently drops keys not declared on the
+        :class:`Identifiers` model, so a newly-added identifier type (e.g. a new
+        retailer) would vanish from the output with no signal. Emit a warning —
+        once per unknown key — so it's noticed and the field can be added.
+        """
+        if isinstance(data, dict):
+            identifiers = data.get("identifiers")
+            if isinstance(identifiers, dict):
+                unknown = set(identifiers) - _KNOWN_IDENTIFIER_FIELDS
+                for key in sorted(unknown):
+                    if key in _WARNED_DROPPED_IDENTIFIERS:
+                        continue
+                    _WARNED_DROPPED_IDENTIFIERS.add(key)
+                    LOGGER.warning(
+                        "Dropping unknown sealed-product identifier %r (product %r) - "
+                        "add it to the Identifiers model to include it in output.",
+                        key,
+                        data.get("name"),
+                    )
+        return data
 
     @model_validator(mode="before")
     @classmethod

--- a/mtgjson5/models/submodels.py
+++ b/mtgjson5/models/submodels.py
@@ -208,6 +208,11 @@ class Identifiers(TypedDict, total=False):
             "introduced": "v5.2.2",
             "optional": True,
         },
+        "hareruyaId": {
+            "description": "The [Hareruya](https://www.hareruyamtg.com/en/) identifier.",
+            "introduced": "v5.3.1",
+            "optional": True,
+        },
         "mcmId": {
             "description": "The [Cardmarket](https://www.cardmarket.com/en/Magic?utm_campaign=card_prices&utm_medium=text&utm_source=mtgjson) card identifier.",
             "introduced": "v4.4.0",
@@ -309,6 +314,7 @@ class Identifiers(TypedDict, total=False):
     abuId: str
     cardtraderId: str
     csiId: str
+    hareruyaId: str
     miniaturemarketId: str
     mvpId: str
     scgId: str

--- a/tests/mtgjson5/test_models_sealed.py
+++ b/tests/mtgjson5/test_models_sealed.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from mtgjson5.models.sealed import SealedProduct
 
 
@@ -61,6 +63,32 @@ class TestSealedProductValidator:
         assert d["uuid"] == "sp-007"
         assert d["name"] == "Minimal Product"
         assert d["identifiers"] == {}
+
+    def test_hareruya_identifier_preserved(self):
+        product = SealedProduct(
+            uuid="sp-009",
+            name="Test Product",
+            identifiers={"cardKingdomId": "1", "hareruyaId": "162494"},
+        )
+        d = product.to_polars_dict(exclude_none=True)
+        assert d["identifiers"]["hareruyaId"] == "162494"
+
+    def test_unknown_identifier_dropped_with_warning(self, caplog):
+        # Use a key unique to this test so the once-per-key dedup doesn't
+        # suppress the warning due to unrelated tests.
+        unknown_key = "someBrandNewRetailerId"
+        with caplog.at_level(logging.WARNING, logger="mtgjson5.models.sealed"):
+            product = SealedProduct.model_validate(
+                {
+                    "uuid": "sp-010",
+                    "name": "Test Product",
+                    "identifiers": {"tcgplayerProductId": "12345", unknown_key: "999"},
+                }
+            )
+        d = product.to_polars_dict(exclude_none=True)
+        assert unknown_key not in d["identifiers"]
+        assert d["identifiers"]["tcgplayerProductId"] == "12345"
+        assert any(unknown_key in r.message for r in caplog.records)
 
     def test_contents_with_multiple_types(self):
         data = {


### PR DESCRIPTION
## Problem

New sealed-product identifiers from [mtg-sealed-content](https://github.com/mtgjson/mtg-sealed-content) (e.g. `hareruyaId`, added in [71564e1](https://github.com/mtgjson/mtg-sealed-content/commit/71564e1c54fad36d7c8168f2fcd2d0f9437b1ff6)) never reach the output.

Identifiers flow correctly from the YAML through the Polars pipeline, but the final `SealedProduct.from_dataframe(...)` validation strips any identifier key not declared on the `Identifiers` model. Because `Identifiers` acts as an allowlist for sealed products, `hareruyaId` was silently dropped.

## Changes

- **Add `hareruyaId`** to the `Identifiers` model (field + `__field_docs__`) so it survives validation and reaches output.
- **Warn on dropped identifiers**: a `mode="before"` validator on `SealedProduct` logs a `WARNING` for any incoming identifier key not recognised by the model (deduped to once per key per build), so the next new identifier type surfaces a signal instead of vanishing silently.
- **Tests** covering both: `hareruyaId` is preserved, and an unknown key is dropped *and* warned.
