### PR TITLE
fix: restore documented Asian-language printings on pre-2004 sets

### DIFF
--- a/mtgjson5/build/assemble.py
+++ b/mtgjson5/build/assemble.py
@@ -23,6 +23,8 @@ from mtgjson5.models.schemas import (
 )
 from mtgjson5.models.sets import SealedProduct
 
+from .languages import merge_set_languages
+
 if TYPE_CHECKING:
     from .context import AssemblyContext
 
@@ -133,14 +135,10 @@ class Assembler:
         """Get metadata for a specific set."""
         return self.ctx.set_meta.get(code, {})
 
-    def build_languages(self, cards: list[dict[str, Any]]) -> list[str]:
-        """Build sorted language list from card foreignData."""
-        languages = {"English"}
-        for card in cards:
-            for fd in card.get("foreignData", []):
-                if fd.get("language"):
-                    languages.add(fd["language"])
-        return sorted(languages)
+    def build_languages(self, cards: list[dict[str, Any]], set_code: str | None = None) -> list[str]:
+        """Build sorted language list from card foreignData and documented printings."""
+        languages = {fd["language"] for card in cards for fd in card.get("foreignData", []) if fd.get("language")}
+        return merge_set_languages(set_code, languages)
 
     def build_minimal_decks(self, set_code: str) -> list[dict[str, Any]] | None:
         """Build minimal deck references for a set, or None if no decks."""
@@ -764,7 +762,7 @@ class SetAssembler(Assembler):
                 set_data[fld] = val
 
         # Languages from foreign data
-        set_data["languages"] = self.build_languages(cards)
+        set_data["languages"] = self.build_languages(cards, set_code)
 
         # Booster config
         if include_booster and set_code in self.ctx.booster_configs:
@@ -843,6 +841,7 @@ class SetListAssembler(Assembler):
         }
 
         # Languages from foreign data
+        fd_langs: list[str] = []
         if not df.is_empty() and "foreignData" in df.columns:
             fd_langs = (
                 df.select("foreignData")
@@ -854,9 +853,7 @@ class SetListAssembler(Assembler):
                 .to_series()
                 .to_list()
             )
-            entry["languages"] = sorted({"English", *fd_langs})
-        else:
-            entry["languages"] = ["English"]
+        entry["languages"] = merge_set_languages(set_code, fd_langs)
 
         # Decks (minimal format)
         decks = self.build_minimal_decks(set_code)

--- a/mtgjson5/build/context.py
+++ b/mtgjson5/build/context.py
@@ -17,6 +17,8 @@ from mtgjson5.models.containers import MtgjsonMeta
 from mtgjson5.mtgjson_config import MtgjsonConfig
 from mtgjson5.utils import LOGGER
 
+from .languages import merge_set_languages
+
 if TYPE_CHECKING:
     from mtgjson5.data import PipelineContext
 
