### PR TITLE
fix: refresh Scryfall bulk cache against published dump timestamps

### DIFF
--- a/mtgjson5/__main__.py
+++ b/mtgjson5/__main__.py
@@ -172,6 +172,7 @@ def dispatcher(args: argparse.Namespace) -> None:
         output_types=outputs_requested,
         export_formats=export_formats,
         skip_mcm=args.skip_mcm,
+        refresh_bulk=args.refresh_bulk,
     )
     profiler.checkpoint("cache_loaded", top_n=10)
 

--- a/mtgjson5/arg_parser.py
+++ b/mtgjson5/arg_parser.py
@@ -155,6 +155,11 @@ def parse_args() -> argparse.Namespace:
         help="Shorthand for --use-models --all-sets --full-build --export all. When combined with --sets, only builds individual set files (skipping compiled outputs and exports unless --outputs/--export/--full-build are specified).",
     )
     pipeline_group.add_argument(
+        "--refresh-bulk",
+        action="store_true",
+        help="Re-download Scryfall bulk data even if the cached files already match the newest published dump.",
+    )
+    pipeline_group.add_argument(
         "--skip-mcm",
         action="store_true",
         help="Skip CardMarket data fetching (speeds up builds when MCM data not needed).",
@@ -253,6 +258,7 @@ def parse_args() -> argparse.Namespace:
         parsed_args.parallel = bool(os.environ.get("PARALLEL", False))
         parsed_args.pretty = bool(os.environ.get("PRETTY", False))
         parsed_args.bulk_files = bool(os.environ.get("USE_BULK", False))
+        parsed_args.refresh_bulk = bool(os.environ.get("REFRESH_BULK", False))
         parsed_args.skip_sets = list(filter(None, os.environ.get("SKIP_SETS", "").split(",")))
         parsed_args.price_build = bool(os.environ.get("PRICE_BUILD", False))
         parsed_args.referrals = bool(os.environ.get("REFERRALS", False))

--- a/mtgjson5/data/cache.py
+++ b/mtgjson5/data/cache.py
@@ -316,6 +316,7 @@ class GlobalCache:
         output_types: set[str] | None = None,
         export_formats: set[str] | None = None,
         skip_mcm: bool = False,
+        refresh_bulk: bool = False,
     ) -> "GlobalCache":
         """
         Load all data sources and pre-compute aggregations.
@@ -329,6 +330,8 @@ class GlobalCache:
                 When specified, can be used to skip loading data not needed
                 for the requested formats.
             skip_mcm: Skip CardMarket data fetching (speeds up builds).
+            refresh_bulk: Re-download Scryfall bulk data even when the cached
+                files already match the newest published dump.
         """
         self._output_types = output_types or set()
         self._export_formats = export_formats
@@ -338,7 +341,7 @@ class GlobalCache:
 
         prof = get_profiler()
 
-        self._download_bulk_data()
+        self._download_bulk_data(force_refresh=refresh_bulk)
         prof.checkpoint("bulk_download")
         self._load_bulk_data()
         prof.checkpoint("bulk_load")
@@ -565,35 +568,20 @@ class GlobalCache:
         LOGGER.warning("uuid_cache not available, cannot build scryfall_id filter")
 
     def _download_bulk_data(self, force_refresh: bool = False) -> None:
