### PR TITLE
fix: restore Cardmarket prices dropped from AllPrices

### DIFF
--- a/mtgjson5/pipeline/stages/output.py
+++ b/mtgjson5/pipeline/stages/output.py
@@ -523,17 +523,21 @@ def _build_mcm_price_mapping_cache(ctx: PipelineContext, lf: pl.LazyFrame) -> No
             mapping.write_parquet(path)
             LOGGER.info(f"Built Cardmarket price mappings: {len(mapping):,} entries")
     except Exception as e:
-        LOGGER.warning(f"Failed to build Cardmarket price mappings: {e}")
+        LOGGER.error(f"Failed to build Cardmarket price mappings, prices will be omitted: {e}")
 
 
 def build_id_mappings_from_parquet(ctx: PipelineContext) -> None:
     """Build ID -> UUID mappings by scanning all partitioned parquet files.
 
-    Projects only the identifier fields the downstream helpers need and casts
-    each to String per-partition before concat. Without this, struct-field
-    dtype drift between partitions (e.g. an all-null column inferred as Null
-    in one partition vs String in another) causes pl.concat to panic and
-    silently disables the price builder's ID mappings.
+    Projects the identifier fields the downstream helpers need and casts each
+    to String per-partition before concat. Without this, struct-field dtype
+    drift between partitions (e.g. an all-null column inferred as Null in one
+    partition vs String in another) causes pl.concat to panic and silently
+    disables the price builder's ID mappings.
+
+    setCode/name/number are projected alongside the identifiers because
+    _build_mcm_price_mapping_cache joins on them to resolve Cardmarket
+    product/finish identity.
     """
     cards_dir = constants.CACHE_PATH / "_parquet"
     tokens_dir = constants.CACHE_PATH / "_parquet_tokens"
@@ -551,6 +555,9 @@ def build_id_mappings_from_parquet(ctx: PipelineContext) -> None:
         return pl.scan_parquet(pq_file).select(
             [
                 pl.col("uuid").cast(pl.String),
+                pl.col("setCode").cast(pl.String),
+                pl.col("name").cast(pl.String),
+                pl.col("number").cast(pl.String),
                 pl.struct(
                     [pl.col("identifiers").struct.field(name).cast(pl.String).alias(name) for name in needed_id_fields]
                 ).alias("identifiers"),

--- a/tests/mtgjson5/test_cardmarket_price_mapping.py
+++ b/tests/mtgjson5/test_cardmarket_price_mapping.py
@@ -177,3 +177,47 @@ def test_every_mapped_finish_is_supported(tmp_path, monkeypatch):
     for row in mapping.iter_rows(named=True):
         card_finish = "nonfoil" if row["finish"] == "normal" else row["finish"]
         assert card_finish in supported[row["uuid"]]
+
+
+def test_post_batch_parquet_path_builds_cardmarket_mapping(tmp_path, monkeypatch):
+    """The production build writes parquet partitions first, then derives ID
+    mappings from them. That projection must keep the columns the Cardmarket
+    mapping joins on, or Cardmarket silently drops out of AllPrices."""
+    from mtgjson5 import constants
+    from mtgjson5.pipeline.stages.output import build_id_mappings_from_parquet
+
+    monkeypatch.setattr(constants, "CACHE_PATH", tmp_path)
+
+    id_fields = [
+        "tcgplayerProductId",
+        "tcgplayerEtchedProductId",
+        "tcgplayerAlternativeFoilProductId",
+        "mtgoId",
+        "scryfallId",
+        "mcmId",
+    ]
+    cards = _cards().with_columns(
+        pl.struct(
+            [
+                (
+                    pl.col("identifiers").struct.field("mcmId") if name == "mcmId" else pl.lit(None, dtype=pl.String)
+                ).alias(name)
+                for name in id_fields
+            ]
+        ).alias("identifiers")
+    )
+    for set_df in cards.partition_by("setCode", as_dict=False):
+        set_path = tmp_path / "_parquet" / f"setCode={set_df['setCode'][0]}"
+        set_path.mkdir(parents=True)
+        set_df.write_parquet(set_path / "0.parquet")
+
+    ctx = PipelineContext()
+    ctx._mcm_price_lookup_enriched = _price_candidates().lazy()
+    build_id_mappings_from_parquet(ctx)
+
+    assert (tmp_path / "cardmarket_to_uuid.parquet").exists()
+    mapping = pl.read_parquet(tmp_path / "mcm_price_mappings.parquet")
+    actual = set(mapping.rows())
+    assert (FORCE_UUID, "566136", "trend", "foil") in actual
+    assert (FORCE_UUID, "567745", "trend", "etched") in actual
+    assert set(mapping.filter(pl.col("uuid") == "normal-foil")["finish"]) == {"normal", "foil"}


### PR DESCRIPTION
## Problem

Cardmarket data is completely missing from `AllPrices` / `AllPricesToday`. The published `2026-09-02` build (108,608 cards) has zero cardmarket entries, while every other provider is present:

| provider | entries |
| --- | --- |
| `('mtgo', 'cardhoarder')` | 62,091 |
| `('paper', 'cardkingdom')` | 97,527 |
| `('paper', 'manapool')` | 99,766 |
| `('paper', 'tcgplayer')` | 99,741 |
| `('paper', 'cardmarket')` | **0** |

## Root cause

Regression from #1681. That PR made Cardmarket prices depend on a new cache file, `mcm_price_mappings.parquet`, built by `_build_mcm_price_mapping_cache()` — which joins on `setCode`, `name` and `number`.

In the batched production build, that function is only ever reached through `build_id_mappings_from_parquet()` (`pipeline/core.py:185`, after each batch is sunk with `skip_id_mappings=True`). Its `_normalized()` projection selects only `uuid`, `identifiers` and `finishes`, so the join fails:

```
ColumnNotFoundError: unable to find column "setCode";
valid columns: ["uuid", "identifiers", "finishes"]
```

The surrounding `try/except` swallowed that as a `warning`, the mapping file was never written, and `price_builder` then took its silent-omit branch: `"Cardmarket finish mapping cache is unavailable; omitting Cardmarket prices"`.

## Changes

- Project `setCode`/`name`/`number` alongside the identifiers in `_normalized()`. All three are in `ALL_CARD_FIELDS` and survive `rename_all_the_things()` into the sunk parquet for both `card_set` and `card_token`.
- Raise the swallowed mapping failure from `warning` to `error`, naming the consequence, so a future break here is visible in the build log.
- Add a regression test.

## Why tests missed it

Both existing test paths (`test_cardmarket_price_mapping.py`, `test_tcgplayer_price_mapping.py:286`) call the builders directly with a full card frame. Nothing covered the batched production path. The new `test_post_batch_parquet_path_builds_cardmarket_mapping` writes real parquet partitions and runs `build_id_mappings_from_parquet()` itself — verified failing on the unpatched code, passing with the fix.

## Testing

Full suite: 903 passed. Ruff clean.

## Note

This does not backfill the price history already lost — Cardmarket has been absent since #1681 merged on Aug 27, so roughly six days of archive is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJiTX1Pq2amkuzAEVjx5xb