### PR TITLE
fix: never publish a partial TCGPlayer catalog (#1721)

### DIFF
--- a/mtgjson5/data/cache.py
+++ b/mtgjson5/data/cache.py
@@ -429,12 +429,28 @@ class GlobalCache:
                 self.tcg_skus_lf = self._tcg_skus_future.result()
                 LOGGER.info("TCGPlayer SKU fetch complete")
             except Exception as e:
-                LOGGER.warning(f"Failed to fetch TCGPlayer SKUs: {e}")
-                from mtgjson5.providers.tcgplayer.models import PRODUCT_SCHEMA
-
-                self.tcg_skus_lf = pl.DataFrame(schema=cast("dict", PRODUCT_SCHEMA)).lazy()
+                LOGGER.error(f"Failed to fetch TCGPlayer SKUs: {e}")
+                self.tcg_skus_lf = self._last_good_tcg_skus()
             finally:
                 self._tcg_skus_future = None
+
+    def _last_good_tcg_skus(self) -> pl.LazyFrame:
+        """Return the previous build's TCG catalog, or an empty frame.
+
+        The fetch never overwrites ``tcg_skus.parquet`` with a partial catalog,
+        so whatever is on disk is a complete catalog from an earlier run. Reusing
+        it costs a day of freshness; the alternative drops every SKU for tens of
+        thousands of cards.
+        """
+        cache_path = self.cache_path / "tcg_skus.parquet"
+        if cache_path.exists():
+            LOGGER.warning(f"Falling back to the previous TCG catalog at {cache_path}")
+            return pl.scan_parquet(cache_path)
+
+        from mtgjson5.providers.tcgplayer.models import PRODUCT_SCHEMA
+
+        LOGGER.error("No previous TCG catalog available; TCGPlayer SKUs will be empty")
+        return pl.DataFrame(schema=cast("dict", PRODUCT_SCHEMA)).lazy()
 
     def _dump_and_reload_as_lazy(self) -> None:
         """

--- a/mtgjson5/providers/tcgplayer/provider.py
+++ b/mtgjson5/providers/tcgplayer/provider.py
@@ -13,6 +13,7 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 import aiohttp
 import polars as pl
@@ -20,12 +21,20 @@ import polars as pl
 from mtgjson5 import constants
 from mtgjson5.mtgjson_config import MtgjsonConfig
 
+from .models import PRODUCT_SCHEMA
+
 LOGGER = logging.getLogger(__name__)
 
 PRODUCTS_PER_PAGE = 100
 CONCURRENT_REQUESTS = 75
 MAX_RETRIES = 3
 RETRY_DELAY = 2.0
+MAX_RATE_LIMIT_WAITS = 8
+# Pages that still failed after the main pass get a second, gentler sweep.
+RETRY_PASS_CONCURRENCY = 4
+# A live catalog shifts under offset pagination, so require near-completeness
+# rather than an exact match against the up-front totalItems.
+MIN_COMPLETENESS = 0.98
 NEAR_MINT_CONDITION = 1
 ENGLISH_LANGUAGE = 1
 NON_FOIL_PRINTING = 1
@@ -49,6 +58,15 @@ SEALED_PRODUCT_TYPES = [
 ALL_PRODUCT_TYPES = ",".join(["Cards", *SEALED_PRODUCT_TYPES])
 
 ProgressCallback = Callable[[int, int, str], None]
+
+
+class TcgPlayerIncompleteFetchError(RuntimeError):
+    """Raised when the TCGPlayer catalog could not be fetched in full.
+
+    A partial catalog silently drops every SKU for the products that went
+    missing, so callers must treat this as a failed fetch and fall back to the
+    previous good data rather than publishing the truncated result.
+    """
 
 
 @dataclass
@@ -163,13 +181,24 @@ class TcgPlayerClient:
         if self._session is None:
             raise RuntimeError("Session not initialized")
 
-        last_error = None
-        for attempt in range(MAX_RETRIES):
+        last_error: Exception | None = None
+        attempt = 0
+        rate_limit_waits = 0
+        # Waiting out a 429 is not a failed attempt, so it gets its own budget.
+        # Sharing one counter meant three consecutive rate limits abandoned the
+        # page even though the API never actually errored.
+        while attempt < MAX_RETRIES:
             try:
                 async with self._session.get(url, headers=headers) as resp:
                     if resp.status == 429:
-                        retry_after = float(resp.headers.get("Retry-After", RETRY_DELAY * (attempt + 1)))
-                        LOGGER.warning(f"Rate limited, waiting {retry_after}s")
+                        if rate_limit_waits >= MAX_RATE_LIMIT_WAITS:
+                            last_error = aiohttp.ClientError(
+                                f"Still rate limited after {rate_limit_waits} waits for {endpoint}"
+                            )
+                            break
+                        rate_limit_waits += 1
+                        retry_after = float(resp.headers.get("Retry-After", RETRY_DELAY * rate_limit_waits))
+                        LOGGER.warning(f"Rate limited, waiting {retry_after}s ({endpoint})")
                         await asyncio.sleep(retry_after)
                         continue
                     resp.raise_for_status()
@@ -177,9 +206,10 @@ class TcgPlayerClient:
                     return result
             except (TimeoutError, aiohttp.ClientError) as e:
                 last_error = e
-                if attempt < MAX_RETRIES - 1:
-                    await asyncio.sleep(RETRY_DELAY * (attempt + 1))
-                    LOGGER.debug(f"Retry {attempt + 1}/{MAX_RETRIES} for {endpoint}: {e}")
+                attempt += 1
+                if attempt < MAX_RETRIES:
+                    LOGGER.debug(f"Retry {attempt}/{MAX_RETRIES} for {endpoint}: {e}")
+                    await asyncio.sleep(RETRY_DELAY * attempt)
 
         raise last_error or aiohttp.ClientError(f"Failed after {MAX_RETRIES} retries")
 
@@ -239,23 +269,7 @@ class TCGProvider:
         Streams results to parquet incrementally using part files.
         Returns LazyFrame of final combined output.
         """
-        empty_schema = {
-            "productId": pl.Int64(),
-            "name": pl.String(),
-            "cleanName": pl.String(),
-            "groupId": pl.Int64(),
-            "url": pl.String(),
-            "skus": pl.List(
-                pl.Struct(
-                    {
-                        "skuId": pl.Int64(),
-                        "languageId": pl.Int64(),
-                        "printingId": pl.Int64(),
-                        "conditionId": pl.Int64(),
-                    }
-                )
-            ),
-        }
+        empty_schema = cast("dict", PRODUCT_SCHEMA)
 
         if not self.configs:
             LOGGER.warning("No TCGPlayer API keys configured")
@@ -279,9 +293,9 @@ class TCGProvider:
             total_items = await clients[0].get_total_products(product_types=self.product_types)
 
             if total_items == 0:
-                LOGGER.info("No TCGPlayer products found")
-                pl.DataFrame(schema=empty_schema).write_parquet(self.output_path)
-                return pl.scan_parquet(self.output_path)
+                # Credentials worked but the catalog came back empty, which is an
+                # upstream failure rather than a real answer.
+                raise TcgPlayerIncompleteFetchError("TCGPlayer reported 0 products for the requested product types")
 
             # Calculate pagination
             offsets = list(range(0, total_items, PRODUCTS_PER_PAGE))
@@ -294,116 +308,78 @@ class TCGProvider:
                 offsets_per_client[i % len(clients)].append(offset)
 
             # Fetch with streaming to part files (pass authenticated clients)
-            part_files = await self._fetch_with_streaming_clients(clients, offsets_per_client, total_pages)
+            part_files, fetched = await self._fetch_with_streaming_clients(clients, offsets_per_client, total_pages)
+
+            if fetched < total_items * MIN_COMPLETENESS:
+                self._discard_parts(part_files)
+                raise TcgPlayerIncompleteFetchError(
+                    f"TCGPlayer returned {fetched:,} of {total_items:,} products "
+                    f"({fetched / total_items:.1%}); refusing to publish a truncated catalog"
+                )
 
             # Combine part files
             return await self._combine_part_files(part_files)
 
-    async def _fetch_with_streaming(self, offsets_per_client: list[list[int]], total_pages: int) -> list[Path]:
-        """Fetch products in parallel, streaming to part files."""
-        part_files: list[Path] = []
-        part_counter = 0
-        buffer: list[dict] = []
-        lock = asyncio.Lock()
-        completed = 0
+    @staticmethod
+    def _parse_products(resp: dict[str, object]) -> list[dict]:
+        """Normalize a catalog/products response into part-file rows."""
+        products_raw = resp.get("results", [])
+        products = products_raw if isinstance(products_raw, list) else []
+        return [
+            {
+                "productId": product["productId"],
+                "name": product.get("name", ""),
+                "cleanName": product.get("cleanName", ""),
+                "groupId": product.get("groupId"),
+                "url": product.get("url", ""),
+                "skus": [
+                    {
+                        "skuId": sku["skuId"],
+                        "languageId": sku["languageId"],
+                        "printingId": sku["printingId"],
+                        "conditionId": sku["conditionId"],
+                    }
+                    for sku in (product.get("skus", []) if isinstance(product.get("skus", []), list) else [])
+                ],
+            }
+            for product in products
+        ]
 
-        async def flush_buffer() -> None:
-            nonlocal buffer, part_counter
-            if not buffer:
-                return
-
-            to_write = buffer
-            buffer = []
-
-            part_path = self.output_path.parent / f".tcg_part_{part_counter:04d}.parquet"
-            part_counter += 1
-            pl.DataFrame(to_write).write_parquet(part_path)
-            part_files.append(part_path)
-            LOGGER.debug(f"Flushed {len(to_write)} products to {part_path}")
-
-        async def fetch_client_pages(config: TcgPlayerConfig, client_offsets: list[int]) -> None:
-            nonlocal completed, buffer
-            async with TcgPlayerClient(config) as client:
-                for offset in client_offsets:
-                    try:
-                        resp = await client.get_products_page(
-                            offset=offset,
-                            include_skus=True,
-                            product_types=self.product_types,
-                        )
-                        products_raw = resp.get("results", [])
-                        products = products_raw if isinstance(products_raw, list) else []
-                        page_products = [
-                            {
-                                "productId": product["productId"],
-                                "name": product.get("name", ""),
-                                "cleanName": product.get("cleanName", ""),
-                                "groupId": product.get("groupId"),
-                                "url": product.get("url", ""),
-                                "skus": [
-                                    {
-                                        "skuId": sku["skuId"],
-                                        "languageId": sku["languageId"],
-                                        "printingId": sku["printingId"],
-                                        "conditionId": sku["conditionId"],
-                                    }
-                                    for sku in (
-                                        product.get("skus", []) if isinstance(product.get("skus", []), list) else []
-                                    )
-                                ],
-                            }
-                            for product in products
-                        ]
-
-                        async with lock:
-                            buffer.extend(page_products)
-                            completed += 1
-                            if len(buffer) >= self.flush_threshold:
-                                await flush_buffer()
-                            if self.on_progress:
-                                self.on_progress(completed, total_pages, f"offset={offset}")
-                    except Exception as e:
-                        LOGGER.warning(f"Failed offset {offset}: {e}")
-                        async with lock:
-                            completed += 1
-
-        try:
-            # Run all clients in parallel
-            await asyncio.gather(
-                *[
-                    fetch_client_pages(config, client_offsets)
-                    for config, client_offsets in zip(self.configs, offsets_per_client, strict=False)
-                ]
-            )
-
-            # Final flush
-            async with lock:
-                await flush_buffer()
-
-            LOGGER.info(f"TCGPlayer fetch complete: {len(part_files)} part files")
-            return part_files
-
-        except Exception as e:
-            LOGGER.error(f"Error during TCGPlayer fetch: {e}")
-            raise
+    def _discard_parts(self, part_files: list[Path]) -> None:
+        """Delete part files from an aborted fetch."""
+        for part_file in part_files:
+            try:
+                part_file.unlink()
+            except OSError as e:
+                LOGGER.warning(f"Failed to delete {part_file}: {e}")
+        part_files.clear()
 
     async def _fetch_with_streaming_clients(
         self,
         clients: list[TcgPlayerClient],
         offsets_per_client: list[list[int]],
         total_pages: int,
-    ) -> list[Path]:
+    ) -> tuple[list[Path], int]:
         """Fetch products in parallel using pre-authenticated clients.
 
-        Uses semaphore to limit concurrent requests while still parallelizing
+        Uses a semaphore to limit concurrent requests while still parallelizing
         within each client for better performance.
+
+        Every page that never landed is tracked, retried at low concurrency, and
+        then raised as :class:`TcgPlayerIncompleteFetchError` if it still fails.
+        A dropped page silently removes ~100 products from the catalog, and every
+        SKU of every card mapped to those products disappears from the build.
+
+        Returns:
+            Tuple of (part file paths, number of products fetched).
         """
         part_files: list[Path] = []
         part_counter = 0
         buffer: list[dict] = []
         lock = asyncio.Lock()
