### PR TITLE
fix missing TCGplayer prices for alternative products

### DIFF
--- a/mtgjson5/build/prices/price_builder.py
+++ b/mtgjson5/build/prices/price_builder.py
@@ -65,6 +65,7 @@ class PriceBuilderContext:
     Owns the ID -> UUID mappings needed by price providers:
     - tcg_to_uuid: TCGPlayer product ID -> MTGJSON UUIDs
     - tcg_etched_to_uuid: TCGPlayer etched product ID -> MTGJSON UUIDs
+    - tcg_alt_foil_to_uuid: Alternative TCGPlayer product ID -> MTGJSON UUID
     - mtgo_to_uuid: MTGO ID -> MTGJSON UUIDs
     - scryfall_to_uuid: Scryfall ID -> single MTGJSON UUID
 
@@ -76,6 +77,7 @@ class PriceBuilderContext:
     # Derived mappings (built lazily)
     _tcg_to_uuid: dict[str, set[str]] | None = field(default=None, repr=False)
     _tcg_etched_to_uuid: dict[str, set[str]] | None = field(default=None, repr=False)
+    _tcg_alt_foil_to_uuid: dict[str, set[str]] | None = field(default=None, repr=False)
     _mtgo_to_uuid: dict[str, set[str]] | None = field(default=None, repr=False)
     _scryfall_to_uuid: dict[str, str] | None = field(default=None, repr=False)
 
