### PR TITLE
fix: read Cardmarket foil-only prices from trend-foil (#1719)

### DIFF
--- a/docs/prices.md
+++ b/docs/prices.md
@@ -117,6 +117,11 @@ with one row per `(productId, uuid, priceColumn, finish)`. This preserves
 separate finish-variant products without exposing partially inferred
 finish-specific identifiers in the public card model.
 
+A `(uuid, finish)` pair may map to more than one price column, because Cardmarket
+is inconsistent about where it stores a foil-only product's price: most use
+`trend-foil`, a few older ones only use `trend`. `MCM_COLUMN_PRIORITY` resolves
+these, taking the value from the most specific column that carries a price.
+
 ## PolarsPriceBuilder (`price_builder.py`)
 
 The main orchestrator class that coordinates provider fetching and delegates to the archive, S3, and writer modules.
@@ -171,7 +176,7 @@ def build_prices(self, parquet_output_dir=None, write_json=True):
 - **Source**: `paper` | **Currency**: `EUR`
 - **Pricing**: Retail + buylist
 - **Method**: Sequential requests via mkmsdk (rate limited to 1 request per 1.5s)
-- **Finish mapping**: Price fields are joined through finish-specific product identity. Verified variant families use expansion-scoped profiles; ambiguous values are omitted.
+- **Finish mapping**: Price fields are joined through finish-specific product identity. Verified variant families use expansion-scoped profiles; ambiguous values are omitted. Foil-only and etched-only products read `trend-foil` first and fall back to `trend`.
 
 ### Card Kingdom (`providers/cardkingdom/provider.py`)
 

--- a/mtgjson5/build/prices/price_builder.py
+++ b/mtgjson5/build/prices/price_builder.py
@@ -45,6 +45,7 @@ from mtgjson5.providers import (
     ManapoolPriceProvider,
     TCGPlayerPriceProvider,
 )
+from mtgjson5.providers.cardmarket.provider import MCM_COLUMN_PRIORITY
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -663,9 +664,15 @@ class PolarsPriceBuilder:
         return self._map_cardmarket_frames(raw, pl.read_parquet(mapping_path))
 
     def _map_cardmarket_frames(self, raw: pl.DataFrame, mapping: pl.DataFrame) -> pl.DataFrame:
-        """Map Cardmarket price fields using explicit product/finish identity."""
+        """Map Cardmarket price fields using explicit product/finish identity.
+
+        A uuid/finish pair can be mapped to both price columns when Cardmarket is
+        inconsistent about where it stores the price (foil-only products mostly use
+        trend-foil, a few only use trend). Columns are resolved by MCM_COLUMN_PRIORITY
+        so the more specific column wins whenever both carry a price.
+        """
         frames: list[pl.DataFrame] = []
-        for price_column in ("trend", "trend_foil"):
+        for price_column, priority in MCM_COLUMN_PRIORITY.items():
             field_mapping = mapping.filter(pl.col("priceColumn") == price_column)
             if field_mapping.is_empty():
                 continue
@@ -681,6 +688,7 @@ class PolarsPriceBuilder:
                     pl.col("finish"),
                     pl.col(price_column).alias("price"),
                     pl.lit("EUR").alias("currency"),
+                    pl.lit(priority).alias("columnPriority"),
                 )
             )
             if not mapped.is_empty():
@@ -688,9 +696,15 @@ class PolarsPriceBuilder:
 
         if not frames:
             return pl.DataFrame(schema=PRICE_SCHEMA)
