### PR TITLE
feat: add CardmarketIdentifiers.json compiled output

### DIFF
--- a/docs/assembly-output.md
+++ b/docs/assembly-output.md
@@ -271,6 +271,22 @@ class TcgplayerSkusAssembler(Assembler):
         """Returns UUID -> [SKU objects] mapping."""
 ```
 
+### CardmarketIdentifiersAssembler
+
+Builds `CardmarketIdentifiers.json`, decoding the opaque IDs in Cardmarket's
+public download files:
+
+```python
+class CardmarketIdentifiersAssembler(Assembler):
+    def build(self) -> dict[str, dict[str, Any]]:
+        """Returns {"expansions": {idExpansion -> {name, setCodes}},
+        "products": {idProduct -> {name, number?, expansionId, uuids?}}}."""
+```
+
+Reads the raw Cardmarket catalog (`mkm_cards.parquet`) and the
+`cardmarket_to_uuid` mapping from the pipeline cache. Produces empty maps when
+no Cardmarket credentials are configured.
+
 ### TableAssembler
 
 Assembles flattened table representations for relational formats:

--- a/docs/subprocess-isolation.md
+++ b/docs/subprocess-isolation.md
@@ -61,7 +61,7 @@ Tasks are grouped to keep intra-group dependencies internal and minimize per-gro
 | **C** | SetFiles, SetList, Meta, CompiledList | _(none)_ | `all_cards_df`, `decks_df`, `sealed_df`, `token_products`, `booster_configs` |
 | **D** | DeckFiles, DeckList | sealed, token_products, boosters | `decks_df` + uuid_index from parquet |
 | **E** | TcgplayerSkus | decks, boosters | `sealed_df`, `token_products`, TCG SKU parquets |
-| **F** | AllIdentifiers, EnumValues, Keywords, CardTypes | token_products, boosters | Parquet reads, `decks_df`/`sealed_df` (EnumValues), scryfall catalogs |
+| **F** | AllIdentifiers, EnumValues, Keywords, CardTypes, CardmarketIdentifiers | token_products, boosters | Parquet reads, `decks_df`/`sealed_df` (EnumValues), scryfall catalogs, MCM catalog parquets |
 
 **Dependencies:** FormatPrintings reads AllPrintings.json from disk (stays in Group A). FormatAtomics reads AtomicCards.json from disk (stays in Group B). No cross-group dependencies.
 

--- a/mtgjson5/_subprocess_assembly.py
+++ b/mtgjson5/_subprocess_assembly.py
@@ -201,6 +201,10 @@ def _run_task(
         count = builder.write_all_identifiers(out / "AllIdentifiers.json")
         results["AllIdentifiers"] = count
 
+    elif task == "CardmarketIdentifiers":
+        cardmarket_file = builder.write_cardmarket_identifiers(out / "CardmarketIdentifiers.json")
+        results["CardmarketIdentifiers"] = sum(len(v) for v in cardmarket_file.data.values())
+
     elif task == "Keywords":
         keywords = builder.write_keywords(out / "Keywords.json")
         results["Keywords"] = sum(len(v) for v in keywords.data.values())

--- a/mtgjson5/arg_parser.py
+++ b/mtgjson5/arg_parser.py
@@ -124,7 +124,7 @@ def parse_args() -> argparse.Namespace:
         type=lambda s: [x.strip() for x in s.split(",") if x.strip()],
         metavar="LIST",
         default=None,
-        help="Compiled outputs to build: AllPrintings, AllIdentifiers, TcgplayerSkus, AllPrices, CompiledList, Keywords, CardTypes, Meta, SetList, AtomicCards, Decks, EnumValues. Defaults to all.",
+        help="Compiled outputs to build: AllPrintings, AllIdentifiers, TcgplayerSkus, CardmarketIdentifiers, AllPrices, CompiledList, Keywords, CardTypes, Meta, SetList, AtomicCards, Decks, EnumValues. Defaults to all.",
     )
     pipeline_group.add_argument(
         "--export",

--- a/mtgjson5/build/assemble.py
+++ b/mtgjson5/build/assemble.py
@@ -1111,6 +1111,114 @@ class TcgplayerSkusAssembler(Assembler):
         return dict(self.iter_skus())
 
 
+class CardmarketIdentifiersAssembler(Assembler):
+    """Assembles CardmarketIdentifiers.json - decodes Cardmarket expansion/product IDs.
+
+    Cardmarket's public download files only reference an opaque ``idExpansion``
+    and ``idProduct`` per product. This output maps those IDs to expansion
+    names, MTGJSON set codes, collector numbers, and MTGJSON UUIDs.
+    """
+
+    def _load_catalog(self) -> pl.DataFrame | None:
+        """Load the raw Cardmarket product catalog from the pipeline cache."""
+        from mtgjson5 import constants
+        from mtgjson5.utils import LOGGER
+
+        catalog_path = constants.CACHE_PATH / "mkm_cards.parquet"
+        if not catalog_path.exists():
+            LOGGER.warning(
+                "Cardmarket catalog not found (mkm_cards.parquet missing). CardmarketIdentifiers.json will be empty."
+            )
+            return None
+        try:
+            return pl.read_parquet(catalog_path)
+        except Exception as e:
+            LOGGER.warning(f"Failed to read Cardmarket catalog: {e}")
+            return None
+
+    def _load_uuid_map(self) -> dict[str, list[str]]:
+        """Build mcmId -> sorted UUID list from GLOBAL_CACHE or disk fallback."""
+        from mtgjson5 import constants
+        from mtgjson5.data import GLOBAL_CACHE
+
+        uuid_lf = GLOBAL_CACHE.cardmarket_to_uuid_lf
+        if uuid_lf is None:
+            path = constants.CACHE_PATH / "cardmarket_to_uuid.parquet"
+            if path.exists():
+                uuid_lf = pl.scan_parquet(path)
+        if uuid_lf is None:
+            return {}
+
+        df = uuid_lf.select(["mcmId", "uuid"]).collect()
+        uuid_map: dict[str, list[str]] = {}
+        for mcm_id, uuid in df.iter_rows():
+            if mcm_id is None or uuid is None:
+                continue
+            uuid_map.setdefault(str(mcm_id), []).append(uuid)
+        for uuids in uuid_map.values():
+            uuids.sort()
+        return uuid_map
+
+    def _build_expansion_set_codes(self) -> dict[int, list[str]]:
+        """Map Cardmarket expansion ID -> MTGJSON set codes via set metadata."""
+        set_codes_by_expansion: dict[int, list[str]] = {}
+        for code, meta in self.ctx.set_meta.items():
+            for key in ("mcmId", "mcmIdExtras"):
+                exp_id = meta.get(key)
+                if exp_id is not None:
+                    set_codes_by_expansion.setdefault(int(exp_id), []).append(code)
+        for codes in set_codes_by_expansion.values():
+            codes.sort()
+        return set_codes_by_expansion
+
+    def build(self) -> dict[str, dict[str, Any]]:
+        """Build CardmarketIdentifiers data with expansion and product maps."""
+        from mtgjson5.utils import LOGGER
+
+        catalog = self._load_catalog()
+        if catalog is None or catalog.is_empty():
+            return {"expansions": {}, "products": {}}
+
+        uuid_map = self._load_uuid_map()
+        set_codes_by_expansion = self._build_expansion_set_codes()
+
+        expansions: dict[str, dict[str, Any]] = {}
+        expansion_rows = (
+            catalog.select(["expansionId", "expansionName"])
+            .unique()
+            .filter(pl.col("expansionId").is_not_null())
+            .sort("expansionId")
+        )
+        for row in expansion_rows.iter_rows(named=True):
+            exp_id = int(row["expansionId"])
+            expansions[str(exp_id)] = {
+                "name": row["expansionName"],
+                "setCodes": set_codes_by_expansion.get(exp_id, []),
+            }
+
+        products: dict[str, dict[str, Any]] = {}
+        product_rows = (
+            catalog.select(["mcmId", "name", "number", "expansionId"])
+            .unique(subset=["mcmId"], keep="first")
+            .filter(pl.col("mcmId").is_not_null())
+            .sort("mcmId")
+        )
+        for row in product_rows.iter_rows(named=True):
+            product_id = str(int(row["mcmId"]))
+            entry: dict[str, Any] = {"name": row["name"]}
+            if row["number"]:
+                entry["number"] = row["number"]
+            if row["expansionId"] is not None:
+                entry["expansionId"] = int(row["expansionId"])
+            uuids = uuid_map.get(product_id)
+            if uuids:
+                entry["uuids"] = uuids
+            products[product_id] = entry
+
+        LOGGER.info(f"Built CardmarketIdentifiers with {len(expansions)} expansions and {len(products)} products")
+        return {"expansions": expansions, "products": products}
+
+
 class TableAssembler:
     """Build normalized relational tables from card data."""
 
@@ -1732,6 +1840,7 @@ class CompiledListAssembler:
         "AllPrintings",
         "AtomicCards",
         "CardTypes",
+        "CardmarketIdentifiers",
         "CompiledList",
         "DeckList",
         "EnumValues",

--- a/mtgjson5/build/context.py
+++ b/mtgjson5/build/context.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from .assemble import (
         AllIdentifiersAssembler,
         AtomicCardsAssembler,
+        CardmarketIdentifiersAssembler,
         DeckAssembler,
         DeckListAssembler,
         SetAssembler,
@@ -693,6 +694,13 @@ class AssemblyContext:
 
         return AllIdentifiersAssembler(self)
 
+    @cached_property
+    def cardmarket_identifiers(self) -> CardmarketIdentifiersAssembler:
+        """Assembler for CardmarketIdentifiers.json."""
+        from .assemble import CardmarketIdentifiersAssembler
+
+        return CardmarketIdentifiersAssembler(self)
+
     def release_card_data(self) -> None:
         """Free card/token DataFrames and assembler caches.
 
@@ -711,6 +719,7 @@ class AssemblyContext:
             "set_list",
             "tcgplayer_skus",
             "all_identifiers",
+            "cardmarket_identifiers",
         ):
             self.__dict__.pop(attr, None)
         gc.collect()

--- a/mtgjson5/build/formats/json.py
+++ b/mtgjson5/build/formats/json.py
@@ -18,6 +18,7 @@ from mtgjson5.models.compiled import EnumValuesFile
 from mtgjson5.models.files import (
     AllPrintingsFile,
     AtomicCardsFile,
+    CardmarketIdentifiersFile,
     CardTypesFile,
     CompiledListFile,
     DeckListFile,
@@ -45,7 +46,7 @@ _ATOMIC_OUTPUTS = {f"{fmt.title()}Atomic" for fmt in _ATOMIC_FORMATS}
 _ASSEMBLY_GROUPS: list[tuple[str, list[str]]] = [
     ("A", ["AllPrintings", "FormatPrintings"]),
     ("D", ["DeckFiles", "DeckList"]),
-    ("F", ["AllIdentifiers", "EnumValues", "Keywords", "CardTypes"]),
+    ("F", ["AllIdentifiers", "EnumValues", "Keywords", "CardTypes", "CardmarketIdentifiers"]),
     ("B", ["AtomicCards", "FormatAtomics"]),
     ("C", ["SetFiles", "SetList", "Meta", "CompiledList"]),
     ("E", ["TcgplayerSkus"]),
@@ -341,6 +342,13 @@ class JsonOutputBuilder:
         data = self.ctx.tcgplayer_skus.build()
         file = TcgplayerSkusFile.with_meta(data, self.ctx.meta)
         file.write(output_path)
+        return file
+
+    def write_cardmarket_identifiers(self, output_path: pathlib.Path) -> CardmarketIdentifiersFile:
+        """Build CardmarketIdentifiers.json."""
+        data = self.ctx.cardmarket_identifiers.build()
+        file = CardmarketIdentifiersFile.with_meta(data, self.ctx.meta)
+        file.write(output_path, pretty=self.ctx.pretty)
         return file
 
     def _write_tcgplayer_skus_streaming(self, output_path: pathlib.Path) -> int:
@@ -801,6 +809,12 @@ class JsonOutputBuilder:
         self.ctx.__dict__.pop("tcgplayer_skus", None)
         gc.collect()
         profiler.checkpoint("assembly/tcgplayer_skus")
+
+        # Build CardmarketIdentifiers.json
+        if should_build("CardmarketIdentifiers"):
+            LOGGER.info("Building CardmarketIdentifiers.json...")
+            cardmarket_file = self.write_cardmarket_identifiers(output_dir / "CardmarketIdentifiers.json")
+            results["CardmarketIdentifiers"] = sum(len(v) for v in cardmarket_file.data.values())
 
         # Build Keywords.json
         if should_build("Keywords"):

--- a/mtgjson5/consts/outputs.py
+++ b/mtgjson5/consts/outputs.py
@@ -27,6 +27,7 @@ COMPILED_OUTPUT_NAMES: Final[frozenset[str]] = frozenset(
         "AllDeckFiles",
         "AllSetFiles",
         "CardTypes",
+        "CardmarketIdentifiers",
         "CompiledList",
         "DeckList",
         "Keywords",

--- a/mtgjson5/models/files.py
+++ b/mtgjson5/models/files.py
@@ -115,6 +115,25 @@ class TcgplayerSkusFile(RecordFileBase):
         return self.data.get(uuid)
 
 
+class CardmarketIdentifiersFile(RecordFileBase):
+    """CardmarketIdentifiers.json: { meta, data: { expansions, products } }
+
+    Decodes the opaque IDs in Cardmarket's public download files:
+    - expansions: { idExpansion: { name, setCodes } }
+    - products: { idProduct: { name, number?, expansionId, uuids? } }
+    """
+
+    data: dict[str, dict[str, dict[str, Any]]]
+
+    def get_expansion(self, expansion_id: str) -> dict[str, Any] | None:
+        """Get expansion info by Cardmarket expansion ID."""
+        return self.data.get("expansions", {}).get(expansion_id)
+
+    def get_product(self, product_id: str) -> dict[str, Any] | None:
+        """Get product info by Cardmarket product ID."""
+        return self.data.get("products", {}).get(product_id)
+
+
 class KeywordsFile(RecordFileBase):
     """Keywords.json: { meta, data: { abilityWords, keywordAbilities, keywordActions } }
 
@@ -285,6 +304,7 @@ class Files:
     AllIdentifiersFile = AllIdentifiersFile
     AllPricesFile = AllPricesFile
     TcgplayerSkusFile = TcgplayerSkusFile
+    CardmarketIdentifiersFile = CardmarketIdentifiersFile
     SetListFile = SetListFile
     DeckListFile = DeckListFile
     IndividualSetFile = IndividualSetFile
@@ -304,6 +324,7 @@ FILE_MODEL_REGISTRY: list[type[BaseModel]] = [
     AllIdentifiersFile,
     AllPricesFile,
     TcgplayerSkusFile,
+    CardmarketIdentifiersFile,
     SetListFile,
     DeckListFile,
     IndividualSetFile,

--- a/tests/mtgjson5/test_cardmarket_identifiers_assembler.py
+++ b/tests/mtgjson5/test_cardmarket_identifiers_assembler.py
@@ -1,0 +1,224 @@
+"""Tests for the CardmarketIdentifiers.json assembler."""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from mtgjson5 import constants
+from mtgjson5.build.assemble import CardmarketIdentifiersAssembler, CompiledListAssembler
+from mtgjson5.consts.outputs import COMPILED_OUTPUT_NAMES
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx(set_meta: dict | None = None):
+    meta = set_meta or {}
+
+    class FakeCtx:
+        parquet_dir = None
+        tokens_dir = None
+        set_meta: dict = meta
+        decks_df = None
+        sealed_df = None
+        booster_configs: dict = {}
+        token_products: dict = {}
+        keyword_data: dict = {}
+        card_type_data: dict = {}
+        super_types: list = []
+        planar_types: list = []
+
+    return FakeCtx()
+
+
+def _write_catalog(cache_dir, rows: list[dict]) -> None:
+    pl.DataFrame(
+        rows,
+        schema={
+            "mcmId": pl.Int64,
+            "mcmMetaId": pl.Int64,
+            "name": pl.String,
+            "number": pl.String,
+            "expansionId": pl.Int64,
+            "expansionName": pl.String,
+        },
+    ).write_parquet(cache_dir / "mkm_cards.parquet")
+
+
+def _write_uuid_map(cache_dir, rows: list[dict]) -> None:
+    pl.DataFrame(
+        rows,
+        schema={"uuid": pl.String, "mcmId": pl.String},
+    ).write_parquet(cache_dir / "cardmarket_to_uuid.parquet")
+
+
+@pytest.fixture
+def cache_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(constants, "CACHE_PATH", tmp_path)
+    from mtgjson5.data import GLOBAL_CACHE
+
+    monkeypatch.setattr(GLOBAL_CACHE, "cardmarket_to_uuid_lf", None)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# TestCardmarketIdentifiersAssembler
+# ---------------------------------------------------------------------------
+
+
+class TestCardmarketIdentifiersAssembler:
+    def test_builds_expansion_and_product_maps(self, cache_dir):
+        _write_catalog(
+            cache_dir,
+            [
+                {
+                    "mcmId": 287295,
+                    "mcmMetaId": 221432,
+                    "name": "Fall of the Titans",
+                    "number": "167",
+                    "expansionId": 1676,
+                    "expansionName": "Oath of the Gatewatch",
+                },
+            ],
+        )
+        _write_uuid_map(cache_dir, [{"uuid": "uuid-a", "mcmId": "287295"}])
+        set_meta = {"OGW": {"code": "OGW", "mcmId": 1676, "mcmName": "Oath of the Gatewatch"}}
+
+        result = CardmarketIdentifiersAssembler(_make_ctx(set_meta)).build()
+
+        assert result["expansions"] == {
+            "1676": {"name": "Oath of the Gatewatch", "setCodes": ["OGW"]},
+        }
+        assert result["products"] == {
+            "287295": {
+                "name": "Fall of the Titans",
+                "number": "167",
+                "expansionId": 1676,
+                "uuids": ["uuid-a"],
+            },
+        }
+
+    def test_extras_expansion_maps_via_mcm_id_extras(self, cache_dir):
+        _write_catalog(
+            cache_dir,
+            [
+                {
+                    "mcmId": 400001,
+                    "mcmMetaId": 300001,
+                    "name": "Garruk, Cursed Huntsman (V.2)",
+                    "number": "270",
+                    "expansionId": 3625,
+                    "expansionName": "Throne of Eldraine: Extras",
+                },
+            ],
+        )
+        set_meta = {"ELD": {"code": "ELD", "mcmId": 3624, "mcmIdExtras": 3625}}
+
+        result = CardmarketIdentifiersAssembler(_make_ctx(set_meta)).build()
+
+        assert result["expansions"]["3625"] == {
+            "name": "Throne of Eldraine: Extras",
+            "setCodes": ["ELD"],
+        }
+
+    def test_product_without_uuid_or_number_omits_fields(self, cache_dir):
+        _write_catalog(
+            cache_dir,
+            [
+                {
+                    "mcmId": 999,
+                    "mcmMetaId": None,
+                    "name": "Mystery Product",
+                    "number": "",
+                    "expansionId": 42,
+                    "expansionName": "Unknown Set",
+                },
+            ],
+        )
+
+        result = CardmarketIdentifiersAssembler(_make_ctx()).build()
+
+        assert result["products"]["999"] == {
+            "name": "Mystery Product",
+            "expansionId": 42,
+        }
+        assert result["expansions"]["42"] == {"name": "Unknown Set", "setCodes": []}
+
+    def test_multiple_uuids_are_sorted(self, cache_dir):
+        _write_catalog(
+            cache_dir,
+            [
+                {
+                    "mcmId": 100,
+                    "mcmMetaId": 1,
+                    "name": "Doubled Card",
+                    "number": "1",
+                    "expansionId": 7,
+                    "expansionName": "Some Set",
+                },
+            ],
+        )
+        _write_uuid_map(
+            cache_dir,
+            [
+                {"uuid": "uuid-b", "mcmId": "100"},
+                {"uuid": "uuid-a", "mcmId": "100"},
+            ],
+        )
+
+        result = CardmarketIdentifiersAssembler(_make_ctx()).build()
+
+        assert result["products"]["100"]["uuids"] == ["uuid-a", "uuid-b"]
+
+    def test_missing_catalog_returns_empty_maps(self, cache_dir):
+        result = CardmarketIdentifiersAssembler(_make_ctx()).build()
+
+        assert result == {"expansions": {}, "products": {}}
+
+    def test_output_keys_sorted_numerically(self, cache_dir):
+        _write_catalog(
+            cache_dir,
+            [
+                {
+                    "mcmId": 1000,
+                    "mcmMetaId": 1,
+                    "name": "B",
+                    "number": "2",
+                    "expansionId": 20,
+                    "expansionName": "Set B",
+                },
+                {
+                    "mcmId": 99,
+                    "mcmMetaId": 2,
+                    "name": "A",
+                    "number": "1",
+                    "expansionId": 3,
+                    "expansionName": "Set A",
+                },
+            ],
+        )
+
+        result = CardmarketIdentifiersAssembler(_make_ctx()).build()
+
+        assert list(result["products"]) == ["99", "1000"]
+        assert list(result["expansions"]) == ["3", "20"]
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestCardmarketIdentifiersRegistration:
+    def test_in_compiled_output_names(self):
+        assert "CardmarketIdentifiers" in COMPILED_OUTPUT_NAMES
+
+    def test_in_compiled_list(self):
+        assert "CardmarketIdentifiers" in CompiledListAssembler.COMPILED_FILES
+
+    def test_file_model_registered(self):
+        from mtgjson5.models.files import CardmarketIdentifiersFile, Files
+
+        assert Files.CardmarketIdentifiersFile is CardmarketIdentifiersFile


### PR DESCRIPTION
Closes #1271

Adds a new compiled output, `CardmarketIdentifiers.json`, that decodes the opaque IDs in Cardmarket's [public download files](https://www.cardmarket.com/en/Magic/Data) so consumers no longer need the Cardmarket API to interpret them.

## File shape

```json
{
  "meta": { "date": "...", "version": "..." },
  "data": {
    "expansions": { "1676": { "name": "Oath of the Gatewatch", "setCodes": ["OGW"] } },
    "products":   { "287295": { "name": "Fall of the Titans", "number": "109",
                                "expansionId": 1676, "uuids": ["692b35f6-..."] } }
  }
}
```

- `expansions`: Cardmarket `idExpansion` → expansion name + MTGJSON set codes (Extras expansions resolve to their parent set via `mcmIdExtras`)
- `products`: Cardmarket `idProduct` → product name (incl. V.1/V.2 variant tags), collector number, expansion id, and MTGJSON uuids
- `number` and `uuids` are omitted when unknown

## Implementation

- New `CardmarketIdentifiersAssembler` built from the existing pipeline caches (`mkm_cards.parquet` + `cardmarket_to_uuid.parquet`) — no new API calls
- Wired into assembly group F, `--outputs CardmarketIdentifiers`, `CompiledList`, and compression via `COMPILED_OUTPUT_NAMES`
- Degrades to empty maps with a logged warning when Cardmarket credentials/cache are absent (same behavior as `TcgplayerSkus`)

## Verification

Full local build: 673 expansions / 112,758 products (12.7 MB), 68% of expansions carry setCodes and 81.8% of products carry uuids (the gaps are Cardmarket-only groupings and non-singles). Issue example round-trips: product `287295` → Fall of the Titans, OGW #109, uuid matches AllIdentifiers. 9 new unit tests; full tox green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)