-        completed = 0
-        semaphore = asyncio.Semaphore(CONCURRENT_REQUESTS)
+        fetched = 0
+        succeeded: set[int] = set()
+        failures: dict[int, str] = {}
 
         async def flush_buffer() -> None:
             nonlocal buffer, part_counter
@@ -415,12 +391,12 @@ class TCGProvider:
 
             part_path = self.output_path.parent / f".tcg_part_{part_counter:04d}.parquet"
             part_counter += 1
-            pl.DataFrame(to_write).write_parquet(part_path)
+            pl.DataFrame(to_write, schema=cast("dict", PRODUCT_SCHEMA)).write_parquet(part_path)
             part_files.append(part_path)
             LOGGER.debug(f"Flushed {len(to_write)} products to {part_path}")
 
-        async def fetch_single_page(client: TcgPlayerClient, offset: int) -> None:
-            nonlocal completed, buffer
+        async def fetch_single_page(client: TcgPlayerClient, offset: int, semaphore: asyncio.Semaphore) -> None:
+            nonlocal fetched, buffer
             async with semaphore:
                 try:
                     resp = await client.get_products_page(
@@ -428,109 +404,94 @@ class TCGProvider:
                         include_skus=True,
                         product_types=self.product_types,
                     )
-                    products_raw = resp.get("results", [])
-                    products = products_raw if isinstance(products_raw, list) else []
-                    page_products = [
-                        {
-                            "productId": product["productId"],
-                            "name": product.get("name", ""),
-                            "cleanName": product.get("cleanName", ""),
-                            "groupId": product.get("groupId"),
-                            "url": product.get("url", ""),
-                            "skus": [
-                                {
-                                    "skuId": sku["skuId"],
-                                    "languageId": sku["languageId"],
-                                    "printingId": sku["printingId"],
-                                    "conditionId": sku["conditionId"],
-                                }
-                                for sku in (
-                                    product.get("skus", []) if isinstance(product.get("skus", []), list) else []
-                                )
-                            ],
-                        }
-                        for product in products
-                    ]
-
-                    async with lock:
-                        buffer.extend(page_products)
-                        completed += 1
-                        if len(buffer) >= self.flush_threshold:
-                            await flush_buffer()
-                        if self.on_progress:
-                            self.on_progress(completed, total_pages, f"offset={offset}")
+                    page_products = self._parse_products(resp)
                 except Exception as e:
                     LOGGER.warning(f"Failed offset {offset}: {e}")
                     async with lock:
