### PR TITLE
fix: map Scryfall "dw" language code to "Dwarvish"

### DIFF
--- a/mtgjson5/constants.py
+++ b/mtgjson5/constants.py
@@ -51,6 +51,7 @@ LANGUAGE_MAP: dict[str, str] = {
     "ar": "Arabic",
     "zhs": "Chinese Simplified",
     "zht": "Chinese Traditional",
+    "dw": "Dwarvish",
     "en": "English",
     "fr": "French",
     "de": "German",

--- a/mtgjson5/consts/languages.py
+++ b/mtgjson5/consts/languages.py
@@ -13,6 +13,7 @@ LANGUAGE_MAP: Final[dict[str, str]] = {
     "ar": "Arabic",
     "zhs": "Chinese Simplified",
     "zht": "Chinese Traditional",
+    "dw": "Dwarvish",
     "en": "English",
     "fr": "French",
     "de": "German",

--- a/tests/mtgjson5/test_consts_extended.py
+++ b/tests/mtgjson5/test_consts_extended.py
@@ -122,6 +122,10 @@ class TestLanguageMap:
         assert LANGUAGE_MAP["ph"] == "Phyrexian"
         assert LANGUAGE_MAP["px"] == "Phyrexian"
 
+    def test_tolkien_languages(self):
+        assert LANGUAGE_MAP["qya"] == "Quenya"
+        assert LANGUAGE_MAP["dw"] == "Dwarvish"
+
     @pytest.mark.parametrize(
         ("code", "name"),
         [("ja", "Japanese"), ("fr", "French"), ("de", "German"), ("es", "Spanish")],


### PR DESCRIPTION
Fixes #1688

### Problem

Scryfall returns `"lang": "dw"` for the 5 Dwarvish-language cards in `HOC` — Dwarven Warriors (93), The Reaver Cleaver (94), Arcane Signet (95), Mox Amber (96), Treasure Vault (97). `LANGUAGE_MAP` had no entry for that code, and every consumer maps with `replace_strict(LANGUAGE_MAP, default=pl.col("lang"))` (e.g. `pipeline/stages/basic_fields.py`, `pipeline/stages/identifiers.py`, `data/context.py`), so the raw code fell through and those cards were emitted as `"language": "dw"` while every other language uses its full name.

Confirmed against the live API — Scryfall's [language docs](https://scryfall.com/docs/api/languages) list `dw` → **Dwarvish**, with a count of exactly 5 cards.

### Fix

Add `"dw": "Dwarvish"` to `LANGUAGE_MAP`. It lives in two places that are kept identical — `mtgjson5/consts/languages.py` (the copy actually imported) and `mtgjson5/constants.py` — so both are updated. `build/assemble.py` derives the `language` enum from `sorted(LANGUAGE_MAP.values())`, so the EnumValues output picks it up automatically.

Note: the `mtgjson5/constants.py` copy appears to have no remaining importers; deduplicating it would prevent this class of drift, but that felt out of scope for a bugfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAQL2oZAj3bnaQ4Ccj9Hzk