@@ -88,9 +90,20 @@ class PriceBuilderContext:
         """
         from mtgjson5.data import GLOBAL_CACHE
 
-        # Load ID mappings from cache if they haven't been set
-        # (happens when running price build separately from card build)
-        if GLOBAL_CACHE.tcg_to_uuid_lf is None and GLOBAL_CACHE.mtgo_to_uuid_lf is None:
+        # Load any persisted mapping that is not already present in memory.
+        # This happens when a price build runs separately from a card build.
+        persisted_mappings = {
+            "tcg_to_uuid_lf": "tcg_to_uuid.parquet",
+            "tcg_etched_to_uuid_lf": "tcg_etched_to_uuid.parquet",
+            "tcg_alt_foil_to_uuid_lf": "tcg_alt_foil_to_uuid.parquet",
+            "mtgo_to_uuid_lf": "mtgo_to_uuid.parquet",
+            "scryfall_to_uuid_lf": "scryfall_to_uuid.parquet",
+            "cardmarket_to_uuid_lf": "cardmarket_to_uuid.parquet",
+        }
+        if any(
+            getattr(GLOBAL_CACHE, attr) is None and (GLOBAL_CACHE.cache_path / filename).exists()
+            for attr, filename in persisted_mappings.items()
+        ):
             GLOBAL_CACHE.load_id_mappings()
 
         return cls(_cache=GLOBAL_CACHE)
@@ -108,6 +121,13 @@ class PriceBuilderContext:
         if self._tcg_etched_to_uuid is None:
             self._tcg_etched_to_uuid = self._build_tcg_etched_to_uuid()
         return self._tcg_etched_to_uuid
+
+    @property
+    def tcg_alt_foil_to_uuid(self) -> dict[str, set[str]]:
+        """Alternative TCGPlayer product ID -> MTGJSON UUID mapping."""
+        if self._tcg_alt_foil_to_uuid is None:
+            self._tcg_alt_foil_to_uuid = self._build_tcg_alt_foil_to_uuid()
+        return self._tcg_alt_foil_to_uuid
 
     @property
     def mtgo_to_uuid(self) -> dict[str, set[str]]:
@@ -157,6 +177,21 @@ class PriceBuilderContext:
                 result[tcg_id].add(uuid)
         return result
 
+    def _build_tcg_alt_foil_to_uuid(self) -> dict[str, set[str]]:
+        """Build alternative TCGPlayer product ID -> UUID mapping from cache."""
+        if self._cache is None or self._cache.tcg_alt_foil_to_uuid_lf is None:
+            return {}
+        df = self._cache.tcg_alt_foil_to_uuid_lf.collect()
+        if df.is_empty():
+            return {}
+        result: dict[str, set[str]] = {}
+        for row in df.iter_rows(named=True):
+            tcg_id = str(row.get("tcgplayerAlternativeFoilProductId", ""))
+            uuid = row.get("uuid")
+            if tcg_id and uuid:
+                result.setdefault(tcg_id, set()).add(uuid)
+        return result
+
     def _build_mtgo_to_uuid(self) -> dict[str, set[str]]:
         """Build MTGO ID -> UUID mapping from cache."""
         if self._cache is None or self._cache.mtgo_to_uuid_lf is None:
@@ -178,6 +213,7 @@ class PriceBuilderContext:
         """Free ID-mapping dicts (no longer needed after fetch)."""
         self._tcg_to_uuid = None
         self._tcg_etched_to_uuid = None
+        self._tcg_alt_foil_to_uuid = None
         self._mtgo_to_uuid = None
         self._scryfall_to_uuid = None
         self._cache = None
@@ -231,6 +267,7 @@ RAW_CACHE_FILES = {
 ID_MAPPING_FILES = {
     "tcg_to_uuid": "tcg_to_uuid.parquet",
     "tcg_etched_to_uuid": "tcg_etched_to_uuid.parquet",
+    "tcg_alt_foil_to_uuid": "tcg_alt_foil_to_uuid.parquet",
     "mtgo_to_uuid": "mtgo_to_uuid.parquet",
     "scryfall_to_uuid": "scryfall_to_uuid.parquet",
     "cardmarket_to_uuid": "cardmarket_to_uuid.parquet",
@@ -292,6 +329,7 @@ class PolarsPriceBuilder:
 
         tcg_to_uuid = ctx.tcg_to_uuid
         tcg_etched_to_uuid = ctx.tcg_etched_to_uuid
+        tcg_alt_foil_to_uuid = ctx.tcg_alt_foil_to_uuid
         mtgo_to_uuid = ctx.mtgo_to_uuid
         scryfall_to_uuid = ctx.scryfall_to_uuid
 
@@ -306,8 +344,12 @@ class PolarsPriceBuilder:
 
         # Fetch TCGPlayer prices (largest, async with streaming)
         LOGGER.info("Fetching TCGPlayer prices")
-        if tcg_to_uuid or tcg_etched_to_uuid:
-            tcg_df = await self._tcg_provider.fetch_all_prices(tcg_to_uuid or {}, tcg_etched_to_uuid or {})
+        if tcg_to_uuid or tcg_etched_to_uuid or tcg_alt_foil_to_uuid:
+            tcg_df = await self._tcg_provider.fetch_all_prices(
+                tcg_to_uuid or {},
+                tcg_etched_to_uuid or {},
+                tcg_alt_foil_to_uuid or {},
+            )
             if len(tcg_df) > 0:
                 frames.append(tcg_df)
                 LOGGER.info(f"  TCGPlayerPriceProvider: {len(tcg_df):,} price points")
@@ -391,8 +433,9 @@ class PolarsPriceBuilder:
         tcg_raw = cache_dir / RAW_CACHE_FILES["tcgplayer"]
         tcg_uuid = cache_dir / ID_MAPPING_FILES["tcg_to_uuid"]
         tcg_etched = cache_dir / ID_MAPPING_FILES["tcg_etched_to_uuid"]
-        if tcg_raw.exists() and (tcg_uuid.exists() or tcg_etched.exists()):
-            df = self._map_tcg_raw(tcg_raw, tcg_uuid, tcg_etched)
+        tcg_alt_foil = cache_dir / ID_MAPPING_FILES["tcg_alt_foil_to_uuid"]
+        if tcg_raw.exists() and (tcg_uuid.exists() or tcg_etched.exists() or tcg_alt_foil.exists()):
+            df = self._map_tcg_raw(tcg_raw, tcg_uuid, tcg_etched, tcg_alt_foil)
             if len(df) > 0:
                 frames.append(df)
                 LOGGER.info(f"  TCGPlayer mapped: {len(df):,} price points")
@@ -442,21 +485,88 @@ class PolarsPriceBuilder:
         LOGGER.info(f"Mapped {len(result):,} total price points from raw cache")
         return result
 
-    def _map_tcg_raw(self, raw_path: Path, uuid_path: Path, etched_uuid_path: Path) -> pl.DataFrame:
+    def _map_tcg_raw(
+        self,
+        raw_path: Path,
+        uuid_path: Path,
+        etched_uuid_path: Path,
+        alt_foil_uuid_path: Path | None = None,
+    ) -> pl.DataFrame:
         """Join TCGPlayer raw data with UUID mappings."""
-        raw = pl.scan_parquet(raw_path)
+        raw = pl.scan_parquet(raw_path).filter(pl.col("marketPrice").is_not_null())
         frames: list[pl.LazyFrame] = []
 
-        # Normal/foil via tcg_to_uuid
+        base_mapping: pl.LazyFrame | None = None
+        etched_mapping: pl.LazyFrame | None = None
+        alt_foil_mapping: pl.LazyFrame | None = None
+
         if uuid_path.exists():
-            tcg_uuid = pl.scan_parquet(uuid_path)
-            normal_foil = (
-                raw.join(tcg_uuid, left_on="productId", right_on="tcgplayerProductId", how="inner")
+            base_mapping = (
+                pl.scan_parquet(uuid_path)
+                .select(
+                    pl.col("tcgplayerProductId").cast(pl.String).alias("productId"),
+                    pl.col("uuid"),
+                )
+                .unique()
+            )
+
+        if etched_uuid_path.exists():
+            etched_mapping = (
+                pl.scan_parquet(etched_uuid_path)
+                .select(
+                    pl.col("tcgplayerEtchedProductId").cast(pl.String).alias("productId"),
+                    pl.col("uuid"),
+                )
+                .unique()
+            )
+
+        # Match live-provider precedence when a product occurs in more than
+        # one authoritative mapping: base products win over etched products.
+        if base_mapping is not None and etched_mapping is not None:
+            etched_mapping = etched_mapping.join(
+                base_mapping.select("productId").unique(),
+                on="productId",
+                how="anti",
+            )
+
+        if alt_foil_uuid_path is not None and alt_foil_uuid_path.exists():
+            alt_foil_mapping = (
+                pl.scan_parquet(alt_foil_uuid_path)
+                .select(
+                    pl.col("tcgplayerAlternativeFoilProductId").cast(pl.String).alias("productId"),
+                    pl.col("uuid"),
+                )
+                .unique()
+                .group_by("productId")
+                .agg(
+                    pl.col("uuid").first(),
+                    pl.col("uuid").n_unique().alias("_uuidCount"),
+                )
+                .filter(pl.col("_uuidCount") == 1)
+                .drop("_uuidCount")
+            )
+
+            reserved_ids: list[pl.LazyFrame] = []
+            if base_mapping is not None:
+                reserved_ids.append(base_mapping.select("productId"))
+            if etched_mapping is not None:
+                reserved_ids.append(etched_mapping.select("productId"))
+            if reserved_ids:
+                alt_foil_mapping = alt_foil_mapping.join(
+                    pl.concat(reserved_ids).unique(),
+                    on="productId",
+                    how="anti",
+                )
+
+        def _map_prices(mapping: pl.LazyFrame, non_normal_finish: str, priority: int) -> pl.LazyFrame:
+            return (
+                raw.join(mapping, on="productId", how="inner")
                 .with_columns(
                     pl.when(pl.col("subTypeName") == "Normal")
                     .then(pl.lit("normal"))
-                    .otherwise(pl.lit("foil"))
-                    .alias("finish")
+                    .otherwise(pl.lit(non_normal_finish))
+                    .alias("finish"),
+                    pl.lit(priority).alias("_mappingPriority"),
                 )
                 .select(
                     pl.col("uuid"),
@@ -467,38 +577,35 @@ class PolarsPriceBuilder:
                     pl.col("finish"),
                     pl.col("marketPrice").alias("price"),
                     pl.lit("USD").alias("currency"),
+                    pl.col("productId"),
+                    pl.col("_mappingPriority"),
                 )
             )
-            frames.append(normal_foil)
+
+        # Normal/foil via tcg_to_uuid
+        if base_mapping is not None:
+            frames.append(_map_prices(base_mapping, "foil", 0))
 
         # Etched via tcg_etched_to_uuid
-        if etched_uuid_path.exists():
-            tcg_etched = pl.scan_parquet(etched_uuid_path)
-            etched = (
-                raw.join(tcg_etched, left_on="productId", right_on="tcgplayerEtchedProductId", how="inner")
-                .with_columns(
-                    pl.when(pl.col("subTypeName") == "Normal")
-                    .then(pl.lit("normal"))
-                    .otherwise(pl.lit("etched"))
-                    .alias("finish")
-                )
-                .select(
-                    pl.col("uuid"),
-                    pl.lit(self.today_date).alias("date"),
-                    pl.lit("paper").alias("source"),
-                    pl.lit("tcgplayer").alias("provider"),
-                    pl.lit("retail").alias("price_type"),
-                    pl.col("finish"),
-                    pl.col("marketPrice").alias("price"),
-                    pl.lit("USD").alias("currency"),
-                )
-            )
-            frames.append(etched)
+        if etched_mapping is not None:
+            frames.append(_map_prices(etched_mapping, "etched", 1))
+
+        # Alternative products are ordinary TCGplayer products whose finish
+        # must be inferred from the price row, not the mapping field name.
+        if alt_foil_mapping is not None:
+            frames.append(_map_prices(alt_foil_mapping, "foil", 2))
 
         if not frames:
             return pl.DataFrame(schema=PRICE_SCHEMA)
 
-        return pl.concat(frames).collect()
+        key_cols = ["uuid", "date", "source", "provider", "price_type", "finish"]
+        return (
+            pl.concat(frames)
+            .sort(["_mappingPriority", "productId"])
+            .unique(subset=key_cols, keep="first", maintain_order=True)
+            .select(list(PRICE_SCHEMA))
+            .collect()
+        )
 
     def _map_cardhoarder_raw(self, raw_path: Path, uuid_path: Path) -> pl.DataFrame:
         """Join CardHoarder raw data with UUID mappings."""

--- a/mtgjson5/build/prices/price_builder.py
+++ b/mtgjson5/build/prices/price_builder.py
@@ -179,18 +179,9 @@ class PriceBuilderContext:
 
     def _build_tcg_alt_foil_to_uuid(self) -> dict[str, set[str]]:
         """Build alternative TCGPlayer product ID -> UUID mapping from cache."""
-        if self._cache is None or self._cache.tcg_alt_foil_to_uuid_lf is None:
+        if self._cache is None:
             return {}
-        df = self._cache.tcg_alt_foil_to_uuid_lf.collect()
-        if df.is_empty():
-            return {}
-        result: dict[str, set[str]] = {}
-        for row in df.iter_rows(named=True):
-            tcg_id = str(row.get("tcgplayerAlternativeFoilProductId", ""))
-            uuid = row.get("uuid")
-            if tcg_id and uuid:
-                result.setdefault(tcg_id, set()).add(uuid)
-        return result
+        return self._cache.get_tcg_alt_foil_to_uuid_map()
 
     def _build_mtgo_to_uuid(self) -> dict[str, set[str]]:
         """Build MTGO ID -> UUID mapping from cache."""
@@ -490,7 +481,7 @@ class PolarsPriceBuilder:
         raw_path: Path,
         uuid_path: Path,
         etched_uuid_path: Path,
-        alt_foil_uuid_path: Path | None = None,
+        alt_foil_uuid_path: Path,
     ) -> pl.DataFrame:
         """Join TCGPlayer raw data with UUID mappings."""
         raw = pl.scan_parquet(raw_path).filter(pl.col("marketPrice").is_not_null())
@@ -529,14 +520,13 @@ class PolarsPriceBuilder:
                 how="anti",
             )
 
-        if alt_foil_uuid_path is not None and alt_foil_uuid_path.exists():
+        if alt_foil_uuid_path.exists():
             alt_foil_mapping = (
                 pl.scan_parquet(alt_foil_uuid_path)
                 .select(
                     pl.col("tcgplayerAlternativeFoilProductId").cast(pl.String).alias("productId"),
                     pl.col("uuid"),
                 )
-                .unique()
                 .group_by("productId")
                 .agg(
                     pl.col("uuid").first(),

--- a/mtgjson5/build/prices/price_builder.py
+++ b/mtgjson5/build/prices/price_builder.py
@@ -520,12 +520,12 @@ class PolarsPriceBuilder:
                 .unique()
             )
 
-        # Match live-provider precedence when a product occurs in more than
-        # one authoritative mapping: base products win over etched products.
+        # Match live-provider precedence when the same product and card occur
+        # in both authoritative mappings: base products win over etched products.
         if base_mapping is not None and etched_mapping is not None:
             etched_mapping = etched_mapping.join(
-                base_mapping.select("productId").unique(),
-                on="productId",
+                base_mapping.select("productId", "uuid").unique(),
+                on=["productId", "uuid"],
                 how="anti",
             )
 

--- a/mtgjson5/build/prices/price_builder.py
+++ b/mtgjson5/build/prices/price_builder.py
@@ -577,7 +577,7 @@ class PolarsPriceBuilder:
                     pl.col("finish"),
                     pl.col("marketPrice").alias("price"),
                     pl.lit("USD").alias("currency"),
-                    pl.col("productId"),
+                    pl.col("productId").cast(pl.Int64),
                     pl.col("_mappingPriority"),
                 )
             )

--- a/mtgjson5/data/cache.py
+++ b/mtgjson5/data/cache.py
@@ -467,6 +467,7 @@ class GlobalCache:
             "tcg_sku_map_lf": "tcg_sku_map.parquet",
             "tcg_to_uuid_lf": "tcg_to_uuid.parquet",
             "tcg_etched_to_uuid_lf": "tcg_etched_to_uuid.parquet",
+            "tcg_alt_foil_to_uuid_lf": "tcg_alt_foil_to_uuid.parquet",
             "mtgo_to_uuid_lf": "mtgo_to_uuid.parquet",
             "scryfall_to_uuid_lf": "scryfall_to_uuid.parquet",
             "cardmarket_to_uuid_lf": "cardmarket_to_uuid.parquet",
@@ -1523,6 +1524,13 @@ class GlobalCache:
     def get_tcg_etched_to_uuid_map(self) -> dict[str, set[str]]:
         """Get mapping from TCGPlayer etched product ID to MTGJSON UUID(s)."""
         return self._get_id_to_uuid_map(self.tcg_etched_to_uuid_lf, "tcgplayerEtchedProductId")
+
+    def get_tcg_alt_foil_to_uuid_map(self) -> dict[str, set[str]]:
+        """Get mapping from alternative TCGPlayer product ID to MTGJSON UUID(s)."""
+        return self._get_id_to_uuid_map(
+            self.tcg_alt_foil_to_uuid_lf,
+            "tcgplayerAlternativeFoilProductId",
+        )
 
     def get_mtgo_to_uuid_map(self) -> dict[str, set[str]]:
         """Get mapping from MTGO ID to MTGJSON UUID(s)."""

--- a/mtgjson5/providers/tcgplayer/prices.py
+++ b/mtgjson5/providers/tcgplayer/prices.py
@@ -78,6 +78,7 @@ class TCGPlayerPriceProvider:
         self,
         tcg_to_uuid_map: dict[str, set[str]],
         tcg_etched_to_uuid_map: dict[str, set[str]],
+        tcg_alt_foil_to_uuid_map: dict[str, set[str]] | None = None,
     ) -> pl.DataFrame:
         """
         Fetch retail prices for all TCGPlayer Magic sets.