-                        completed += 1
+                        failures[offset] = str(e)
+                    return
+
+                async with lock:
+                    buffer.extend(page_products)
+                    fetched += len(page_products)
+                    succeeded.add(offset)
+                    failures.pop(offset, None)
+                    if len(buffer) >= self.flush_threshold:
+                        await flush_buffer()
+                    if self.on_progress:
+                        self.on_progress(len(succeeded), total_pages, f"offset={offset}")
 
         try:
-            # Create tasks for all pages across all clients
-            tasks = []
-            for client, client_offsets in zip(clients, offsets_per_client, strict=False):
-                for offset in client_offsets:
-                    tasks.append(fetch_single_page(client, offset))
+            semaphore = asyncio.Semaphore(CONCURRENT_REQUESTS)
+            await asyncio.gather(
+                *[
+                    fetch_single_page(client, offset, semaphore)
+                    for client, client_offsets in zip(clients, offsets_per_client, strict=False)
+                    for offset in client_offsets
+                ]
+            )
 
-            # Run all tasks in parallel (semaphore limits concurrency)
-            await asyncio.gather(*tasks)
+            if failures:
+                # Failures arrive in bursts when the API rate limits or wobbles,
+                # so a burst takes out a whole run of neighbouring pages. Sweep
+                # them again slowly instead of accepting the hole.
+                retry_offsets = sorted(failures)
+                LOGGER.warning(
+                    f"{len(retry_offsets):,} of {total_pages:,} TCGPlayer pages failed; "
+                    f"retrying at concurrency {RETRY_PASS_CONCURRENCY}"
+                )
+                retry_semaphore = asyncio.Semaphore(RETRY_PASS_CONCURRENCY)
+                await asyncio.gather(
+                    *[
+                        fetch_single_page(clients[i % len(clients)], offset, retry_semaphore)
+                        for i, offset in enumerate(retry_offsets)
+                    ]
+                )
 