-        """Download Scryfall bulk data if missing or stale."""
-        cards_path = self.cache_path / "all_cards.ndjson"
-        default_cards_path = self.cache_path / "default_cards.ndjson"
-        rulings_path = self.cache_path / "rulings.ndjson"
+        """
+        Sync Scryfall bulk data to the newest published dump.
 
-        needs_download = force_refresh
-        if not cards_path.exists() or cards_path.stat().st_size == 0:
-            needs_download = True
-        if not default_cards_path.exists() or default_cards_path.stat().st_size == 0:
-            needs_download = True
-        if not rulings_path.exists() or rulings_path.stat().st_size == 0:
-            needs_download = True
-
-        # Check age (72h max)
-        if not needs_download and cards_path.exists():
-            age_hours = (time.time() - cards_path.stat().st_mtime) / 3600
-            if age_hours > 72:
-                LOGGER.info(f"Bulk data is {age_hours:.1f}h old, refreshing...")
-                needs_download = True
-
-        if needs_download:
-            LOGGER.info("Downloading bulk scryfall data...")
-            self.bulkdata.download_bulk_files_sync(
-                self.cache_path,
-                ["all_cards", "default_cards", "rulings"],
-                force_refresh,
-            )
-        else:
-            LOGGER.info("Using cached bulk data")
+        Freshness is decided per file inside the provider, which compares each
+        cached file against the `updated_at` Scryfall reports for that dump. A
+        build therefore always reads the newest snapshot rather than whichever
+        one happened to be left in the cache.
+        """
+        LOGGER.info("Checking bulk scryfall data...")
+        self.bulkdata.download_bulk_files_sync(
+            self.cache_path,
+            ["all_cards", "default_cards", "rulings"],
+            force_refresh,
+        )
 
     def _load_bulk_data(self) -> None:
         """Load bulk NDJSON files into LazyFrames."""

--- a/mtgjson5/providers/scryfall/provider.py
+++ b/mtgjson5/providers/scryfall/provider.py
@@ -7,9 +7,11 @@ of Scryfall bulk data files for Polars ingestion, plus API access methods.
 """
 
 import asyncio
+import datetime
 import gzip
 import json
 import logging
+import os
 import pathlib
 import time
 from typing import IO, Any, cast
@@ -55,6 +57,9 @@ class ScryfallProvider:
     RATE_LIMIT_BACKOFF_BASE: float = 2.0
     RATE_LIMIT_MAX_RETRIES: int = 5
 
+    # Only used when Scryfall omits `updated_at` for a bulk entry
+    BULK_MAX_AGE_HOURS: float = 24.0
+
     def __init__(self) -> None:
         self._cards_without_limits: set[str] | None = None
         self._rate_limiter: asyncio.Semaphore = asyncio.Semaphore(2)
@@ -98,26 +103,63 @@ class ScryfallProvider:
         uri = item.get("jsonl_download_uri") or item.get("download_uri")
         return str(uri) if uri else None
 
-    async def get_bulk_download_url(self, session: aiohttp.ClientSession, bulk_type: str) -> str:
-        """Fetch the download URL for a bulk data type."""
+    @staticmethod
+    def _parse_updated_at(item: dict[str, Any]) -> datetime.datetime | None:
+        """Read the timestamp Scryfall cut a bulk dump at, or None if it is unusable."""
+        raw = item.get("updated_at")
+        if not raw:
+            return None
+        try:
+            parsed = datetime.datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=datetime.UTC)
+        return parsed
+
+    def _cached_dump_is_current(
+        self,
+        destination: pathlib.Path,
+        updated_at: datetime.datetime | None,
+    ) -> bool:
+        """
+        Decide whether the on-disk NDJSON already holds Scryfall's newest dump.
+
+        Downloaded files are stamped with the dump's own `updated_at` (see
+        download_to_ndjson), so an mtime at or past the remote timestamp means we
+        already have that dump. Files written before that stamping existed carry
+        their download time, which is still later than the dump they came from.
+        """
+        if not destination.exists() or destination.stat().st_size == 0:
+            return False
+        if updated_at is None:
+            age_hours = (time.time() - destination.stat().st_mtime) / 3600
+            return age_hours < self.BULK_MAX_AGE_HOURS
+        return destination.stat().st_mtime >= updated_at.timestamp()
+
+    async def get_bulk_metadata(self, session: aiohttp.ClientSession) -> dict[str, dict[str, Any]]:
+        """Fetch Scryfall's bulk data catalog, keyed by bulk type."""
         response = await self._rate_limited_get(session, self.BULK_DATA_URL)
         async with response:
             response.raise_for_status()
             data = await response.json()
 
-        for item in data.get("data", []):
-            if item.get("type") == bulk_type:
-                download_uri = self._select_download_uri(item)
-                if download_uri:
-                    return download_uri
+        return {item["type"]: item for item in data.get("data", []) if item.get("type")}
 