@@ -85,6 +86,7 @@ class TCGPlayerPriceProvider:
         Args:
             tcg_to_uuid_map: TCGPlayer productId -> MTGJSON UUIDs mapping
             tcg_etched_to_uuid_map: TCGPlayer etched productId -> MTGJSON UUIDs
+            tcg_alt_foil_to_uuid_map: Alternative TCGPlayer productId -> MTGJSON UUID
 
         Returns:
             DataFrame with flat price records
@@ -114,7 +116,13 @@ class TCGPlayerPriceProvider:
                     continue
 
                 # Fetch retail prices for this group
-                prices = await self._fetch_group_prices(client, group_id, tcg_to_uuid_map, tcg_etched_to_uuid_map)
+                prices = await self._fetch_group_prices(
+                    client,
+                    group_id,
+                    tcg_to_uuid_map,
+                    tcg_etched_to_uuid_map,
+                    tcg_alt_foil_to_uuid_map or {},
+                )
                 self._buffer.extend(prices)
                 self._completed_groups.add(group_id)
 
@@ -219,9 +227,10 @@ class TCGPlayerPriceProvider:
         self,
         tcg_to_uuid_map: dict[str, set[str]],
         tcg_etched_to_uuid_map: dict[str, set[str]],
+        tcg_alt_foil_to_uuid_map: dict[str, set[str]] | None = None,
     ) -> pl.DataFrame:
         """Sync wrapper for fetch_all_prices."""
-        return asyncio.run(self.fetch_all_prices(tcg_to_uuid_map, tcg_etched_to_uuid_map))
+        return asyncio.run(self.fetch_all_prices(tcg_to_uuid_map, tcg_etched_to_uuid_map, tcg_alt_foil_to_uuid_map))
 
     async def _get_magic_set_ids(self, client: TcgPlayerClient) -> list[tuple[int, str]]:
         """
@@ -263,13 +272,14 @@ class TCGPlayerPriceProvider:
         group_id: int,
         tcg_to_uuid_map: dict[str, set[str]],
         tcg_etched_to_uuid_map: dict[str, set[str]],
+        tcg_alt_foil_to_uuid_map: dict[str, set[str]] | None = None,
     ) -> list[dict[str, Any]]:
         """
         Fetch RETAIL prices for a single set.
 
         Note: Buylist endpoint (/pricing/buy/group/) is deprecated and not called.
         """
-        records: list[dict[str, Any]] = []
+        candidates: dict[tuple[str, str], tuple[tuple[int, str], dict[str, Any]]] = {}
 
         try:
             endpoint = f"pricing/group/{group_id}"
@@ -287,12 +297,21 @@ class TCGPlayerPriceProvider:
                 if market_price is None:
                     continue
 
-                # Determine which mapping to use
+                # Base and etched mappings are authoritative. Alternative IDs
+                # are used only when the product is otherwise unknown and the
+                # alternative association resolves to exactly one UUID.
                 is_etched = False
+                mapping_priority = 0
                 uuids = tcg_to_uuid_map.get(product_id)
                 if not uuids:
                     uuids = tcg_etched_to_uuid_map.get(product_id)
                     is_etched = bool(uuids)
+                    mapping_priority = 1
+                if not uuids and tcg_alt_foil_to_uuid_map:
+                    alt_uuids = tcg_alt_foil_to_uuid_map.get(product_id)
+                    if alt_uuids and len(alt_uuids) == 1:
+                        uuids = alt_uuids
+                        mapping_priority = 2
                 if not uuids:
                     continue
 
@@ -305,9 +324,17 @@ class TCGPlayerPriceProvider:
                 else:
                     finish = "foil"
 
-                # Create price record for each UUID
+                # Create one price record per unique output key. A primary
+                # mapping wins when an alternative product exposes the same
+                # finish for the same UUID.
                 for uuid in uuids:
-                    records.append(
+                    key = (uuid, finish)
+                    rank = (mapping_priority, product_id)
+                    existing = candidates.get(key)
+                    if existing is not None and existing[0] <= rank:
+                        continue
+                    candidates[key] = (
+                        rank,
                         {
                             "uuid": uuid,
                             "date": self.today_date,
@@ -317,13 +344,13 @@ class TCGPlayerPriceProvider:
                             "finish": finish,
                             "price": float(market_price),
                             "currency": "USD",
-                        }
+                        },
                     )
 
         except Exception as e:
             LOGGER.debug(f"Failed to fetch prices for group {group_id}: {e}")
 
-        return records
+        return [candidate[1] for _, candidate in sorted(candidates.items())]
 
     def _load_checkpoint(self) -> None:
         """Load checkpoint data if exists."""
@@ -361,7 +388,11 @@ class TCGPlayerPriceProvider:
         if not self._buffer:
             return pl.DataFrame(schema=PRICE_SCHEMA)
 
-        df = pl.DataFrame(self._buffer, schema=PRICE_SCHEMA)
+        df = pl.DataFrame(self._buffer, schema=PRICE_SCHEMA).unique(
+            subset=["uuid", "date", "source", "provider", "price_type", "finish"],
+            keep="first",
+            maintain_order=True,
+        )
 
         if self.output_path:
             self.output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -374,13 +405,14 @@ class TCGPlayerPriceProvider:
         self,
         tcg_to_uuid_map: dict[str, set[str]],
         tcg_etched_to_uuid_map: dict[str, set[str]],
+        tcg_alt_foil_to_uuid_map: dict[str, set[str]] | None = None,
     ) -> dict[str, MtgjsonPriceEntry]:
         """
         Generate MTGJSON-format price dict for compatibility with legacy code.
 
         Returns dict mapping UUID -> MtgjsonPriceEntry.
         """
-        df = await self.fetch_all_prices(tcg_to_uuid_map, tcg_etched_to_uuid_map)
+        df = await self.fetch_all_prices(tcg_to_uuid_map, tcg_etched_to_uuid_map, tcg_alt_foil_to_uuid_map)
         return self._dataframe_to_price_dict(df)
 
     def _dataframe_to_price_dict(self, df: pl.DataFrame) -> dict[str, MtgjsonPriceEntry]:
@@ -414,6 +446,7 @@ async def get_tcgplayer_prices(
     tcg_to_uuid_map: dict[str, set[str]],
     tcg_etched_to_uuid_map: dict[str, set[str]],
     on_progress: ProgressCallback | None = None,
+    tcg_alt_foil_to_uuid_map: dict[str, set[str]] | None = None,
 ) -> pl.DataFrame:
     """
     Fetch TCGPlayer prices as DataFrame.
