### PR TITLE
fix: preserve exact Cardmarket variant IDs

### DIFF
--- a/mtgjson5/pipeline/stages/identifiers.py
+++ b/mtgjson5/pipeline/stages/identifiers.py
@@ -78,13 +78,17 @@ def join_cardmarket_ids(
         how="left",
     )
 
-    # Coalesce: prefer first join results, fall back to second join, then Scryfall
+    # Scryfall identifies the exact Cardmarket printing and version. Prefer that
+    # value over the name/number joins, which can be ambiguous when Cardmarket
+    # gives multiple variants the same collector number (for example RVR #404
+    # and its serialized counterpart). Use the Cardmarket lookup as a fallback
+    # for cards that do not have a Scryfall Cardmarket ID.
     lf = lf.with_columns(
         [
             pl.coalesce(
+                pl.col("cardmarketId").cast(pl.String),
                 pl.col("mcmId"),
                 pl.col("_mcmId2"),
-                pl.col("cardmarketId").cast(pl.String),
             ).alias("mcmId"),
             pl.coalesce(
                 pl.col("mcmMetaId"),

--- a/tests/mtgjson5/test_cardmarket_identifiers.py
+++ b/tests/mtgjson5/test_cardmarket_identifiers.py
@@ -1,0 +1,60 @@
+"""Regression tests for Cardmarket card identity mapping."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from mtgjson5.data.context import PipelineContext
+from mtgjson5.pipeline.stages.identifiers import join_cardmarket_ids
+
+
+def _mcm_lookup() -> pl.LazyFrame:
+    return pl.LazyFrame(
+        {
+            "mcmId": ["750355", "123456"],
+            "mcmMetaId": ["7595", "654321"],
+            "setCode": ["RVR", "TST"],
+            "nameLower": ["hallowed fountain", "fallback card"],
+            "number": ["404", "1"],
+        }
+    )
+
+
+def test_scryfall_cardmarket_id_preserves_rvr_variant_identity():
+    cards = pl.LazyFrame(
+        {
+            "name": ["Hallowed Fountain", "Hallowed Fountain"],
+            "setCode": ["RVR", "RVR"],
+            "number": ["404", "404z"],
+            "cardmarketId": [748753, 750355],
+        }
+    )
+    ctx = PipelineContext(_test_data={"_mcm_lookup_lf": _mcm_lookup()})
+
+    result = join_cardmarket_ids(cards, ctx).collect()
+
+    assert result["mcmId"].to_list() == ["748753", "750355"]
+    assert result["mcmMetaId"].to_list() == ["7595", None]
+
+
+def test_cardmarket_lookup_fills_missing_scryfall_id():
+    cards = pl.LazyFrame(
+        {
+            "name": ["Fallback Card"],
+            "setCode": ["TST"],
+            "number": ["1"],
+            "cardmarketId": [None],
+        },
+        schema={
+            "name": pl.String,
+            "setCode": pl.String,
+            "number": pl.String,
+            "cardmarketId": pl.Int64,
+        },
+    )
+    ctx = PipelineContext(_test_data={"_mcm_lookup_lf": _mcm_lookup()})
+
+    result = join_cardmarket_ids(cards, ctx).collect()
+
+    assert result["mcmId"].to_list() == ["123456"]
+    assert result["mcmMetaId"].to_list() == ["654321"]


### PR DESCRIPTION
Hey,
I noticed that some Ravnica Remastered Cardmarket foil prices were incorrect, while Scryfall had the correct prices. The issue appeared around January 30–31, 2026, and seems to have been introduced by the [v5.3.0 rewrite](https://github.com/mtgjson/mtgjson/commit/4547b6bc0eb402da2af492e8adbf8c7bda244ca8).

For example, Hallowed Fountain RVR#404 was receiving the foil price of the serialized #404z version.

Scryfall provides exact Cardmarket product IDs for both versions:
RVR#404: 748753
RVR#404z: 750355

MTGJSON’s Cardmarket lookup matches cards by set, normalized name, and collector number. Cardmarket gives some regular and serialized variants the same collector number, making this lookup ambiguous. The lookup result was preferred over Scryfall’s exact ID, causing both versions to use product 750355. This affected 38 non-serialized RVR cards with serialized counterparts.

This change makes MTGJSON prefer Scryfall’s exact Cardmarket product ID when available. The existing Cardmarket lookup remains as a fallback for cards without a Scryfall Cardmarket ID.