-            # Final flush
             async with lock:
                 await flush_buffer()
 
-            LOGGER.info(f"TCGPlayer fetch complete: {len(part_files)} part files")
-            return part_files
+            if failures:
+                sample = ", ".join(f"{offset} ({failures[offset]})" for offset in sorted(failures)[:3])
+                raise TcgPlayerIncompleteFetchError(
+                    f"{len(failures):,} of {total_pages:,} TCGPlayer catalog pages still failed "
+                    f"after retries; first failures: {sample}"
+                )
+
+            LOGGER.info(f"TCGPlayer fetch complete: {fetched:,} products in {len(part_files)} part files")
+            return part_files, fetched
 
         except Exception as e:
-            LOGGER.error(f"Error during TCGPlayer fetch: {e}")
+            if not isinstance(e, TcgPlayerIncompleteFetchError):
+                LOGGER.error(f"Error during TCGPlayer fetch: {e}")
+            self._discard_parts(part_files)
             raise
 
     async def _combine_part_files(self, part_files: list[Path]) -> pl.LazyFrame:
         """Combine part files into single output parquet."""
         if not part_files:
-            pl.DataFrame(
-                schema={
-                    "productId": pl.Int64(),
-                    "name": pl.String(),
-                    "cleanName": pl.String(),
-                    "groupId": pl.Int64(),
-                    "url": pl.String(),
-                    "skus": pl.List(
-                        pl.Struct(
-                            {
-                                "skuId": pl.Int64(),
-                                "languageId": pl.Int64(),
-                                "printingId": pl.Int64(),
-                                "conditionId": pl.Int64(),
-                            }
-                        )
-                    ),
-                }
-            ).write_parquet(self.output_path)
+            pl.DataFrame(schema=cast("dict", PRODUCT_SCHEMA)).write_parquet(self.output_path)
             return pl.scan_parquet(self.output_path)
 
+        # Build alongside the existing cache and swap it in only once the whole
+        # catalog is on disk, so a crash mid-write leaves yesterday's good file.
+        staging_path = self.output_path.with_suffix(".parquet.staging")
         try:
-            # Scan and combine all parts
-            lf = pl.scan_parquet(
-                source=str(self.output_path.parent / ".tcg_part_*.parquet"),
-                glob=True,
-                rechunk=True,
-            )
+            # Scan and combine this run's parts. Listing them explicitly keeps
+            # orphans from an earlier interrupted fetch out of the catalog.
+            lf = pl.scan_parquet(source=part_files, rechunk=True)
 
             # Stream to final output