@@ -422,18 +455,22 @@ async def get_tcgplayer_prices(
         tcg_to_uuid_map: TCGPlayer productId -> UUID mapping
         tcg_etched_to_uuid_map: TCGPlayer etched productId -> UUID mapping
         on_progress: Optional callback for progress updates
+        tcg_alt_foil_to_uuid_map: Alternative TCGPlayer productId -> UUID mapping
 
     Returns:
         DataFrame with flat price records
     """
     provider = TCGPlayerPriceProvider(on_progress=on_progress)
-    return await provider.fetch_all_prices(tcg_to_uuid_map, tcg_etched_to_uuid_map)
+    return await provider.fetch_all_prices(tcg_to_uuid_map, tcg_etched_to_uuid_map, tcg_alt_foil_to_uuid_map)
 
 
 def get_tcgplayer_prices_sync(
     tcg_to_uuid_map: dict[str, set[str]],
     tcg_etched_to_uuid_map: dict[str, set[str]],
     on_progress: ProgressCallback | None = None,
+    tcg_alt_foil_to_uuid_map: dict[str, set[str]] | None = None,
 ) -> pl.DataFrame:
     """Sync wrapper for get_tcgplayer_prices."""
-    return asyncio.run(get_tcgplayer_prices(tcg_to_uuid_map, tcg_etched_to_uuid_map, on_progress))
+    return asyncio.run(
+        get_tcgplayer_prices(tcg_to_uuid_map, tcg_etched_to_uuid_map, on_progress, tcg_alt_foil_to_uuid_map)
+    )

--- a/mtgjson5/providers/tcgplayer/prices.py
+++ b/mtgjson5/providers/tcgplayer/prices.py
@@ -60,7 +60,7 @@ class TCGPlayerPriceProvider:
 
     Usage:
         provider = TCGPlayerPriceProvider()
-        prices_df = await provider.fetch_all_prices(tcg_to_uuid_map, tcg_etched_map)
+        prices_df = await provider.fetch_all_prices(tcg_to_uuid_map, tcg_etched_map, tcg_alt_foil_map)
     """
 
     output_path: Path | None = None
@@ -84,7 +84,7 @@ class TCGPlayerPriceProvider:
         self,
         tcg_to_uuid_map: dict[str, set[str]],
         tcg_etched_to_uuid_map: dict[str, set[str]],
-        tcg_alt_foil_to_uuid_map: dict[str, set[str]] | None = None,
+        tcg_alt_foil_to_uuid_map: dict[str, set[str]],
     ) -> pl.DataFrame:
         """
         Fetch retail prices for all TCGPlayer Magic sets.
@@ -92,7 +92,7 @@ class TCGPlayerPriceProvider:
         Args:
             tcg_to_uuid_map: TCGPlayer productId -> MTGJSON UUIDs mapping
             tcg_etched_to_uuid_map: TCGPlayer etched productId -> MTGJSON UUIDs
-            tcg_alt_foil_to_uuid_map: Alternative TCGPlayer productId -> MTGJSON UUID
+            tcg_alt_foil_to_uuid_map: Alternative TCGPlayer productId -> MTGJSON UUIDs
 
         Returns:
             DataFrame with flat price records
@@ -127,7 +127,7 @@ class TCGPlayerPriceProvider:
                     group_id,
                     tcg_to_uuid_map,
                     tcg_etched_to_uuid_map,
-                    tcg_alt_foil_to_uuid_map or {},
+                    tcg_alt_foil_to_uuid_map,
                 )
                 self._buffer.extend(prices)
                 self._completed_groups.add(group_id)
@@ -233,7 +233,7 @@ class TCGPlayerPriceProvider:
         self,
         tcg_to_uuid_map: dict[str, set[str]],
         tcg_etched_to_uuid_map: dict[str, set[str]],
-        tcg_alt_foil_to_uuid_map: dict[str, set[str]] | None = None,
+        tcg_alt_foil_to_uuid_map: dict[str, set[str]],
     ) -> pl.DataFrame:
         """Sync wrapper for fetch_all_prices."""
         return asyncio.run(self.fetch_all_prices(tcg_to_uuid_map, tcg_etched_to_uuid_map, tcg_alt_foil_to_uuid_map))
@@ -278,7 +278,7 @@ class TCGPlayerPriceProvider:
         group_id: int,
         tcg_to_uuid_map: dict[str, set[str]],
         tcg_etched_to_uuid_map: dict[str, set[str]],
-        tcg_alt_foil_to_uuid_map: dict[str, set[str]] | None = None,
+        tcg_alt_foil_to_uuid_map: dict[str, set[str]],
     ) -> list[dict[str, Any]]:
         """
         Fetch RETAIL prices for a single set.
@@ -307,18 +307,18 @@ class TCGPlayerPriceProvider:
                 # the same product and card occur in both, the base mapping wins.
                 base_uuids = tcg_to_uuid_map.get(product_id) or set()
                 etched_uuids = (tcg_etched_to_uuid_map.get(product_id) or set()) - base_uuids
-                mapping_candidates: list[tuple[set[str], bool, int]] = []
+                mapping_candidates: list[tuple[set[str], int]] = []
                 if base_uuids:
-                    mapping_candidates.append((base_uuids, False, 0))
+                    mapping_candidates.append((base_uuids, 0))
                 if etched_uuids:
-                    mapping_candidates.append((etched_uuids, True, 1))
+                    mapping_candidates.append((etched_uuids, 1))
 
                 # Alternative IDs are used only when the product is otherwise
                 # unknown and the association resolves to exactly one UUID.
                 if not mapping_candidates and tcg_alt_foil_to_uuid_map:
                     alt_uuids = tcg_alt_foil_to_uuid_map.get(product_id)
                     if alt_uuids and len(alt_uuids) == 1:
