### PR TITLE
Sanitize branch name for Docker tag in build-container CI

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -32,8 +32,13 @@ jobs:
 
       - name: Generate Tag
         id: generate-tag
+        env:
+          BRANCH_NAME: ${{ steps.branch-name.outputs.current_branch }}
         run: |
-          echo "release_tag=mtgjson:$(date +"%Y-%m-%d_%H-%M")-${{ steps.branch-name.outputs.current_branch }}" >> $GITHUB_OUTPUT
+          # Docker tags only allow [a-zA-Z0-9_.-]; replace anything else (e.g. the
+          # "/" in branch names like "fix/foo") with "-" so the tag is valid.
+          safe_branch=$(printf '%s' "$BRANCH_NAME" | tr -c 'a-zA-Z0-9_.-' '-')
+          echo "release_tag=mtgjson:$(date +"%Y-%m-%d_%H-%M")-${safe_branch}" >> "$GITHUB_OUTPUT"
 
       - name: Build Image
         id: build-image


### PR DESCRIPTION
## Problem

The `build-container` workflow composes a Docker tag from the branch name:

```
mtgjson:$(date +"%Y-%m-%d_%H-%M")-${{ steps.branch-name.outputs.current_branch }}
```

Branch names containing a `/` (e.g. `fix/base-set-size-overrides-1651`) produce an invalid Docker tag, and the build fails:

```
ERROR: failed to build: invalid tag "mtgjson:2026-07-13_09-08-fix/base-set-size-overrides-1651": invalid reference format
```

(seen in the CI run for #1682)

## Fix

Docker tags may only contain `[a-zA-Z0-9_.-]`. This sanitizes the branch name by replacing any other character with `-` before composing the release tag. The branch name is now passed via an env var to avoid shell injection.

Examples:
- `fix/base-set-size-overrides-1651` → `...-fix-base-set-size-overrides-1651`
- `master` → `...-master` (unchanged)

This is a standalone fix branched from `master` so it can land independently of the PRs whose branch names trigger the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)