-        raise ValueError(f"Unknown bulk type: {bulk_type}")
+    async def get_bulk_download_url(self, session: aiohttp.ClientSession, bulk_type: str) -> str:
+        """Fetch the download URL for a bulk data type."""
+        item = (await self.get_bulk_metadata(session)).get(bulk_type)
+        download_uri = self._select_download_uri(item) if item else None
+        if not download_uri:
+            raise ValueError(f"Unknown bulk type: {bulk_type}")
+        return download_uri
 
     async def download_to_ndjson(
         self,
         session: aiohttp.ClientSession,
         url: str,
         destination: pathlib.Path,
+        updated_at: datetime.datetime | None = None,
     ) -> pathlib.Path:
         """Stream a bulk file to a temp file, then convert it to NDJSON on disk."""
         self.LOGGER.info(f"Downloading {url}...")
@@ -160,6 +202,13 @@ class ScryfallProvider:
         # asyncio.to_thread to offload the blocking file conversion
         await asyncio.to_thread(self._convert_file_to_ndjson, tmp, destination)
         tmp.unlink(missing_ok=True)
+
+        # Stamp the file with the dump's own timestamp so later builds can tell
+        # which Scryfall snapshot they are sitting on
+        if updated_at is not None:
+            stamp = updated_at.timestamp()
+            os.utime(destination, (stamp, stamp))
+
         return destination
 
     @staticmethod
@@ -208,35 +257,56 @@ class ScryfallProvider:
         """
         Download multiple bulk files concurrently.
 
+        A cached file is reused only when it holds the newest dump Scryfall has
+        published; anything older is re-downloaded. Without that check a build
+        pins itself to whatever snapshot happened to be on disk, so passthrough
+        identifiers appear to flip back and forth between builds.
+
         Returns dict mapping bulk_type to file path.
         """
         headers = {
             "User-Agent": "MTGJSON/5.0 (https://mtgjson.com)",
             "Accept": "application/json",
         }
+        results = {bt: cache_dir / f"{bt}.ndjson" for bt in bulk_types}
         timeout = aiohttp.ClientTimeout(total=1800)
         async with aiohttp.ClientSession(headers=headers, timeout=timeout) as session:
-            # Resolve all download URLs first
-            urls = {}
-            for bulk_type in bulk_types:
-                urls[bulk_type] = await self.get_bulk_download_url(session, bulk_type)
+            try:
+                catalog = await self.get_bulk_metadata(session)
+            except (TimeoutError, aiohttp.ClientError) as exc:
+                usable = all(path.exists() and path.stat().st_size > 0 for path in results.values())
+                if force_refresh or not usable:
+                    raise
+                self.LOGGER.warning(
+                    f"Could not reach the Scryfall bulk catalog ({exc}); falling back to cached bulk data"
+                )
+                return results
 
-            # Download concurrently
             tasks = []
-            for bulk_type, url in urls.items():
-                dest = cache_dir / f"{bulk_type}.ndjson"
-                # local caching for dev convenience - wont matter in prod
-                if not force_refresh and dest.exists() and dest.stat().st_size > 0:
-                    self.LOGGER.info(f"Using cached {bulk_type}")
+            for bulk_type in bulk_types:
+                item = catalog.get(bulk_type)
+                if not item:
+                    raise ValueError(f"Unknown bulk type: {bulk_type}")
+                url = self._select_download_uri(item)
+                if not url:
+                    raise ValueError(f"No download URI for bulk type: {bulk_type}")
+
+                dest = results[bulk_type]
+                updated_at = self._parse_updated_at(item)
+                dump = updated_at.isoformat() if updated_at else "unknown timestamp"
+                if not force_refresh and self._cached_dump_is_current(dest, updated_at):
+                    self.LOGGER.info(f"Using cached {bulk_type} (Scryfall dump {dump})")
                     continue
+
+                self.LOGGER.info(f"Refreshing {bulk_type} to Scryfall dump {dump}")
                 # send to executor to avoid blocking event loop