-            lf.sink_parquet(self.output_path)
+            lf.sink_parquet(staging_path)
+            staging_path.replace(self.output_path)
             LOGGER.info(f"Combined {len(part_files)} parts to {self.output_path}")
 
         except Exception as e:
             LOGGER.error(f"Error combining part files: {e}")
+            staging_path.unlink(missing_ok=True)
             raise
         finally:
-            # Clean up part files
-            for part_file in part_files:
-                try:
-                    part_file.unlink()
-                except OSError as e:
-                    LOGGER.warning(f"Failed to delete {part_file}: {e}")
+            self._discard_parts(part_files)
 
         return pl.scan_parquet(self.output_path)
 

--- a/mtgjson5/providers/tcgplayer/provider.py
+++ b/mtgjson5/providers/tcgplayer/provider.py
@@ -35,6 +35,9 @@ RETRY_PASS_CONCURRENCY = 4
 # A live catalog shifts under offset pagination, so require near-completeness
 # rather than an exact match against the up-front totalItems.
 MIN_COMPLETENESS = 0.98
+# The catalog only ever grows in practice, so a real day-over-day shrink of more
+# than this is a fetch problem rather than TCGPlayer delisting products.
+MIN_CATALOG_RETENTION = 0.95
 NEAR_MINT_CONDITION = 1
 ENGLISH_LANGUAGE = 1
 NON_FOIL_PRINTING = 1
@@ -467,6 +470,34 @@ class TCGProvider:
             self._discard_parts(part_files)
             raise
 
+    def _reject_regression(self, staging_path: Path) -> None:
+        """Refuse a catalog that lost ground against the last good one.
+
+        Counting pages is not enough on its own: the API can answer every page
+        and still hand back products whose ``skus`` array is empty, which drops
+        the same cards from TcgplayerSkus.json without losing a single product.
+        Comparing both totals against the previous catalog catches either shape.
+        """
+        if not self.output_path.exists():
+            return
+
+        counts = pl.col("skus").list.len().sum().alias("skus")
+        try:
+            previous = pl.scan_parquet(self.output_path).select(pl.len().alias("products"), counts).collect()
+            current = pl.scan_parquet(staging_path).select(pl.len().alias("products"), counts).collect()
+        except Exception as e:
+            LOGGER.warning(f"Could not compare against the previous TCG catalog: {e}")
+            return
+
+        for label in ("products", "skus"):
+            before = previous[label][0] or 0
+            after = current[label][0] or 0
+            if before and after < before * MIN_CATALOG_RETENTION:
+                raise TcgPlayerIncompleteFetchError(
+                    f"TCGPlayer catalog dropped from {before:,} to {after:,} {label} "
+                    f"({after / before:.1%} of the previous build); refusing to publish it"
+                )
+
     async def _combine_part_files(self, part_files: list[Path]) -> pl.LazyFrame:
         """Combine part files into single output parquet."""
         if not part_files:
@@ -483,6 +514,7 @@ class TCGProvider:
 
             # Stream to final output
             lf.sink_parquet(staging_path)
+            self._reject_regression(staging_path)
             staging_path.replace(self.output_path)
             LOGGER.info(f"Combined {len(part_files)} parts to {self.output_path}")
 