@@ -262,6 +264,14 @@ def _build_languages_by_set(cards_df: pl.DataFrame | None) -> dict[str, list[str
     return result
 
 
+def _enrich_sets_with_languages(records: list[dict[str, Any]], cards_df: pl.DataFrame | None) -> None:
+    """Attach the language list to each set record, in place."""
+    languages_map = _build_languages_by_set(cards_df)
+    for rec in records:
+        code = rec.get("code", "")
+        rec["languages"] = merge_set_languages(code, languages_map.get(code, ["English"]))
+
+
 def _load_scryfall_catalogs(
     ctx: PipelineContext,
 ) -> tuple[dict[str, list[str]], dict[str, list[str]], list[str], list[str]]:
@@ -382,9 +392,7 @@ class AssemblyContext:
         # Enrich with sealed products, decks, and languages
         _enrich_sets_with_sealed(records, self.sealed_df)
         _enrich_sets_with_decks(records, self.decks_df)
-        languages_map = _build_languages_by_set(self.all_cards_df)
-        for rec in records:
-            rec["languages"] = languages_map.get(rec.get("code", ""), ["English"])
+        _enrich_sets_with_languages(records, self.all_cards_df)
         df = pl.DataFrame(records, schema_overrides=schema_overrides)
         if "type" in df.columns:
             is_traditional_token = (pl.col("type") == "token") & pl.col("code").str.starts_with("T")

--- a/mtgjson5/build/languages.py
+++ b/mtgjson5/build/languages.py
@@ -1,0 +1,40 @@
+"""Set language list construction.
+
+A set's ``languages`` list is derived from the languages present in its cards'
+``foreignData``. That data only covers printings our upstream providers track,
+so pre-2004 Asian-language printings (and Italian 7th Edition) are absent even
+though Wizards of the Coast documented them on the Card Set Archive product
+information pages. ``set_language_additions.json`` records those printings so
+the per-set list matches the official one.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from functools import lru_cache
+
+from mtgjson5 import constants
+from mtgjson5.utils import LOGGER
+
+RESOURCE_NAME = "set_language_additions.json"
+
+
+@lru_cache(maxsize=1)
+def get_set_language_additions() -> dict[str, tuple[str, ...]]:
+    """Load the set code -> extra language names mapping, keyed by upper-case set code."""
+    file_path = constants.RESOURCE_PATH / RESOURCE_NAME
+    if not file_path.exists():
+        LOGGER.warning(f"Resource file not found: {file_path}")
+        return {}
+    with file_path.open("rb") as f:
+        raw = json.loads(f.read())
+    return {code.upper(): tuple(langs) for code, langs in raw.items()}
+
+
+def merge_set_languages(set_code: str | None, languages: Iterable[str]) -> list[str]:
+    """Combine languages found in card data with documented printings for the set."""
+    result = {"English", *languages}
+    if set_code:
+        result.update(get_set_language_additions().get(set_code.upper(), ()))
+    return sorted(result)

--- a/mtgjson5/resources/set_language_additions.json
+++ b/mtgjson5/resources/set_language_additions.json
@@ -1,0 +1,23 @@
+{
+    "4ED": ["Chinese Traditional", "Korean"],
+    "VIS": ["Chinese Traditional", "Korean"],
+    "WTH": ["Chinese Traditional", "Korean"],
+    "5ED": ["Chinese Traditional"],
+    "USG": ["Chinese Simplified", "Chinese Traditional", "Korean"],
+    "ULG": ["Chinese Traditional"],
+    "PTK": ["Chinese Traditional"],
+    "UDS": ["Chinese Traditional"],
+    "6ED": ["Chinese Simplified", "Chinese Traditional", "Korean"],
+    "MMQ": ["Chinese Traditional"],
+    "NEM": ["Chinese Traditional"],
+    "PLS": ["Chinese Simplified", "Chinese Traditional"],
+    "7ED": ["Chinese Simplified", "Chinese Traditional", "Italian"],
+    "ODY": ["Chinese Simplified", "Chinese Traditional"],
+    "TOR": ["Chinese Simplified", "Chinese Traditional"],
+    "JUD": ["Chinese Simplified", "Chinese Traditional"],
+    "LGN": ["Chinese Simplified", "Chinese Traditional"],
+    "SCG": ["Chinese Simplified", "Chinese Traditional"],
+    "MRD": ["Chinese Simplified", "Chinese Traditional"],
+    "8ED": ["Chinese Simplified", "Chinese Traditional"],
+    "10E": ["Chinese Traditional"]
+}

--- a/tests/mtgjson5/test_assembly.py
+++ b/tests/mtgjson5/test_assembly.py
@@ -120,6 +120,18 @@ class TestBuildLanguages:
         assert result == expected_langs
         assert result == sorted(result)
 
+    def test_documented_printings_are_added(self):
+        """Sets with documented printings missing from foreignData get them back."""
+        assembler = _make_assembler()
+        cards = [{"name": "Ravenous Rats", "foreignData": [{"language": "Japanese"}]}]
+        result = assembler.build_languages(cards, "PTK")
+        assert result == ["Chinese Traditional", "English", "Japanese"]
+
+    def test_documented_printings_ignored_for_other_sets(self):
+        assembler = _make_assembler()
+        cards = [{"name": "A", "foreignData": [{"language": "Japanese"}]}]
+        assert assembler.build_languages(cards, "NEO") == ["English", "Japanese"]
+
     def test_unicode_language_names(self):
         """Verify sort handles accented characters correctly."""
         assembler = _make_assembler()

--- a/tests/mtgjson5/test_assembly_context.py
+++ b/tests/mtgjson5/test_assembly_context.py
@@ -7,6 +7,7 @@ import polars as pl
 from mtgjson5.build.context import (
     _build_languages_by_set,
     _enrich_sets_with_decks,
+    _enrich_sets_with_languages,
     _enrich_sets_with_sealed,
 )
 
@@ -145,3 +146,35 @@ class TestBuildLanguagesBySet:
         )
         result = _build_languages_by_set(cards_df)
         assert "ZZZ" not in result
+
+
+class TestEnrichSetsWithLanguages:
+    def _make_cards_df(self, set_code: str, languages: list[str]) -> pl.DataFrame:
+        return pl.DataFrame(
+            [
+                {
+                    "setCode": set_code,
+                    "foreignData": [{"language": lang, "name": lang} for lang in languages],
+                }
+            ],
+            schema={
+                "setCode": pl.String,
+                "foreignData": pl.List(pl.Struct({"language": pl.String, "name": pl.String})),
+            },
+        )
+
+    def test_languages_attached_from_card_data(self):
+        records = [{"code": "M10", "name": "Magic 2010"}]
+        _enrich_sets_with_languages(records, self._make_cards_df("M10", ["French"]))
+        assert records[0]["languages"] == ["English", "French"]
+
+    def test_documented_printings_added(self):
+        """Portal Three Kingdoms keeps its Traditional Chinese printing (issue #1691)."""
+        records = [{"code": "PTK", "name": "Portal Three Kingdoms"}]
+        _enrich_sets_with_languages(records, self._make_cards_df("PTK", ["Japanese"]))
+        assert records[0]["languages"] == ["Chinese Traditional", "English", "Japanese"]
+
+    def test_sets_without_cards_get_english(self):
+        records = [{"code": "ZZZ", "name": "No Cards"}]
+        _enrich_sets_with_languages(records, self._make_cards_df("M10", ["French"]))
+        assert records[0]["languages"] == ["English"]

--- a/tests/mtgjson5/test_set_languages.py
+++ b/tests/mtgjson5/test_set_languages.py
@@ -1,0 +1,60 @@
+"""Tests for documented set language additions."""
+
+from __future__ import annotations
+
+import pytest
+
+from mtgjson5.build.languages import get_set_language_additions, merge_set_languages
+from mtgjson5.consts.languages import LANGUAGE_MAP
+
+
+class TestSetLanguageAdditions:
+    def test_resource_loads(self):
+        assert get_set_language_additions()
+
+    def test_set_codes_are_upper_case(self):
+        for code in get_set_language_additions():
+            assert code == code.upper()
+
+    def test_languages_are_known_names(self):
+        known = set(LANGUAGE_MAP.values())
+        for code, langs in get_set_language_additions().items():
+            unknown = set(langs) - known
+            assert not unknown, f"{code} lists unknown language(s): {sorted(unknown)}"
+
+    def test_languages_are_sorted_and_unique(self):
+        for code, langs in get_set_language_additions().items():
+            assert list(langs) == sorted(set(langs)), f"{code} additions are unsorted or duplicated"
+
+    def test_english_is_never_an_addition(self):
+        for code, langs in get_set_language_additions().items():
+            assert "English" not in langs, f"{code} lists English, which is always implied"
+
+    @pytest.mark.parametrize(
+        ("set_code", "expected"),
+        [
+            # Portal Three Kingdoms was printed in Traditional Chinese
+            ("PTK", "Chinese Traditional"),
+            # Seventh Edition had an Italian printing
+            ("7ED", "Italian"),
+            # Fourth Edition had a Korean printing
+            ("4ED", "Korean"),
+        ],
+    )
+    def test_known_printings_present(self, set_code, expected):
+        assert expected in get_set_language_additions()[set_code]
+
+
+class TestMergeSetLanguages:
+    def test_english_always_present(self):
+        assert merge_set_languages("NEO", []) == ["English"]
+
+    def test_missing_set_code(self):
+        assert merge_set_languages(None, ["French"]) == ["English", "French"]
+
+    def test_result_is_sorted_and_deduped(self):
+        result = merge_set_languages("PTK", ["Japanese", "Japanese", "Chinese Traditional"])
+        assert result == ["Chinese Traditional", "English", "Japanese"]
+
+    def test_set_code_is_case_insensitive(self):
+        assert merge_set_languages("ptk", []) == merge_set_languages("PTK", [])


### PR DESCRIPTION
Fixes #1691.

### Problem

A set's `languages` list is derived purely from the languages present in its cards' `foreignData`. That data does not cover the Asian-language printings of many 1996–2007 sets, so 21 sets end up missing languages that Wizards of the Coast's own Card Set Archive product information pages list for them:

* **Chinese Traditional** — all 21 sets
* **Chinese Simplified** — 11 sets
* **Korean** — 5 sets
* **Italian** — 7ED

### Fix

Adds `mtgjson5/resources/set_language_additions.json`, a set code → extra language names map transcribed from the WotC Card Set Archive pages (linked per set in the issue), and merges it into the language list everywhere that list is built:

* `Set.json` / `AllPrintings.json` (`SetAssembler.build_languages`)
* `SetList.json` (`SetListAssembler.build_one`)
* the `sets` table behind the csv/parquet/sqlite/mysql exports (`AssemblyContext.sets_df`)

The merge lives in the new `mtgjson5/build/languages.py` so all three paths stay in agreement, and `AssemblyContext.sets_df`'s language enrichment is extracted into `_enrich_sets_with_languages` to match the neighbouring `_enrich_sets_with_sealed` / `_enrich_sets_with_decks` helpers.

Sets not listed in the resource are unaffected, and the additions only ever add to what the card data already provides.

### Sets touched

| Set | Added |
|---|---|
| 4ED, VIS, WTH | Chinese Traditional, Korean |
| USG, 6ED | Chinese Simplified, Chinese Traditional, Korean |
| 5ED, ULG, PTK, UDS, MMQ, NEM, 10E | Chinese Traditional |
| PLS, ODY, TOR, JUD, LGN, SCG, MRD, 8ED | Chinese Simplified, Chinese Traditional |
| 7ED | Chinese Simplified, Chinese Traditional, Italian |

### Tests

New `tests/mtgjson5/test_set_languages.py` validates the resource itself (known language names, sorted/deduped, English never listed) and the merge helper; `test_assembly.py` and `test_assembly_context.py` gain coverage for the two assembly paths. Full suite passes, as do `ruff check`, `ruff format` and `mypy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCMU4ZPSWgMtxVCaPQEk7G