-                        mapping_candidates.append((alt_uuids, False, 2))
+                        mapping_candidates.append((alt_uuids, 2))
                 if not mapping_candidates:
                     continue
                 numeric_product_id = int(product_id)
@@ -326,10 +326,10 @@ class TCGPlayerPriceProvider:
                 # Create one price record per unique output key. A primary
                 # mapping wins when an alternative product exposes the same
                 # finish for the same UUID.
-                for uuids, is_etched, mapping_priority in mapping_candidates:
+                for uuids, mapping_priority in mapping_candidates:
                     if sub_type == "Normal":
                         finish = "normal"
-                    elif is_etched:
+                    elif mapping_priority == 1:
                         finish = "etched"
                     else:
                         finish = "foil"
@@ -419,7 +419,7 @@ class TCGPlayerPriceProvider:
         self,
         tcg_to_uuid_map: dict[str, set[str]],
         tcg_etched_to_uuid_map: dict[str, set[str]],
-        tcg_alt_foil_to_uuid_map: dict[str, set[str]] | None = None,
+        tcg_alt_foil_to_uuid_map: dict[str, set[str]],
     ) -> dict[str, MtgjsonPriceEntry]:
         """
         Generate MTGJSON-format price dict for compatibility with legacy code.
@@ -460,7 +460,8 @@ async def get_tcgplayer_prices(
     tcg_to_uuid_map: dict[str, set[str]],
     tcg_etched_to_uuid_map: dict[str, set[str]],
     on_progress: ProgressCallback | None = None,
-    tcg_alt_foil_to_uuid_map: dict[str, set[str]] | None = None,
+    *,
+    tcg_alt_foil_to_uuid_map: dict[str, set[str]],
 ) -> pl.DataFrame:
     """
     Fetch TCGPlayer prices as DataFrame.
@@ -482,9 +483,15 @@ def get_tcgplayer_prices_sync(
     tcg_to_uuid_map: dict[str, set[str]],
     tcg_etched_to_uuid_map: dict[str, set[str]],
     on_progress: ProgressCallback | None = None,
-    tcg_alt_foil_to_uuid_map: dict[str, set[str]] | None = None,
+    *,
+    tcg_alt_foil_to_uuid_map: dict[str, set[str]],
 ) -> pl.DataFrame:
     """Sync wrapper for get_tcgplayer_prices."""
     return asyncio.run(
-        get_tcgplayer_prices(tcg_to_uuid_map, tcg_etched_to_uuid_map, on_progress, tcg_alt_foil_to_uuid_map)
+        get_tcgplayer_prices(
+            tcg_to_uuid_map,
+            tcg_etched_to_uuid_map,
+            on_progress,
+            tcg_alt_foil_to_uuid_map=tcg_alt_foil_to_uuid_map,
+        )
     )

--- a/mtgjson5/providers/tcgplayer/prices.py
+++ b/mtgjson5/providers/tcgplayer/prices.py
@@ -40,6 +40,12 @@ PRICE_SCHEMA = {
     "currency": pl.String,
 }
 
+_BUFFER_SCHEMA = {
+    **PRICE_SCHEMA,
+    "productId": pl.String,
+    "_mappingPriority": pl.UInt8,
+}
+
 
 @dataclass
 class TCGPlayerPriceProvider:
@@ -344,6 +350,8 @@ class TCGPlayerPriceProvider:
                             "finish": finish,
                             "price": float(market_price),
                             "currency": "USD",
+                            "productId": product_id,
+                            "_mappingPriority": mapping_priority,
                         },
                     )
 
@@ -388,10 +396,15 @@ class TCGPlayerPriceProvider:
         if not self._buffer:
             return pl.DataFrame(schema=PRICE_SCHEMA)
 