--- a/tests/mtgjson5/test_tcgplayer_fetch_completeness.py
+++ b/tests/mtgjson5/test_tcgplayer_fetch_completeness.py
@@ -1,0 +1,237 @@
+"""Tests that a partial TCGPlayer catalog fetch never reaches the build.
+
+A page that fails silently removes ~100 products from the catalog, and every SKU
+of every card mapped to those products vanishes from TcgplayerSkus.json.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import polars as pl
+import pytest
+
+from mtgjson5.providers.tcgplayer import provider as provider_mod
+from mtgjson5.providers.tcgplayer.provider import (
+    PRODUCTS_PER_PAGE,
+    TcgPlayerClient,
+    TcgPlayerIncompleteFetchError,
+    TCGProvider,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _catalog(size: int) -> list[dict]:
+    return [
+        {
+            "productId": pid,
+            "name": f"Card {pid}",
+            "cleanName": f"Card {pid}",
+            "groupId": 1,
+            "url": f"/product/{pid}",
+            "skus": [{"skuId": pid * 10, "languageId": 1, "printingId": 1, "conditionId": 1}],
+        }
+        for pid in range(size)
+    ]
+
+
+class FakeApi:
+    """Serves a catalog by offset, failing chosen offsets a set number of times."""
+
+    def __init__(self, products: list[dict], failures: dict[int, int] | None = None):
+        self.products = products
+        self.failures = dict(failures or {})
+        self.short_pages: set[int] = set()
+        self.requested: list[int] = []
+
+    def page(self, offset: int) -> list[dict]:
+        self.requested.append(offset)
+        remaining = self.failures.get(offset, 0)
+        if remaining:
+            self.failures[offset] = remaining - 1
+            raise ConnectionError(f"boom at {offset}")
+        if offset in self.short_pages:
+            return []
+        return self.products[offset : offset + PRODUCTS_PER_PAGE]
+
+
+class FakeClient:
+    """Stands in for TcgPlayerClient inside TCGProvider.fetch_all_products."""
+
+    api: FakeApi
+
+    def __init__(self, config: object):
+        self.config = config
+
+    async def __aenter__(self) -> FakeClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def get_total_products(self, product_types: str = "Cards") -> int:
+        return len(self.api.products)
+
+    async def get_products_page(
+        self,
+        category_id: int = 1,
+        product_types: str = "Cards",
+        offset: int = 0,
+        limit: int = PRODUCTS_PER_PAGE,
+        include_skus: bool = True,
+    ) -> dict[str, object]:
+        return {"totalItems": len(self.api.products), "results": self.api.page(offset)}
+
+
+@pytest.fixture
+def make_provider(tmp_path, monkeypatch):
+    def _make(api: FakeApi) -> TCGProvider:
+        FakeClient.api = api
+        monkeypatch.setattr(provider_mod, "TcgPlayerClient", FakeClient)
+        return TCGProvider(
+            output_path=tmp_path / "tcg_skus.parquet",
+            configs=[SimpleNamespace(public_key="a", private_key="b")],
+        )
+
+    return _make
+
+
+def _part_files(directory) -> list:
+    return sorted(directory.glob(".tcg_part_*.parquet"))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchCompleteness:
+    def test_full_fetch_writes_every_product(self, make_provider, tmp_path):
+        provider = make_provider(FakeApi(_catalog(500)))
+
+        lf = provider.fetch_all_products_sync()
+
+        assert lf.collect().height == 500
+        assert _part_files(tmp_path) == []
+
+    def test_transient_page_failure_is_retried(self, make_provider, tmp_path):
+        api = FakeApi(_catalog(500), failures={200: 1})
+        provider = make_provider(api)
+
+        lf = provider.fetch_all_products_sync()
+
+        # The offset that failed in the main pass came back in the retry sweep.
+        assert api.requested.count(200) == 2
+        df = lf.collect()
+        assert df.height == 500
+        assert sorted(df["productId"].to_list()) == list(range(500))
+
+    def test_persistent_page_failure_raises(self, make_provider):
+        provider = make_provider(FakeApi(_catalog(500), failures={200: 99}))
+
+        with pytest.raises(TcgPlayerIncompleteFetchError, match="still failed after retries"):
+            provider.fetch_all_products_sync()
+
+    def test_persistent_failure_keeps_previous_catalog(self, make_provider, tmp_path):
+        output_path = tmp_path / "tcg_skus.parquet"
+        pl.DataFrame({"productId": [1, 2, 3]}).write_parquet(output_path)
+        provider = make_provider(FakeApi(_catalog(500), failures={200: 99}))
+
+        with pytest.raises(TcgPlayerIncompleteFetchError):
+            provider.fetch_all_products_sync()
+
+        # Yesterday's catalog survives, and no part files are left behind.
+        assert pl.read_parquet(output_path)["productId"].to_list() == [1, 2, 3]
+        assert _part_files(tmp_path) == []
+
+    def test_short_page_trips_the_completeness_check(self, make_provider):
+        api = FakeApi(_catalog(500))
+        api.short_pages.add(300)
+        provider = make_provider(api)
+
+        # Every page answers, but one comes back empty - 400 of 500 products.
+        with pytest.raises(TcgPlayerIncompleteFetchError, match="refusing to publish a truncated catalog"):
+            provider.fetch_all_products_sync()
+
+    def test_empty_catalog_raises(self, make_provider):
+        provider = make_provider(FakeApi([]))
+
+        with pytest.raises(TcgPlayerIncompleteFetchError, match="0 products"):
+            provider.fetch_all_products_sync()
+
+
+# ---------------------------------------------------------------------------
+# Rate limit handling
+# ---------------------------------------------------------------------------
+
+
+class FakeResponse:
+    def __init__(self, status: int, payload: dict | None = None):
+        self.status = status
+        self.headers = {"Retry-After": "0"}
+        self._payload = payload or {}
+
+    async def __aenter__(self) -> FakeResponse:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def json(self) -> dict:
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, responses: list[FakeResponse]):
+        self._responses = list(responses)
+        self.calls = 0
+
+    def get(self, url: str, headers: dict | None = None) -> FakeResponse:
+        self.calls += 1
+        return self._responses.pop(0)
+
+
+class TestRateLimitRetries:
+    def test_waits_out_repeated_rate_limits(self):
+        """A 429 is a 'come back later', not one of the three error retries."""
+        client = TcgPlayerClient(SimpleNamespace(base_url="https://x", api_version="v1"))
+        client._session = FakeSession([FakeResponse(429) for _ in range(5)] + [FakeResponse(200, {"totalItems": 7})])
+
+        result = asyncio.run(client._get("catalog/products", versioned=False))
+
+        assert result == {"totalItems": 7}
+        assert client._session.calls == 6
+
+    def test_gives_up_after_the_rate_limit_budget(self, monkeypatch):
+        monkeypatch.setattr(provider_mod, "MAX_RATE_LIMIT_WAITS", 2)
+        client = TcgPlayerClient(SimpleNamespace(base_url="https://x", api_version="v1"))
+        client._session = FakeSession([FakeResponse(429) for _ in range(4)])
+
+        with pytest.raises(Exception, match="Still rate limited"):
+            asyncio.run(client._get("catalog/products", versioned=False))
+
+
+class TestLastGoodCatalogFallback:
+    def test_falls_back_to_the_catalog_on_disk(self, tmp_path):
+        from mtgjson5.data.cache import GlobalCache
+
+        pl.DataFrame({"productId": [11, 22]}).write_parquet(tmp_path / "tcg_skus.parquet")
+
+        lf = GlobalCache._last_good_tcg_skus(SimpleNamespace(cache_path=tmp_path))
+
+        assert lf.collect()["productId"].to_list() == [11, 22]
+
+    def test_empty_frame_when_nothing_cached(self, tmp_path):
+        from mtgjson5.data.cache import GlobalCache
+
+        lf = GlobalCache._last_good_tcg_skus(SimpleNamespace(cache_path=tmp_path))
+
+        assert lf.collect().height == 0
+        assert "skus" in lf.collect_schema()

--- a/tests/mtgjson5/test_tcgplayer_fetch_completeness.py
+++ b/tests/mtgjson5/test_tcgplayer_fetch_completeness.py
@@ -164,6 +164,35 @@ class TestFetchCompleteness:
             provider.fetch_all_products_sync()
 
 
+class TestRegressionAgainstPreviousCatalog:
+    def test_a_growing_catalog_is_accepted(self, make_provider, tmp_path):
+        make_provider(FakeApi(_catalog(400))).fetch_all_products_sync()
+        provider = make_provider(FakeApi(_catalog(500)))
+
+        assert provider.fetch_all_products_sync().collect().height == 500
+
+    def test_a_shrinking_catalog_is_rejected(self, make_provider, tmp_path):
+        make_provider(FakeApi(_catalog(500))).fetch_all_products_sync()
+        provider = make_provider(FakeApi(_catalog(300)))
+
+        with pytest.raises(TcgPlayerIncompleteFetchError, match="500 to 300 products"):
+            provider.fetch_all_products_sync()
+
+        assert pl.read_parquet(tmp_path / "tcg_skus.parquet").height == 500
+
+    def test_products_that_lose_their_skus_are_rejected(self, make_provider, tmp_path):
+        """Every page can answer in full and still come back stripped of SKUs."""
+        make_provider(FakeApi(_catalog(500))).fetch_all_products_sync()
+
+        stripped = _catalog(500)
+        for product in stripped[:100]:
+            product["skus"] = []
+        provider = make_provider(FakeApi(stripped))
+
+        with pytest.raises(TcgPlayerIncompleteFetchError, match="500 to 400 skus"):
+            provider.fetch_all_products_sync()
+
+
 # ---------------------------------------------------------------------------
 # Rate limit handling
 # ---------------------------------------------------------------------------

--- a/tests/mtgjson5/test_tcgplayer_fetch_completeness.py
+++ b/tests/mtgjson5/test_tcgplayer_fetch_completeness.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
+from typing import cast
 
+import aiohttp
 import polars as pl
 import pytest
 
@@ -16,6 +18,7 @@ from mtgjson5.providers.tcgplayer import provider as provider_mod
 from mtgjson5.providers.tcgplayer.provider import (
     PRODUCTS_PER_PAGE,
     TcgPlayerClient,
+    TcgPlayerConfig,
     TcgPlayerIncompleteFetchError,
     TCGProvider,
 )
@@ -53,7 +56,7 @@ class FakeApi:
         remaining = self.failures.get(offset, 0)
         if remaining:
             self.failures[offset] = remaining - 1
-            raise ConnectionError(f"boom at {offset}")
+            raise aiohttp.ClientError(f"boom at {offset}")
         if offset in self.short_pages:
             return []
         return self.products[offset : offset + PRODUCTS_PER_PAGE]
@@ -94,7 +97,7 @@ def make_provider(tmp_path, monkeypatch):
         monkeypatch.setattr(provider_mod, "TcgPlayerClient", FakeClient)
         return TCGProvider(
             output_path=tmp_path / "tcg_skus.parquet",
-            configs=[SimpleNamespace(public_key="a", private_key="b")],
+            configs=[TcgPlayerConfig(public_key="a", private_key="b")],
         )
 
     return _make
@@ -227,21 +230,26 @@ class FakeSession:
         return self._responses.pop(0)
 
 
+def _client_with(responses: list[FakeResponse]) -> tuple[TcgPlayerClient, FakeSession]:
+    client = TcgPlayerClient(TcgPlayerConfig(public_key="a", private_key="b"))
+    session = FakeSession(responses)
+    client._session = cast("aiohttp.ClientSession", session)
+    return client, session
+
+
 class TestRateLimitRetries:
     def test_waits_out_repeated_rate_limits(self):
         """A 429 is a 'come back later', not one of the three error retries."""
-        client = TcgPlayerClient(SimpleNamespace(base_url="https://x", api_version="v1"))
-        client._session = FakeSession([FakeResponse(429) for _ in range(5)] + [FakeResponse(200, {"totalItems": 7})])
+        client, session = _client_with([FakeResponse(429) for _ in range(5)] + [FakeResponse(200, {"totalItems": 7})])
 
         result = asyncio.run(client._get("catalog/products", versioned=False))
 
         assert result == {"totalItems": 7}
-        assert client._session.calls == 6
+        assert session.calls == 6
 
     def test_gives_up_after_the_rate_limit_budget(self, monkeypatch):
         monkeypatch.setattr(provider_mod, "MAX_RATE_LIMIT_WAITS", 2)
-        client = TcgPlayerClient(SimpleNamespace(base_url="https://x", api_version="v1"))
-        client._session = FakeSession([FakeResponse(429) for _ in range(4)])
+        client, _ = _client_with([FakeResponse(429) for _ in range(4)])
 
         with pytest.raises(Exception, match="Still rate limited"):
             asyncio.run(client._get("catalog/products", versioned=False))


### PR DESCRIPTION
Fixes #1721.

## What happened

The 2026-09-07 build dropped **19,026 uuids (-16.7%)** and **732,057 SKU rows (-12.5%)** from `TcgplayerSkus.json`, with nothing added — a pure deletion, concentrated so that 70 of the 118 affected sets lost 90%+ of their uuids.

Three things pin this down:

- **It wasn't a code change.** No commits landed between the 09-06 and 09-07 builds. The last was 09-04, the next 09-08.
- **It self-healed.** The published 09-08 file is back at exactly **114,152** uuids, the same as 09-06. Same code, three runs: 114k → 95k → 114k.
- **The mapping side is innocent.** `tcgplayerProductId` comes only from Scryfall's `tcgplayer_id` (`identifiers.py:135`), so whole sets can't lose it overnight. The loss had to be on the catalog side.

## Why the build published it anyway

`catalog/products` is paged 100 products at a time across 75 concurrent requests. Every page failure was caught, logged as a warning, and discarded:

```python
except Exception as e:
    LOGGER.warning(f"Failed offset {offset}: {e}")
```

The partial catalog was then written to `tcg_skus.parquet` and inner-joined against the productId → uuid mappings, so each lost page took every SKU of every card mapped to it out of the build. Nothing compared the fetched count against `totalItems`, nothing compared against the previous day, and the run reported success. The same truncated file also feeds TCGPlayer prices and alt-foil detection, so the blast radius was wider than the one output file.

A contributing detail in `_get`: a 429 consumed one of the three retry attempts, so three consecutive rate limits abandoned a page even though the API never actually errored — and because `last_error` stayed `None`, the raised exception lost the reason.

## Changes

- Track failed offsets, retry them at concurrency 4 after the main pass, and raise `TcgPlayerIncompleteFetchError` if any still fail.
- Check the fetched product count against `totalItems` (98%), so pages that answer with short results are caught too.
- Give 429 handling its own wait budget, separate from the error-retry budget, and preserve the real error.
- Reject a catalog that lost more than 5% of either its products or its SKU rows versus the last good one. This covers the shape page-counting cannot see: every page answering, but with products returned with an empty `skus` array.
- Stage the combined parquet and swap it in atomically, and combine only this run's part files instead of globbing the directory — orphans from a killed run used to be eligible for inclusion.
- On a failed fetch, fall back to the previous complete catalog on disk instead of an empty frame, at error level rather than warning.

Net effect: a bad night now costs a day of freshness plus a loud error, instead of 19k cards silently vanishing from a published file.

## Tests

13 new tests in `tests/mtgjson5/test_tcgplayer_fetch_completeness.py` covering transient page failures that recover on retry, persistent failures, short pages, an empty catalog, day-over-day product and SKU regressions, the 429 budget, and the last-good-catalog fallback. Full suite, ruff, and mypy pass.

## Not addressed here

- If a fetch fails on a machine with no prior `tcg_skus.parquet`, the build still publishes an empty `TcgplayerSkus.json` rather than failing. Making that fatal is a policy change to the nightly that felt out of scope for this fix.
- The reporter's note that 753 of the dropped uuids no longer resolve against `AllPrintings` could not be reproduced from the current published files and looks like a separate issue.

## Not verified

Which specific offsets failed on 09-07 — the build logs and that day's file are both gone. The set-level granularity implies the failures clustered along whatever order TCGPlayer serves that endpoint in; productIds are only 1-4% dense within a set, so it was not a plain productId range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kj7cpnmE6KwipwimYpVXiv