-        return pl.concat(frames).unique(
-            subset=["uuid", "date", "source", "provider", "price_type", "finish"],
-            keep="first",
+        return (
+            pl.concat(frames)
+            .sort("columnPriority")
+            .unique(
+                subset=["uuid", "date", "source", "provider", "price_type", "finish"],
+                keep="first",
+                maintain_order=True,
+            )
+            .drop("columnPriority")
         )
 
     def _map_ck_raw(self, raw_path: Path, uuid_path: Path) -> pl.DataFrame:

--- a/mtgjson5/pipeline/stages/output.py
+++ b/mtgjson5/pipeline/stages/output.py
@@ -493,11 +493,31 @@ def _build_mcm_price_mapping_cache(ctx: PipelineContext, lf: pl.LazyFrame) -> No
         if not explicit_pairs.is_empty():
             base = base.join(explicit_pairs, on=["uuid", "productId"], how="anti")
 
-        single = base.filter(pl.col("finishes").list.len() == 1).select(
+        single_nonfoil = base.filter(
+            (pl.col("finishes").list.len() == 1) & pl.col("finishes").list.contains("nonfoil")
+        ).select(
             "uuid",
             "productId",
             pl.lit("trend").alias("priceColumn"),
-            pl.col("finishes").list.first().replace({"nonfoil": "normal"}).alias("finish"),
+            pl.lit("normal").alias("finish"),
+        )
+        # Foil-only and etched-only products usually carry their price in trend-foil,
+        # but a few older ones only populate trend. Emit both columns; the price
+        # mapper prefers trend_foil and falls back to trend when it is missing.
+        single_foil_base = base.filter(
+            (pl.col("finishes").list.len() == 1) & ~pl.col("finishes").list.contains("nonfoil")
+        )
+        single_foil = single_foil_base.select(
+            "uuid",
+            "productId",
+            pl.lit("trend_foil").alias("priceColumn"),
+            pl.col("finishes").list.first().alias("finish"),
+        )
+        single_foil_fallback = single_foil_base.select(
+            "uuid",
+            "productId",
+            pl.lit("trend").alias("priceColumn"),
+            pl.col("finishes").list.first().alias("finish"),
         )
         normal = base.filter((pl.col("finishes").list.len() > 1) & pl.col("finishes").list.contains("nonfoil")).select(
             "uuid",
@@ -515,7 +535,11 @@ def _build_mcm_price_mapping_cache(ctx: PipelineContext, lf: pl.LazyFrame) -> No
             pl.lit("trend_foil").alias("priceColumn"),
             pl.lit("foil").alias("finish"),
         )
-        frames.extend(frame for frame in [single, normal, normal_foil] if not frame.is_empty())
+        frames.extend(
+            frame
+            for frame in [single_nonfoil, single_foil, single_foil_fallback, normal, normal_foil]
+            if not frame.is_empty()
+        )
 
         if frames:
             mapping = pl.concat(frames).unique()

--- a/mtgjson5/providers/cardmarket/provider.py
+++ b/mtgjson5/providers/cardmarket/provider.py
@@ -26,6 +26,13 @@ from mtgjson5.utils import generate_entity_mapping
 
 LOGGER = logging.getLogger(__name__)
 
+# Cardmarket price columns, most specific first. A uuid/finish pair mapped to more
+# than one column takes the value from the earliest column that carries a price.
+MCM_COLUMN_PRIORITY = {
+    "trend_foil": 0,
+    "trend": 1,
+}
+
 
 def _load_mcm_finishes_from_parquet() -> dict[str, set[Any]]:
     """Load mcmId → finishes mapping from parquet cache written during pipeline."""
@@ -487,7 +494,14 @@ class CardMarketProvider:
         finish_mapping_path = constants.CACHE_PATH / "mcm_price_mappings.parquet"
         if finish_mapping_path.exists():
             finish_mappings = pl.read_parquet(finish_mapping_path)
-            for row in finish_mappings.iter_rows(named=True):
+            # A uuid/finish pair can map to more than one price column; take the
+            # value from the most specific column that Cardmarket actually filled.
+            rows = sorted(
+                finish_mappings.iter_rows(named=True),
+                key=lambda row: MCM_COLUMN_PRIORITY.get(str(row["priceColumn"]), len(MCM_COLUMN_PRIORITY)),
+            )
+            resolved: set[tuple[str, str]] = set()
+            for row in rows:
                 product_id = str(row["productId"])
                 price_column = str(row["priceColumn"])
                 finish = str(row["finish"])
@@ -495,6 +509,9 @@ class CardMarketProvider:
                 if price is None:
                     continue
                 uuid = str(row["uuid"])
+                if (uuid, finish) in resolved:
+                    continue
+                resolved.add((uuid, finish))
                 entry = today_dict.setdefault(
                     uuid,
                     MtgjsonPriceEntry("paper", "cardmarket", self.today_date, "EUR"),

--- a/tests/mtgjson5/test_cardmarket_price_mapping.py
+++ b/tests/mtgjson5/test_cardmarket_price_mapping.py
@@ -96,7 +96,9 @@ def test_finish_mapping_is_explicit_and_conservative(tmp_path, monkeypatch):
     assert not mapping.filter(pl.col("uuid") == "ambiguous").height
     assert set(mapping.filter(pl.col("uuid") == "normal-foil")["finish"]) == {"normal", "foil"}
     assert set(mapping.filter(pl.col("uuid") == "foil-only")["finish"]) == {"foil"}
+    assert set(mapping.filter(pl.col("uuid") == "foil-only")["priceColumn"]) == {"trend_foil", "trend"}
     assert set(mapping.filter(pl.col("uuid") == "etched-only")["finish"]) == {"etched"}
+    assert set(mapping.filter(pl.col("uuid") == "etched-only")["priceColumn"]) == {"trend_foil", "trend"}
     assert set(mapping.filter(pl.col("uuid") == "all-three")["finish"]) == {"normal"}
 
 
@@ -141,10 +143,51 @@ def test_ordinary_and_single_finish_price_fields(tmp_path, monkeypatch):
     }
 
     assert by_uuid["normal-foil"] == {"normal": 10.0, "foil": 11.0}
-    assert by_uuid["foil-only"] == {"foil": 20.0}
-    assert by_uuid["etched-only"] == {"etched": 30.0}
+    assert by_uuid["foil-only"] == {"foil": 21.0}
+    assert by_uuid["etched-only"] == {"etched": 31.0}
     assert by_uuid["all-three"] == {"normal": 40.0}
     assert "ambiguous" not in by_uuid
+
+
+def test_foil_only_cards_priced_from_trend_foil(tmp_path, monkeypatch):
+    """Cardmarket stores foil-only and etched-only prices in trend-foil, leaving
+    trend empty. Reading trend for those products drops the price entirely (#1719)."""
+    mapping = _build_mapping(tmp_path, monkeypatch)
+    raw = pl.DataFrame(
+        {
+            "productId": ["101", "102"],
+            "trend": [None, None],
+            "trend_foil": [1334.47, 61.78],
+        },
+        schema={"productId": pl.String, "trend": pl.Float64, "trend_foil": pl.Float64},
+    )
+    prices = PolarsPriceBuilder()._map_cardmarket_frames(raw, mapping)
+    by_uuid = {
+        uuid: dict(zip(group["finish"], group["price"], strict=False)) for (uuid,), group in prices.group_by("uuid")
+    }
+
+    assert by_uuid["foil-only"] == {"foil": 1334.47}
+    assert by_uuid["etched-only"] == {"etched": 61.78}
+
+
+def test_foil_only_cards_fall_back_to_trend(tmp_path, monkeypatch):
+    """A handful of older foil-only products only populate trend."""
+    mapping = _build_mapping(tmp_path, monkeypatch)
+    raw = pl.DataFrame(
+        {
+            "productId": ["101", "102"],
+            "trend": [4.5, 6.5],
+            "trend_foil": [None, None],
+        },
+        schema={"productId": pl.String, "trend": pl.Float64, "trend_foil": pl.Float64},
+    )
+    prices = PolarsPriceBuilder()._map_cardmarket_frames(raw, mapping)
+    by_uuid = {
+        uuid: dict(zip(group["finish"], group["price"], strict=False)) for (uuid,), group in prices.group_by("uuid")
+    }
+
+    assert by_uuid["foil-only"] == {"foil": 4.5}
+    assert by_uuid["etched-only"] == {"etched": 6.5}
 
 
 def test_all_three_finishes_when_separate_product_identity_is_known():


### PR DESCRIPTION
Fixes #1719.

## Root cause

Cardmarket's price guide stores a foil-only product's price in `trend-foil` and leaves `trend` at `0`. Straight from today's `price_guide_1.json` for the three products named in the issue:

```
292648  Sol Ring          trend=0  trend-foil=1334.47
292637  Cloudstone Curio  trend=0  trend-foil=61.78
292643  Mox Opal          trend=0  trend-foil=1055.78
```

The finish-specific mapping added in #1681 (Aug 27) built its single-finish rule as "one finish, therefore read `trend`":

```python
single = base.filter(pl.col("finishes").list.len() == 1).select(
    "uuid",
    "productId",
    pl.lit("trend").alias("priceColumn"),
    pl.col("finishes").list.first().replace({"nonfoil": "normal"}).alias("finish"),
)
```

MPS cards are `finishes: ["foil"]`, so the mapper looked in `trend`, found nothing (`fetch_raw_prices` turns the `0` into `None`), and emitted no row at all. The code #1681 replaced read `trend_foil` for every product unconditionally, which is why the prices disappeared on the first build after that commit and not before. Timing matches the Aug 30th the issue reports.

## Scope — this is wider than MPS

Joining the Scryfall bulk dump against the live price guide, grouped by MTGJSON finishes and which columns Cardmarket actually populates:

| printings | finishes | columns populated |
|---:|---|---|
| 47,918 | foil, nonfoil | trend + trend-foil |
| 28,765 | nonfoil | trend only |
| **8,844** | **foil** | **trend-foil only** |
| 8,576 | nonfoil | trend + trend-foil |
| 1,841 | foil | trend + trend-foil |
| 1,449 | foil, nonfoil | trend only |
| **459** | **etched** | **trend-foil only** |
| 433 | etched | trend + trend-foil |
| 9 | foil | trend only |

The bolded rows — 9,303 printings — got no Cardmarket price at all. The 1,841 + 433 rows that populate both columns were getting `trend` written to `eur_foil`, i.e. the wrong number rather than no number.

## Fix

Foil-only and etched-only products map to `trend_foil`, with `trend` kept as a fallback. That fallback earns its place: the 9 printings in the last row (`7ed 131★ Duress`, `plg21 J1 Orb of Dragonkind`, ...) only populate `trend`, so reading `trend_foil` alone would trade one regression for another.

Because a `(uuid, finish)` pair can now reach two columns, resolution order is defined once in `MCM_COLUMN_PRIORITY` (Cardmarket provider) and both consumers honour it:

- `PolarsPriceBuilder._map_cardmarket_frames` sorts by priority before its existing dedupe
- `CardMarketProvider.generate_today_price_dict` sorts rows and skips a `(uuid, finish)` a higher-priority column already resolved

H1R is untouched: its expansion-scoped profile rows are anti-joined out of `base` before the single-finish branch runs, so `4275`'s `trend → foil` / `trend → etched` mapping still applies.

## Verification

Replayed the real `_build_mcm_price_mapping_cache` → `_map_cardmarket_frames` path over the full Scryfall `default_cards` dump (99,497 printings with an `mcmId`) joined with the live Cardmarket price guide, on master and on this branch:

| | before | after |
|---|---:|---:|
| MPS printings priced | 0 / 54 | 54 / 54 |
| foil/etched-only printings priced | 2,283 | 11,586 |
| total Cardmarket price points | 137,340 | 146,643 |

The three cards from the issue resolve to `eur_foil` of 1334.47, 61.78 and 1055.78 — matching the guide.

## Tests

- `test_ordinary_and_single_finish_price_fields` updated: a foil-only product with both columns now takes `trend_foil`'s value, which is the correct one
- `test_foil_only_cards_priced_from_trend_foil` — new, the MPS shape (`trend` null, `trend-foil` set)
- `test_foil_only_cards_fall_back_to_trend` — new, guards the fallback for the 9 old products
- `test_finish_mapping_is_explicit_and_conservative` asserts both columns are emitted for single-finish foil/etched cards

Full suite, ruff and mypy pass.

## Left alone deliberately

Cards with `["etched", "foil", "nonfoil"]` (245 printings) still receive only a `normal` price, and `["etched", "nonfoil"]` likewise. That is pre-existing #1681 behavior and needs per-product identity to resolve correctly, so it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkmnhzmGF7GpbH2UW4H4Ry
