### PR TITLE
Fix build crash on cards with empty finishes arrays

### DIFF
--- a/mtgjson5/pipeline/expressions.py
+++ b/mtgjson5/pipeline/expressions.py
@@ -38,15 +38,22 @@ def order_finishes_expr(col: str = "finishes") -> pl.Expr:
     Orders finishes without Python UDFs.
     Assigns weights: nonfoil=0, foil=1, etched=2, signed=3, others=99.
     """
-    return pl.col(col).list.eval(
-        pl.element().sort_by(
-            pl.element().replace_strict(
-                {"nonfoil": 0, "foil": 1, "etched": 2, "signed": 3},
-                default=99,
-                return_dtype=pl.Int32,
-            ),
-            pl.element(),  # secondary sort alphabetical
+    # sort_by inside list.eval raises "must have matching group lengths" on
+    # empty lists (polars 1.40), so mask them to null and restore afterwards
+    return (
+        pl.when(pl.col(col).list.len() > 0)
+        .then(pl.col(col))
+        .list.eval(
+            pl.element().sort_by(
+                pl.element().replace_strict(
+                    {"nonfoil": 0, "foil": 1, "etched": 2, "signed": 3},
+                    default=99,
+                    return_dtype=pl.Int32,
+                ),
+                pl.element(),  # secondary sort alphabetical
+            )
         )
+        .fill_null(pl.col(col))
     )
 
 

--- a/tests/mtgjson5/test_ordering.py
+++ b/tests/mtgjson5/test_ordering.py
@@ -66,6 +66,24 @@ class TestFinishesFollowFinishOrder:
         assert ordered[0] == "nonfoil"
         assert ordered[1] == "mystery"
 
+    def test_empty_list(self):
+        df = pl.DataFrame(
+            {"finishes": [[], ["foil", "nonfoil"]]},
+            schema={"finishes": pl.List(pl.String)},
+        )
+        result = df.select(order_finishes_expr("finishes"))
+        assert result["finishes"][0].to_list() == []
+        assert result["finishes"][1].to_list() == ["nonfoil", "foil"]
+
+    def test_null_list(self):
+        df = pl.DataFrame(
+            {"finishes": [None, ["foil", "nonfoil"]]},
+            schema={"finishes": pl.List(pl.String)},
+        )
+        result = df.select(order_finishes_expr("finishes"))
+        assert result["finishes"][0] is None
+        assert result["finishes"][1].to_list() == ["nonfoil", "foil"]
+
 
 # =============================================================================
 # TestColorsWubrgForSplitLayout


### PR DESCRIPTION
polars raises 'expressions in sort_by must have matching group lengths' when sort_by runs inside list.eval over an empty list. Mask empty lists to null before sorting and restore them afterwards.

<!--
Thanks for submitting this change to help improve upon MTGJSON! If you have any questions, please don't hesitate to ask.
Discord: https://mtgjson.com/discord
-->