-                tasks.append(self.download_to_ndjson(session, url, dest))
+                tasks.append(self.download_to_ndjson(session, url, dest, updated_at))
 
             if tasks:
                 # we waits
                 await asyncio.gather(*tasks)
 
-        return {bt: cache_dir / f"{bt}.ndjson" for bt in bulk_types}
+        return results
 
     def download_bulk_files_sync(
         self,

--- a/tests/mtgjson5/test_scryfall_bulk.py
+++ b/tests/mtgjson5/test_scryfall_bulk.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
+import datetime
 import gzip
 import json
+import os
+import time
 
+import aiohttp
 import orjson
 import pytest
 
@@ -104,3 +109,247 @@ class TestConvertFileToNdjson:
 
         assert count == 2
         assert _read_ndjson(dest) == CARDS
+
+
+# =============================================================================
+# TestParseUpdatedAt
+# =============================================================================
+
+
+class TestParseUpdatedAt:
+    def test_parses_offset_timestamp(self):
+        parsed = ScryfallProvider._parse_updated_at({"updated_at": "2026-08-20T21:18:12.301+00:00"})
+        assert parsed == datetime.datetime(2026, 8, 20, 21, 18, 12, 301000, tzinfo=datetime.UTC)
+
+    def test_parses_zulu_timestamp(self):
+        parsed = ScryfallProvider._parse_updated_at({"updated_at": "2026-08-20T21:18:12Z"})
+        assert parsed == datetime.datetime(2026, 8, 20, 21, 18, 12, tzinfo=datetime.UTC)
+
+    def test_assumes_utc_when_offset_missing(self):
+        parsed = ScryfallProvider._parse_updated_at({"updated_at": "2026-08-20T21:18:12"})
+        assert parsed == datetime.datetime(2026, 8, 20, 21, 18, 12, tzinfo=datetime.UTC)
+
+    def test_returns_none_when_absent(self):
+        assert ScryfallProvider._parse_updated_at({"type": "all_cards"}) is None
+
+    def test_returns_none_when_unparseable(self):
+        assert ScryfallProvider._parse_updated_at({"updated_at": "yesterday"}) is None
+
+
+# =============================================================================
+# TestCachedDumpIsCurrent
+# =============================================================================
+
+
+DUMP_TIME = datetime.datetime(2026, 8, 20, 21, 18, 12, tzinfo=datetime.UTC)
+
+
+def _write_dump(path, mtime):
+    path.write_text("{}\n", encoding="utf-8")
+    os.utime(path, (mtime, mtime))
+    return path
+
+
+class TestCachedDumpIsCurrent:
+    def test_missing_file_is_not_current(self, provider, tmp_path):
+        assert provider._cached_dump_is_current(tmp_path / "all_cards.ndjson", DUMP_TIME) is False
+
+    def test_empty_file_is_not_current(self, provider, tmp_path):
+        dest = tmp_path / "all_cards.ndjson"
+        dest.write_bytes(b"")
+        os.utime(dest, (DUMP_TIME.timestamp(), DUMP_TIME.timestamp()))
+        assert provider._cached_dump_is_current(dest, DUMP_TIME) is False
+
+    def test_file_older_than_dump_is_not_current(self, provider, tmp_path):
+        # This is the churn case: yesterday's snapshot sitting in the cache
+        dest = _write_dump(tmp_path / "all_cards.ndjson", DUMP_TIME.timestamp() - 86400)
+        assert provider._cached_dump_is_current(dest, DUMP_TIME) is False
+
+    def test_file_stamped_with_dump_is_current(self, provider, tmp_path):
+        dest = _write_dump(tmp_path / "all_cards.ndjson", DUMP_TIME.timestamp())
+        assert provider._cached_dump_is_current(dest, DUMP_TIME) is True
+
+    def test_file_downloaded_after_dump_is_current(self, provider, tmp_path):
+        dest = _write_dump(tmp_path / "all_cards.ndjson", DUMP_TIME.timestamp() + 3600)
+        assert provider._cached_dump_is_current(dest, DUMP_TIME) is True
+
+    def test_falls_back_to_age_when_timestamp_unknown(self, provider, tmp_path):
+        fresh = _write_dump(tmp_path / "fresh.ndjson", time.time() - 3600)
+        stale = _write_dump(tmp_path / "stale.ndjson", time.time() - 48 * 3600)
+        assert provider._cached_dump_is_current(fresh, None) is True
+        assert provider._cached_dump_is_current(stale, None) is False
+
+
+# =============================================================================
+# TestDownloadBulkFiles
+# =============================================================================
+
+
+CATALOG = {
+    "all_cards": {
+        "type": "all_cards",
+        "jsonl_download_uri": "https://data.scryfall.io/all-cards.jsonl.gz",
+        "updated_at": DUMP_TIME.isoformat(),
+    },
+    "rulings": {
+        "type": "rulings",
+        "jsonl_download_uri": "https://data.scryfall.io/rulings.jsonl.gz",
+        "updated_at": DUMP_TIME.isoformat(),
+    },
+}
+
+
+def _stub_downloads(provider, catalog=CATALOG, metadata_error=None):
+    """Record which bulk types would be downloaded, without touching the network."""
+    downloaded = []
+
+    async def fake_metadata(_session):
+        if metadata_error is not None:
+            raise metadata_error
+        return catalog
+
+    async def fake_download(_session, url, destination, updated_at=None):
+        downloaded.append(destination.name)
+        return destination
+
+    provider.get_bulk_metadata = fake_metadata
+    provider.download_to_ndjson = fake_download
+    return downloaded
+
+
+class TestDownloadBulkFiles:
+    def test_refreshes_cache_older_than_published_dump(self, provider, tmp_path):
+        _write_dump(tmp_path / "all_cards.ndjson", DUMP_TIME.timestamp() - 86400)
+        _write_dump(tmp_path / "rulings.ndjson", DUMP_TIME.timestamp() - 86400)
+        downloaded = _stub_downloads(provider)
+
+        asyncio.run(provider.download_bulk_files(tmp_path, ["all_cards", "rulings"]))
+
+        assert sorted(downloaded) == ["all_cards.ndjson", "rulings.ndjson"]
+
+    def test_keeps_cache_matching_published_dump(self, provider, tmp_path):
+        _write_dump(tmp_path / "all_cards.ndjson", DUMP_TIME.timestamp())
+        _write_dump(tmp_path / "rulings.ndjson", DUMP_TIME.timestamp())
+        downloaded = _stub_downloads(provider)
+
+        asyncio.run(provider.download_bulk_files(tmp_path, ["all_cards", "rulings"]))
+
+        assert downloaded == []
+
+    def test_refreshes_only_the_stale_file(self, provider, tmp_path):
+        _write_dump(tmp_path / "all_cards.ndjson", DUMP_TIME.timestamp() - 86400)
+        _write_dump(tmp_path / "rulings.ndjson", DUMP_TIME.timestamp())
+        downloaded = _stub_downloads(provider)
+
+        asyncio.run(provider.download_bulk_files(tmp_path, ["all_cards", "rulings"]))
+
+        assert downloaded == ["all_cards.ndjson"]
+
+    def test_force_refresh_redownloads_current_cache(self, provider, tmp_path):
+        _write_dump(tmp_path / "all_cards.ndjson", DUMP_TIME.timestamp())
+        downloaded = _stub_downloads(provider)
+
+        asyncio.run(provider.download_bulk_files(tmp_path, ["all_cards"], force_refresh=True))
+
+        assert downloaded == ["all_cards.ndjson"]
+
+    def test_missing_file_is_downloaded(self, provider, tmp_path):
+        downloaded = _stub_downloads(provider)
+
+        asyncio.run(provider.download_bulk_files(tmp_path, ["all_cards"]))
+
+        assert downloaded == ["all_cards.ndjson"]
+
+    def test_unreachable_catalog_falls_back_to_cache(self, provider, tmp_path):
+        _write_dump(tmp_path / "all_cards.ndjson", DUMP_TIME.timestamp() - 86400)
+        downloaded = _stub_downloads(provider, metadata_error=aiohttp.ClientError("boom"))
+
+        result = asyncio.run(provider.download_bulk_files(tmp_path, ["all_cards"]))
+
+        assert downloaded == []
+        assert result["all_cards"] == tmp_path / "all_cards.ndjson"
+
+    def test_unreachable_catalog_raises_without_usable_cache(self, provider, tmp_path):
+        _stub_downloads(provider, metadata_error=aiohttp.ClientError("boom"))
+
+        with pytest.raises(aiohttp.ClientError):
+            asyncio.run(provider.download_bulk_files(tmp_path, ["all_cards"]))
+
+    def test_unknown_bulk_type_raises(self, provider, tmp_path):
+        _stub_downloads(provider)
+
+        with pytest.raises(ValueError, match="Unknown bulk type"):
+            asyncio.run(provider.download_bulk_files(tmp_path, ["nonexistent"]))
+
+
+# =============================================================================
+# TestDownloadStamping
+# =============================================================================
+
+
+class _FakeContent:
+    def __init__(self, body):
+        self._body = body
+
+    async def iter_chunked(self, _size):
+        yield self._body
+
+
+class _FakeResponse:
+    def __init__(self, body):
+        self.content = _FakeContent(body)
+        self.headers = {"Content-Length": str(len(body))}
+
+    def raise_for_status(self):
+        return None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+class _FakeSession:
+    """Minimal stand-in for aiohttp.ClientSession serving one fixed body."""
+
+    def __init__(self, body):
+        self._body = body
+
+    def get(self, _url):
+        return _FakeResponse(self._body)
+
+
+class TestDownloadStamping:
+    def test_download_stamps_file_with_dump_time(self, provider, tmp_path):
+        body = gzip.compress(b"\n".join(orjson.dumps(c) for c in CARDS) + b"\n")
+        dest = tmp_path / "all_cards.ndjson"
+
+        asyncio.run(
+            provider.download_to_ndjson(
+                _FakeSession(body),
+                "https://data.scryfall.io/all-cards.jsonl.gz",
+                dest,
+                DUMP_TIME,
+            )
+        )
+
+        assert _read_ndjson(dest) == CARDS
+        assert dest.stat().st_mtime == pytest.approx(DUMP_TIME.timestamp())
+        # A build that finds this file must recognise it as the current dump
+        assert provider._cached_dump_is_current(dest, DUMP_TIME) is True
+
+    def test_download_leaves_mtime_alone_without_dump_time(self, provider, tmp_path):
+        body = gzip.compress(b"\n".join(orjson.dumps(c) for c in CARDS) + b"\n")
+        dest = tmp_path / "all_cards.ndjson"
+
+        asyncio.run(
+            provider.download_to_ndjson(
+                _FakeSession(body),
+                "https://data.scryfall.io/all-cards.jsonl.gz",
+                dest,
+            )
+        )
+
+        assert _read_ndjson(dest) == CARDS
+        assert dest.stat().st_mtime == pytest.approx(time.time(), abs=60)

--- a/tests/mtgjson5/test_scryfall_bulk.py
+++ b/tests/mtgjson5/test_scryfall_bulk.py
@@ -199,14 +199,14 @@ CATALOG = {
 }
 
 
-def _stub_downloads(provider, catalog=CATALOG, metadata_error=None):
+def _stub_downloads(provider, metadata_error=None):
     """Record which bulk types would be downloaded, without touching the network."""
     downloaded = []
 
     async def fake_metadata(_session):
         if metadata_error is not None:
             raise metadata_error
-        return catalog
+        return CATALOG
 
     async def fake_download(_session, url, destination, updated_at=None):
         downloaded.append(destination.name)
@@ -234,7 +234,7 @@ class TestDownloadBulkFiles:
 
         asyncio.run(provider.download_bulk_files(tmp_path, ["all_cards", "rulings"]))
 
-        assert downloaded == []
+        assert not downloaded
 
     def test_refreshes_only_the_stale_file(self, provider, tmp_path):
         _write_dump(tmp_path / "all_cards.ndjson", DUMP_TIME.timestamp() - 86400)
@@ -266,7 +266,7 @@ class TestDownloadBulkFiles:
 
         result = asyncio.run(provider.download_bulk_files(tmp_path, ["all_cards"]))
 
-        assert downloaded == []
+        assert not downloaded
         assert result["all_cards"] == tmp_path / "all_cards.ndjson"
 
     def test_unreachable_catalog_raises_without_usable_cache(self, provider, tmp_path):


### PR DESCRIPTION
Fixes #1706 (partially — see "What this does not fix" below).

## The bug

`_download_bulk_data` in `mtgjson5/data/cache.py` computed a 72-hour staleness rule and then threw it away:

```python
if age_hours > 72:
    needs_download = True                                        # set here...

if needs_download:
    self.bulkdata.download_bulk_files_sync(..., force_refresh)   # ...but this is passed
```

`force_refresh` is always `False` — the single call site, `GlobalCache.load_all()`, passes nothing — and `download_bulk_files` skipped any file already on disk:

```python
if not force_refresh and dest.exists() and dest.stat().st_size > 0:
    self.LOGGER.info(f"Using cached {bulk_type}")
    continue
```

So once `.mtgjson5_cache/all_cards.ndjson` existed it was never refreshed by age, only by being deleted or truncated. Which Scryfall snapshot a build read depended entirely on when that cache file happened to be created or evicted, which turns any upstream change into visible back-and-forth churn — across every Scryfall passthrough field, not only `mtgoId`. The age check also only looked at `all_cards.ndjson`'s mtime even though it gated `default_cards` and `rulings` as well.

## The fix

I went with the "better fix" from the issue rather than the one-line `force_refresh` → `True`, since that would re-download ~3.5 GB on every build.

Freshness now lives in the provider and is decided per file against `updated_at` from Scryfall's own bulk-data catalog:

- `get_bulk_metadata()` fetches the catalog once. Previously `get_bulk_download_url` re-fetched it once per bulk type, so this is 3 requests down to 1.
- `_cached_dump_is_current()` reuses a cached file only when its mtime is at or past the dump's `updated_at`.
- `download_to_ndjson` stamps the finished file with the dump's own timestamp via `os.utime`, so mtime records which snapshot is on disk rather than when it was fetched. Files written before this change carry their download time, which is still later than the dump they came from, so they compare correctly without needing to be re-fetched.
- If Scryfall omits `updated_at` for an entry, a 24h TTL applies.
- If the catalog is unreachable and a usable cache exists, the build logs a warning and proceeds on cache instead of failing. A warm-cache build previously never touched the network at all, so this keeps that from becoming a regression.

`--refresh-bulk` (and `REFRESH_BULK` for `--use-envvars`) forces a re-download, plumbed through `load_all`.

## Verification

Checked against the live catalog and the local cache. All three dumps parse, and a cache fetched at 22:59Z against dumps cut at 21:00–21:17Z is correctly held as current; the next day's dump triggers a refresh.

```
all_cards       local=2026-09-02T22:59:07Z remote=2026-09-02T21:17:33Z current=True
default_cards   local=2026-09-02T22:58:43Z remote=2026-09-02T21:05:32Z current=True
rulings         local=2026-09-02T22:58:31Z remote=2026-09-02T21:00:34Z current=True
```

29 tests in `tests/mtgjson5/test_scryfall_bulk.py` cover `updated_at` parsing, the per-file freshness decision, the download/skip/force paths, catalog-failure fallback, and mtime stamping. Full suite (852 tests), ruff, and mypy pass.

## What this does not fix

The `mtgoId` churn itself originates upstream. Scryfall serves two live values for the same card across their search index and card store, and multiface cards flip between adjacent MTGO catalog entries (±2). This change removes MTGJSON as a variable — builds now pin to the newest published dump — so any remaining churn is cleanly attributable to Scryfall and worth an upstream report.

I deliberately did not add an `mtgoId` workaround. Pinning previous values would freeze data Scryfall considers current, and that seemed like a maintainer call rather than something to slip into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZYxVnRkaqut6RgbMoXTUq