-        df = pl.DataFrame(self._buffer, schema=PRICE_SCHEMA).unique(
-            subset=["uuid", "date", "source", "provider", "price_type", "finish"],
-            keep="first",
-            maintain_order=True,
+        df = (
+            pl.DataFrame(self._buffer, schema=_BUFFER_SCHEMA)
+            .sort(["_mappingPriority", "productId"])
+            .unique(
+                subset=["uuid", "date", "source", "provider", "price_type", "finish"],
+                keep="first",
+                maintain_order=True,
+            )
+            .select(list(PRICE_SCHEMA))
         )
 
         if self.output_path:

--- a/mtgjson5/providers/tcgplayer/prices.py
+++ b/mtgjson5/providers/tcgplayer/prices.py
@@ -42,7 +42,7 @@ PRICE_SCHEMA = {
 
 _BUFFER_SCHEMA = {
     **PRICE_SCHEMA,
-    "productId": pl.String,
+    "productId": pl.Int64,
     "_mappingPriority": pl.UInt8,
 }
 
@@ -285,7 +285,7 @@ class TCGPlayerPriceProvider:
 
         Note: Buylist endpoint (/pricing/buy/group/) is deprecated and not called.
         """
-        candidates: dict[tuple[str, str], tuple[tuple[int, str], dict[str, Any]]] = {}
+        candidates: dict[tuple[str, str], tuple[tuple[int, int], dict[str, Any]]] = {}
 
         try:
             endpoint = f"pricing/group/{group_id}"
@@ -320,6 +320,7 @@ class TCGPlayerPriceProvider:
                         mapping_priority = 2
                 if not uuids:
                     continue
+                numeric_product_id = int(product_id)
 
                 # Determine finish type
                 is_normal = sub_type == "Normal"
@@ -335,7 +336,7 @@ class TCGPlayerPriceProvider:
                 # finish for the same UUID.
                 for uuid in uuids:
                     key = (uuid, finish)
-                    rank = (mapping_priority, product_id)
+                    rank = (mapping_priority, numeric_product_id)
                     existing = candidates.get(key)
                     if existing is not None and existing[0] <= rank:
                         continue
@@ -350,7 +351,7 @@ class TCGPlayerPriceProvider:
                             "finish": finish,
                             "price": float(market_price),
                             "currency": "USD",
-                            "productId": product_id,
+                            "productId": numeric_product_id,
                             "_mappingPriority": mapping_priority,
                         },
                     )

--- a/mtgjson5/providers/tcgplayer/prices.py
+++ b/mtgjson5/providers/tcgplayer/prices.py
@@ -303,58 +303,58 @@ class TCGPlayerPriceProvider:
                 if market_price is None:
                     continue
 
-                # Base and etched mappings are authoritative. Alternative IDs
-                # are used only when the product is otherwise unknown and the
-                # alternative association resolves to exactly one UUID.
-                is_etched = False
-                mapping_priority = 0
-                uuids = tcg_to_uuid_map.get(product_id)
-                if not uuids:
-                    uuids = tcg_etched_to_uuid_map.get(product_id)
-                    is_etched = bool(uuids)
-                    mapping_priority = 1
-                if not uuids and tcg_alt_foil_to_uuid_map:
+                # Preserve base and etched mappings for different cards. When
+                # the same product and card occur in both, the base mapping wins.
+                base_uuids = tcg_to_uuid_map.get(product_id) or set()
+                etched_uuids = (tcg_etched_to_uuid_map.get(product_id) or set()) - base_uuids
+                mapping_candidates: list[tuple[set[str], bool, int]] = []
+                if base_uuids:
+                    mapping_candidates.append((base_uuids, False, 0))
+                if etched_uuids:
+                    mapping_candidates.append((etched_uuids, True, 1))
+
+                # Alternative IDs are used only when the product is otherwise
+                # unknown and the association resolves to exactly one UUID.
+                if not mapping_candidates and tcg_alt_foil_to_uuid_map:
                     alt_uuids = tcg_alt_foil_to_uuid_map.get(product_id)
                     if alt_uuids and len(alt_uuids) == 1:
-                        uuids = alt_uuids
-                        mapping_priority = 2
-                if not uuids:
+                        mapping_candidates.append((alt_uuids, False, 2))
+                if not mapping_candidates:
                     continue
                 numeric_product_id = int(product_id)
-
-                # Determine finish type
-                is_normal = sub_type == "Normal"
-                if is_normal:
-                    finish = "normal"
-                elif is_etched:
-                    finish = "etched"
-                else:
-                    finish = "foil"
 
                 # Create one price record per unique output key. A primary
                 # mapping wins when an alternative product exposes the same
                 # finish for the same UUID.
-                for uuid in uuids:
-                    key = (uuid, finish)
-                    rank = (mapping_priority, numeric_product_id)
-                    existing = candidates.get(key)
-                    if existing is not None and existing[0] <= rank:
-                        continue
-                    candidates[key] = (
-                        rank,
-                        {
-                            "uuid": uuid,
-                            "date": self.today_date,
-                            "source": "paper",
-                            "provider": "tcgplayer",
-                            "price_type": "retail",
-                            "finish": finish,
-                            "price": float(market_price),
-                            "currency": "USD",
-                            "productId": numeric_product_id,
-                            "_mappingPriority": mapping_priority,
-                        },
-                    )
+                for uuids, is_etched, mapping_priority in mapping_candidates:
+                    if sub_type == "Normal":
+                        finish = "normal"
+                    elif is_etched:
+                        finish = "etched"
+                    else:
+                        finish = "foil"
+
+                    for uuid in uuids:
+                        key = (uuid, finish)
+                        rank = (mapping_priority, numeric_product_id)
+                        existing = candidates.get(key)
+                        if existing is not None and existing[0] <= rank:
+                            continue
+                        candidates[key] = (
+                            rank,
+                            {
+                                "uuid": uuid,
+                                "date": self.today_date,
+                                "source": "paper",
+                                "provider": "tcgplayer",
+                                "price_type": "retail",
+                                "finish": finish,
+                                "price": float(market_price),
+                                "currency": "USD",
+                                "productId": numeric_product_id,
+                                "_mappingPriority": mapping_priority,
+                            },
+                        )
 
         except Exception as e:
             LOGGER.debug(f"Failed to fetch prices for group {group_id}: {e}")

--- a/tests/mtgjson5/test_tcgplayer_price_mapping.py
+++ b/tests/mtgjson5/test_tcgplayer_price_mapping.py
@@ -1,0 +1,217 @@
+"""Regression tests for TCGplayer alternative-product price mapping."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import polars as pl
+import pytest
+
+from mtgjson5 import constants
+from mtgjson5.build.prices.price_builder import PolarsPriceBuilder, PriceBuilderContext
+from mtgjson5.build.prices.price_writers import stream_write_all_prices_json, stream_write_today_prices_json
+from mtgjson5.data import GLOBAL_CACHE
+from mtgjson5.data.context import PipelineContext
+from mtgjson5.pipeline.stages.output import _build_id_mappings
+from mtgjson5.providers.tcgplayer import prices as tcg_prices_module
+from mtgjson5.providers.tcgplayer.prices import TCGPlayerPriceProvider
+
+TODAY = "2026-08-07"
+JAWS_UUID = "373dab28-3a38-5b34-abdb-f77d1801a6d2"
+FLIPPED_UUID = "face0000-0000-0000-0000-000000000001"
+ETCHED_UUID = "etched00-0000-0000-0000-000000000001"
+BASE_COLLISION_UUID = "base0000-0000-0000-0000-000000000001"
+ETCHED_COLLISION_UUID = "etched00-0000-0000-0000-000000000002"
+OVERLAP_UUID = "base0000-0000-0000-0000-000000000002"
+
+BASE_MAP = {
+    "656542": {JAWS_UUID},
+    "700": {FLIPPED_UUID},
+    "900": {BASE_COLLISION_UUID},
+    "910": {OVERLAP_UUID},
+}
+ETCHED_MAP = {
+    "800": {ETCHED_UUID},
+    "901": {ETCHED_COLLISION_UUID},
+    "910": {"wrong-etched-overlap"},
+}
+ALT_MAP = {
+    "656544": {JAWS_UUID},
+    "701": {FLIPPED_UUID},
+    "900": {"wrong-alt-base-collision"},
+    "901": {"wrong-alt-etched-collision"},
+    "902": {"ambiguous-one", "ambiguous-two"},
+    "903": {JAWS_UUID},
+    "904": {"null-price"},
+}
+RAW_PRICES = [
+    # Put the duplicate alternative first to prove selection is deterministic.
+    {"productId": "903", "subTypeName": "Foil", "marketPrice": 999.0},
+    {"productId": "656544", "subTypeName": "Foil", "marketPrice": 22.0},
+    {"productId": "656542", "subTypeName": "Normal", "marketPrice": 11.0},
+    {"productId": "700", "subTypeName": "Foil", "marketPrice": 31.0},
+    {"productId": "701", "subTypeName": "Normal", "marketPrice": 32.0},
+    {"productId": "800", "subTypeName": "Foil", "marketPrice": 40.0},
+    {"productId": "900", "subTypeName": "Normal", "marketPrice": 50.0},
+    {"productId": "901", "subTypeName": "Foil", "marketPrice": 60.0},
+    {"productId": "902", "subTypeName": "Foil", "marketPrice": 70.0},
+    {"productId": "904", "subTypeName": "Foil", "marketPrice": None},
+    {"productId": "910", "subTypeName": "Foil", "marketPrice": 80.0},
+]
+
+
+class _FakeTcgClient:
+    def __init__(self, results: list[dict[str, Any]]) -> None:
+        self.results = results
+
+    async def __aenter__(self) -> _FakeTcgClient:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+    async def get(self, _endpoint: str, versioned: bool = True) -> dict[str, list[dict[str, Any]]]:
+        assert versioned
+        return {"results": self.results}
+
+
+def _write_mapping(path, id_column: str, mapping: dict[str, set[str]]) -> None:
+    rows = [{id_column: product_id, "uuid": uuid} for product_id, uuids in mapping.items() for uuid in uuids]
+    pl.DataFrame(rows, schema={id_column: pl.String, "uuid": pl.String}).write_parquet(path)
+
+
+@pytest.fixture
+def mapped_price_frames(tmp_path, monkeypatch) -> tuple[pl.DataFrame, pl.DataFrame]:
+    fake_client = _FakeTcgClient(RAW_PRICES)
+    monkeypatch.setattr(tcg_prices_module, "TcgPlayerClient", lambda _config: fake_client)
+
+    provider = TCGPlayerPriceProvider(output_path=tmp_path / "live_prices.parquet")
+    provider.today_date = TODAY
+    provider._config = object()  # type: ignore[assignment]
+
+    async def _group_ids(_client: object) -> list[tuple[int, str]]:
+        return [(1, "Regression fixtures")]
+
+    monkeypatch.setattr(provider, "_get_magic_set_ids", _group_ids)
+    live = asyncio.run(provider.fetch_all_prices(BASE_MAP, ETCHED_MAP, ALT_MAP))
+
+    pl.DataFrame(
+        RAW_PRICES,
+        schema={"productId": pl.String, "subTypeName": pl.String, "marketPrice": pl.Float64},
+    ).write_parquet(tmp_path / "tcg_raw_prices.parquet")
+    _write_mapping(tmp_path / "tcg_to_uuid.parquet", "tcgplayerProductId", BASE_MAP)
+    _write_mapping(tmp_path / "tcg_etched_to_uuid.parquet", "tcgplayerEtchedProductId", ETCHED_MAP)
+    _write_mapping(
+        tmp_path / "tcg_alt_foil_to_uuid.parquet",
+        "tcgplayerAlternativeFoilProductId",
+        ALT_MAP,
+    )
+
+    builder = PolarsPriceBuilder()
+    builder.today_date = TODAY
+    raw = builder.map_raw_to_today_df(tmp_path)
+    return live, raw
+
+
+def test_live_and_raw_paths_map_alternative_products_equivalently(mapped_price_frames):
+    live, raw = mapped_price_frames
+    sort_columns = ["uuid", "finish", "price"]
+
+    assert live.sort(sort_columns).rows(named=True) == raw.sort(sort_columns).rows(named=True)
+
+    actual = {(row["uuid"], row["finish"]): row["price"] for row in raw.iter_rows(named=True)}
+    assert actual == {
+        (JAWS_UUID, "normal"): 11.0,
+        (JAWS_UUID, "foil"): 22.0,
+        (FLIPPED_UUID, "foil"): 31.0,
+        (FLIPPED_UUID, "normal"): 32.0,
+        (ETCHED_UUID, "etched"): 40.0,
+        (BASE_COLLISION_UUID, "normal"): 50.0,
+        (ETCHED_COLLISION_UUID, "etched"): 60.0,
+        (OVERLAP_UUID, "foil"): 80.0,
+    }
+
+
+def test_alternative_mapping_does_not_duplicate_or_override_authoritative_products(mapped_price_frames):
+    live, raw = mapped_price_frames
+    key_columns = ["uuid", "date", "source", "provider", "price_type", "finish"]
+
+    assert live.unique(subset=key_columns).height == live.height
+    assert raw.unique(subset=key_columns).height == raw.height
+    assert not set(raw["uuid"]).intersection(
+        {
+            "wrong-alt-base-collision",
+            "wrong-alt-etched-collision",
+            "wrong-etched-overlap",
+            "ambiguous-one",
+            "ambiguous-two",
+            "null-price",
+        }
+    )
+
+
+def test_alternative_price_serializes_in_today_and_history_outputs(tmp_path, mapped_price_frames):
+    _live, raw = mapped_price_frames
+    output_paths = [tmp_path / "AllPricesToday.json", tmp_path / "AllPrices.json"]
+
+    stream_write_today_prices_json(raw, output_paths[0], TODAY)
+    stream_write_all_prices_json(raw.lazy(), output_paths[1], TODAY)
+
+    for output_path in output_paths:
+        output = json.loads(output_path.read_text(encoding="utf-8"))
+        retail = output["data"][JAWS_UUID]["paper"]["tcgplayer"]["retail"]
+        assert retail == {
+            "foil": {TODAY: 22.0},
+            "normal": {TODAY: 11.0},
+        }
+
+
+def test_standalone_price_context_loads_persisted_alternative_mapping(tmp_path, monkeypatch):
+    mapping_attrs = [
+        "tcg_to_uuid_lf",
+        "tcg_etched_to_uuid_lf",
+        "tcg_alt_foil_to_uuid_lf",
+        "mtgo_to_uuid_lf",
+        "scryfall_to_uuid_lf",
+        "cardmarket_to_uuid_lf",
+    ]
+    monkeypatch.setattr(constants, "CACHE_PATH", tmp_path)
+    monkeypatch.setattr(GLOBAL_CACHE, "cache_path", tmp_path)
+    for attr in mapping_attrs:
+        monkeypatch.setattr(GLOBAL_CACHE, attr, None)
+
+    cards = pl.DataFrame(
+        {
+            "uuid": [JAWS_UUID],
+            "identifiers": [
+                {
+                    "tcgplayerProductId": "656542",
+                    "tcgplayerEtchedProductId": None,
+                    "tcgplayerAlternativeFoilProductId": "656544",
+                    "mtgoId": None,
+                    "scryfallId": "c6d16a9e-98c0-46e0-987c-f0de0915a204",
+                    "mcmId": None,
+                }
+            ],
+        }
+    )
+    pipeline_ctx = PipelineContext(_cache=GLOBAL_CACHE)
+    _build_id_mappings(pipeline_ctx, cards.lazy())
+
+    persisted = pl.read_parquet(tmp_path / "tcg_alt_foil_to_uuid.parquet")
+    assert persisted.to_dicts() == [
+        {
+            "uuid": JAWS_UUID,
+            "tcgplayerAlternativeFoilProductId": "656544",
+        }
+    ]
+
+    # Simulate the clean process used for a standalone --price-build run.
+    for attr in mapping_attrs:
+        monkeypatch.setattr(GLOBAL_CACHE, attr, None)
+
+    price_ctx = PriceBuilderContext.from_cache()
+    assert price_ctx.tcg_to_uuid == {"656542": {JAWS_UUID}}
+    assert price_ctx.tcg_alt_foil_to_uuid == {"656544": {JAWS_UUID}}

--- a/tests/mtgjson5/test_tcgplayer_price_mapping.py
+++ b/tests/mtgjson5/test_tcgplayer_price_mapping.py
@@ -25,6 +25,9 @@ ETCHED_UUID = "etched00-0000-0000-0000-000000000001"
 BASE_COLLISION_UUID = "base0000-0000-0000-0000-000000000001"
 ETCHED_COLLISION_UUID = "etched00-0000-0000-0000-000000000002"
 OVERLAP_UUID = "base0000-0000-0000-0000-000000000002"
+CROSS_GROUP_UUID = "cross000-0000-0000-0000-000000000001"
+CROSS_GROUP_ETCHED_UUID = "cross000-0000-0000-0000-000000000002"
+ALT_TIE_UUID = "alttie00-0000-0000-0000-000000000001"
 
 BASE_MAP = {
     "656542": {JAWS_UUID},
@@ -63,7 +66,7 @@ RAW_PRICES = [
 
 
 class _FakeTcgClient:
-    def __init__(self, results: list[dict[str, Any]]) -> None:
+    def __init__(self, results: list[dict[str, Any]] | dict[int, list[dict[str, Any]]]) -> None:
         self.results = results
 
     async def __aenter__(self) -> _FakeTcgClient:
@@ -72,8 +75,11 @@ class _FakeTcgClient:
     async def __aexit__(self, *_args: object) -> None:
         return None
 
-    async def get(self, _endpoint: str, versioned: bool = True) -> dict[str, list[dict[str, Any]]]:
+    async def get(self, endpoint: str, versioned: bool = True) -> dict[str, list[dict[str, Any]]]:
         assert versioned
+        if isinstance(self.results, dict):
+            group_id = int(endpoint.rsplit("/", maxsplit=1)[-1])
+            return {"results": self.results[group_id]}
         return {"results": self.results}
 
 
@@ -131,6 +137,74 @@ def test_live_and_raw_paths_map_alternative_products_equivalently(mapped_price_f
         (BASE_COLLISION_UUID, "normal"): 50.0,
         (ETCHED_COLLISION_UUID, "etched"): 60.0,
         (OVERLAP_UUID, "foil"): 80.0,
+    }
+
+
+@pytest.mark.parametrize(
+    "group_ids",
+    [
+        [(1, "Alternatives"), (2, "Base products")],
+        [(2, "Base products"), (1, "Alternatives")],
+    ],
+)
+def test_live_mapping_priority_applies_across_groups(tmp_path, monkeypatch, group_ids):
+    grouped_prices = {
+        1: [
+            {"productId": "200", "subTypeName": "Foil", "marketPrice": 20.0},
+            {"productId": "201", "subTypeName": "Normal", "marketPrice": 21.0},
+            {"productId": "301", "subTypeName": "Foil", "marketPrice": 31.0},
+        ],
+        2: [
+            {"productId": "100", "subTypeName": "Foil", "marketPrice": 10.0},
+            {"productId": "101", "subTypeName": "Normal", "marketPrice": 11.0},
+            {"productId": "300", "subTypeName": "Foil", "marketPrice": 30.0},
+        ],
+    }
+    base_map = {"100": {CROSS_GROUP_UUID}}
+    etched_map = {"101": {CROSS_GROUP_ETCHED_UUID}}
+    alt_map = {
+        "200": {CROSS_GROUP_UUID},
+        "201": {CROSS_GROUP_ETCHED_UUID},
+        "300": {ALT_TIE_UUID},
+        "301": {ALT_TIE_UUID},
+    }
+
+    fake_client = _FakeTcgClient(grouped_prices)
+    monkeypatch.setattr(tcg_prices_module, "TcgPlayerClient", lambda _config: fake_client)
+
+    provider = TCGPlayerPriceProvider(output_path=tmp_path / "live_prices.parquet")
+    provider.today_date = TODAY
+    provider._config = object()  # type: ignore[assignment]
+
+    async def _group_ids(_client: object) -> list[tuple[int, str]]:
+        return group_ids
+
+    monkeypatch.setattr(provider, "_get_magic_set_ids", _group_ids)
+    live = asyncio.run(provider.fetch_all_prices(base_map, etched_map, alt_map))
+
+    raw_prices = [price for group_id, _name in group_ids for price in grouped_prices[group_id]]
+    pl.DataFrame(
+        raw_prices,
+        schema={"productId": pl.String, "subTypeName": pl.String, "marketPrice": pl.Float64},
+    ).write_parquet(tmp_path / "tcg_raw_prices.parquet")
+    _write_mapping(tmp_path / "tcg_to_uuid.parquet", "tcgplayerProductId", base_map)
+    _write_mapping(tmp_path / "tcg_etched_to_uuid.parquet", "tcgplayerEtchedProductId", etched_map)
+    _write_mapping(
+        tmp_path / "tcg_alt_foil_to_uuid.parquet",
+        "tcgplayerAlternativeFoilProductId",
+        alt_map,
+    )
+
+    builder = PolarsPriceBuilder()
+    builder.today_date = TODAY
+    raw = builder.map_raw_to_today_df(tmp_path)
+
+    sort_columns = ["uuid", "finish", "price"]
+    assert live.sort(sort_columns).rows(named=True) == raw.sort(sort_columns).rows(named=True)
+    assert {(row["uuid"], row["finish"]): row["price"] for row in live.iter_rows(named=True)} == {
+        (CROSS_GROUP_UUID, "foil"): 10.0,
+        (CROSS_GROUP_ETCHED_UUID, "normal"): 11.0,
+        (ALT_TIE_UUID, "foil"): 30.0,
     }
 
 

--- a/tests/mtgjson5/test_tcgplayer_price_mapping.py
+++ b/tests/mtgjson5/test_tcgplayer_price_mapping.py
@@ -46,12 +46,12 @@ ALT_MAP = {
     "900": {"wrong-alt-base-collision"},
     "901": {"wrong-alt-etched-collision"},
     "902": {"ambiguous-one", "ambiguous-two"},
-    "903": {JAWS_UUID},
+    "700000": {JAWS_UUID},
     "904": {"null-price"},
 }
 RAW_PRICES = [
     # Put the duplicate alternative first to prove selection is deterministic.
-    {"productId": "903", "subTypeName": "Foil", "marketPrice": 999.0},
+    {"productId": "700000", "subTypeName": "Foil", "marketPrice": 999.0},
     {"productId": "656544", "subTypeName": "Foil", "marketPrice": 22.0},
     {"productId": "656542", "subTypeName": "Normal", "marketPrice": 11.0},
     {"productId": "700", "subTypeName": "Foil", "marketPrice": 31.0},
@@ -152,12 +152,12 @@ def test_live_mapping_priority_applies_across_groups(tmp_path, monkeypatch, grou
         1: [
             {"productId": "200", "subTypeName": "Foil", "marketPrice": 20.0},
             {"productId": "201", "subTypeName": "Normal", "marketPrice": 21.0},
-            {"productId": "301", "subTypeName": "Foil", "marketPrice": 31.0},
+            {"productId": "1000", "subTypeName": "Foil", "marketPrice": 31.0},
         ],
         2: [
             {"productId": "100", "subTypeName": "Foil", "marketPrice": 10.0},
             {"productId": "101", "subTypeName": "Normal", "marketPrice": 11.0},
-            {"productId": "300", "subTypeName": "Foil", "marketPrice": 30.0},
+            {"productId": "999", "subTypeName": "Foil", "marketPrice": 30.0},
         ],
     }
     base_map = {"100": {CROSS_GROUP_UUID}}
@@ -165,8 +165,8 @@ def test_live_mapping_priority_applies_across_groups(tmp_path, monkeypatch, grou
     alt_map = {
         "200": {CROSS_GROUP_UUID},
         "201": {CROSS_GROUP_ETCHED_UUID},
-        "300": {ALT_TIE_UUID},
-        "301": {ALT_TIE_UUID},
+        "999": {ALT_TIE_UUID},
+        "1000": {ALT_TIE_UUID},
     }
 
     fake_client = _FakeTcgClient(grouped_prices)

--- a/tests/mtgjson5/test_tcgplayer_price_mapping.py
+++ b/tests/mtgjson5/test_tcgplayer_price_mapping.py
@@ -25,6 +25,7 @@ ETCHED_UUID = "etched00-0000-0000-0000-000000000001"
 BASE_COLLISION_UUID = "base0000-0000-0000-0000-000000000001"
 ETCHED_COLLISION_UUID = "etched00-0000-0000-0000-000000000002"
 OVERLAP_UUID = "base0000-0000-0000-0000-000000000002"
+SHARED_PRODUCT_ETCHED_UUID = "etched00-0000-0000-0000-000000000003"
 CROSS_GROUP_UUID = "cross000-0000-0000-0000-000000000001"
 CROSS_GROUP_ETCHED_UUID = "cross000-0000-0000-0000-000000000002"
 ALT_TIE_UUID = "alttie00-0000-0000-0000-000000000001"
@@ -38,7 +39,8 @@ BASE_MAP = {
 ETCHED_MAP = {
     "800": {ETCHED_UUID},
     "901": {ETCHED_COLLISION_UUID},
-    "910": {"wrong-etched-overlap"},
+    # The exact base overlap is dropped, while the different card is retained.
+    "910": {OVERLAP_UUID, SHARED_PRODUCT_ETCHED_UUID},
 }
 ALT_MAP = {
     "656544": {JAWS_UUID},
@@ -137,7 +139,17 @@ def test_live_and_raw_paths_map_alternative_products_equivalently(mapped_price_f
         (BASE_COLLISION_UUID, "normal"): 50.0,
         (ETCHED_COLLISION_UUID, "etched"): 60.0,
         (OVERLAP_UUID, "foil"): 80.0,
+        (SHARED_PRODUCT_ETCHED_UUID, "etched"): 80.0,
     }
+
+
+def test_base_overlap_only_suppresses_same_card_etched_mapping(mapped_price_frames):
+    for prices in mapped_price_frames:
+        actual = {(row["uuid"], row["finish"]): row["price"] for row in prices.iter_rows(named=True)}
+
+        assert actual[(OVERLAP_UUID, "foil")] == 80.0
+        assert (OVERLAP_UUID, "etched") not in actual
+        assert actual[(SHARED_PRODUCT_ETCHED_UUID, "etched")] == 80.0
 
 
 @pytest.mark.parametrize(
@@ -218,7 +230,6 @@ def test_alternative_mapping_does_not_duplicate_or_override_authoritative_produc
         {
             "wrong-alt-base-collision",
             "wrong-alt-etched-collision",
-            "wrong-etched-overlap",
             "ambiguous-one",
             "ambiguous-two",
             "null-price",


### PR DESCRIPTION
This fixes missing TCGplayer Market prices for cards that use `tcgplayerAlternativeFoilProductId`.

The alternative product mapping was already created and published, but the price builder only used the base and etched product mappings. As a result, prices attached to an alternative product were not included in `AllPrices.json` or `AllPricesToday.json`.

This follows:

- [#1545](https://github.com/mtgjson/mtgjson/pull/1545), which added the alternative product support.
- [#1678](https://github.com/mtgjson/mtgjson/pull/1678), which made the mapping anchor-aware and noted that alternative-product prices were still missing because the price builder did not use this mapping.

## Changes

- Use the alternative product mapping in both live and cached price builds.
- Load the mapping during standalone price builds.
- Determine `normal`, `foil`, or `etched` from TCGplayer's price data.
- Keep base and etched mappings authoritative when product IDs conflict.
- Avoid ambiguous mappings and duplicate price rows.

## Example

Jaws, Relentless Predator (`373dab28-3a38-5b34-abdb-f77d1801a6d2`) uses:

- Base product: `656542`
- Alternative product: `656544`

Product `656544` has a Foil Market price. This price is now published for the card.